### PR TITLE
Default false-y values to "" in inputValue

### DIFF
--- a/src/Components/TitleAutocomplete.js
+++ b/src/Components/TitleAutocomplete.js
@@ -11,7 +11,7 @@ export default function TitleAutocomplete(search) {
   let location = useLocation();
 
   let [value, setValue] = useState();
-  let [inputValue, setInputValue] = useState(search);
+  let [inputValue, setInputValue] = useState(search ?? "");
 
   let [options, setOptions] = useState([]);
   let [loading, setLoading] = useState(false);


### PR DESCRIPTION
This will prevent errors where inputValue is initialized to undefined, due to lack of prop, and then Autocomplete complains later when it becomes something other than undefined.