### PR TITLE
Fix bug where 'null episodes' can appear on anime page

### DIFF
--- a/src/Components/DetailedView.js
+++ b/src/Components/DetailedView.js
@@ -152,26 +152,15 @@ export default function DetailedView() {
                 })}
               />
             </ListItem>
-            <ListItem sx={{ paddingTop: 0 }}>
-              {/* TERNARY BELOW SCREENS FOR WHETHER 'EPISODE' SHOULD PRINT AS PLURAL OR NOT */}
-              {anime.episodes > 1 ? (
-                <ListItemText
-                  primary={`${anime.format} • ${anime.episodes} episodes`}
-                  primaryTypographyProps={{
-                    fontFamily: "interMedium",
-                    fontSize: "1.0rem",
-                    whiteSpace: "pre-line",
-                  }}
-                />
-              ) : (
-                <ListItemText
-                  primary={`${anime.format} • ${anime.episodes} episode`}
-                  primaryTypographyProps={{
-                    fontFamily: "interMedium",
-                    fontSize: "1.0rem",
-                  }}
-                />
-              )}
+            <ListItem sx={{ paddingTop: 0, pb: 0 }}>
+              <ListItemText
+                primary={getFormatAndEpisodesText(anime)}
+                primaryTypographyProps={{
+                  fontFamily: "interMedium",
+                  fontSize: "1.0rem",
+                  whiteSpace: "pre-line",
+                }}
+              />
             </ListItem>
             <ListItem>
               <ListItemText
@@ -234,4 +223,14 @@ export default function DetailedView() {
       </Container>
     </div>
   );
+}
+
+function getFormatAndEpisodesText(anime) {
+  if (anime.episodes === 1) {
+    return `${anime.format} • ${anime.episodes} episode`;
+  } else if (anime.episodes > 1) {
+    return `${anime.format} • ${anime.episodes} episodes`;
+  } else {
+    return `${anime.format}`;
+  }
 }


### PR DESCRIPTION
If a show has not finished yet, it can be possible for the 'episodes' field to be null.  A good example is the show One Piece (/anime/21).  It is my mistake that I didn't notice this and include it in the API documentation.  I've added support for these cases in DetailedView, and when episodes is null I just shorten the text to print only the format.  

I also extracted the logic to determine the byline text to a helper function -- although I love a good ternary, in this case I would have had to add a third case and it was getting pretty long.