### PR TITLE
Fix build of DetailedView at head

### DIFF
--- a/src/Components/DetailedView.js
+++ b/src/Components/DetailedView.js
@@ -98,9 +98,10 @@ export default function DetailedView() {
                   console.log(localUser);
                   SaveToFirestore(user, temp);
                 }}
-                component="div"
-                className="tile"
-                src={location.state.image_large}
+              />
+              <Box
+                component="img"
+                src={frown}
                 alt=""
                 className="overlaidIcon"
                 id="frownIcon"
@@ -226,7 +227,6 @@ export default function DetailedView() {
                 </div>
               ))}
             </div> */}
-            </Grid>
           </Grid>
         </Grid>
         <h3 className="leftH3">Similar Titles</h3>


### PR DESCRIPTION
Looks like a bad merge between my changes in pr #7 and some changes you committed the day before caused things to get a little janky -- it ended up merging two Box tags for icons into one broken one, and adding an extra closing Grid tag.  This should put it back to how it was.

I'll try to be more careful to merge origin's main into my branches before sending and PRs in the future.