### PR TITLE
Add 'all' redirect for firebase hosting

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -10,10 +10,12 @@
   },
   "hosting": {
     "public": "build",
-    "ignore": [
-      "firebase.json",
-      "**/.*",
-      "**/node_modules/**"
+    "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],
+    "rewrites": [
+      {
+        "source": "**",
+        "destination": "/index.html"
+      }
     ]
   }
 }


### PR DESCRIPTION
This will allow direct navigation to any path.  Previously, going directly to any named path, like /home (or hitting reload on any named path) would 404.