### PR TITLE
Fix MUI warnings regarding tooltip elements detaching

### DIFF
--- a/src/Components/AnimeCard.js
+++ b/src/Components/AnimeCard.js
@@ -44,8 +44,9 @@ export default function AnimeCard({ anime, large, onChangeSelected }) {
         <Box
           sx={{
             height: "100%",
-            display: selected ? "flex" : "none",
-            flexDirection: selected ? "column" : "unset",
+            display: "flex",
+            flexDirection: "column",
+            visibility: selected ? "visible" : "hidden",
             color: "#fff",
             cursor: "pointer",
             justifyContent: "flex-end",


### PR DESCRIPTION
To fix this, I just make the overlay invisible using visibility:hidden.  Tooltip seems to like this better, since display:none actually removed it from the document, whereas this approach just hides it.