### PR TITLE
use whitespace: "pre-line" for description text

### DIFF
--- a/src/Components/DetailedView.js
+++ b/src/Components/DetailedView.js
@@ -146,6 +146,7 @@ export default function DetailedView() {
                 primaryTypographyProps={{
                   fontFamily: "interMedium",
                   fontSize: "1.0rem",
+                  whiteSpace: "pre-line",
                 }}
               />
             </ListItem>


### PR DESCRIPTION
The description text contains newline characters for formatting.  Usually, all stretches of whitespace in text in html are collapsed to a single space.  This css setting will allow newlines in the text to be rendered.