### PR TITLE
Fix useLikeState to handle some undefined cases

### DIFF
--- a/src/Hooks/useLikeState.js
+++ b/src/Hooks/useLikeState.js
@@ -8,11 +8,11 @@ export default function useLikeState(anime) {
   const [user] = useAuthState(auth);
   const [localUser, setLocalUser] = useContext(LocalUserContext);
 
-  const liked = Boolean(localUser.likes.find((x) => x.id === anime.id));
-  const disliked = Boolean(localUser.dislikes.find((x) => x.id === anime.id));
+  const likes = localUser.likes ?? [];
+  const dislikes = localUser.dislikes ?? [];
 
-  const likes = localUser.likes;
-  const dislikes = localUser.dislikes;
+  const liked = Boolean(likes.find((x) => x.id === anime.id));
+  const disliked = Boolean(dislikes.find((x) => x.id === anime.id));
 
   const setLiked = (value) => {
     const newLocalUser = {


### PR DESCRIPTION
I found that if I got my LocalUser into a state where it had no likes or dislikes fields, useLikeState messed up pretty bad.  This fix will allow it to continue to behave as expected, and default those fields to empty lists.

I will investigate more on how I was able to get my LocalUser into such a state, but this code could be more resilient to unexpected inputs.