### PR TITLE
Break apart generic api calls into diff useEffects

### DIFF
--- a/src/Components/Home.js
+++ b/src/Components/Home.js
@@ -154,29 +154,43 @@ export default function Home() {
     recommendContent();
   }, [user, localUser]);
 
+  //Get generic recommendations
   useEffect(() => {
-    //Get generic recommendations
     getAnimeListing(
       `https://api-jet-lfoguxrv7q-uw.a.run.app/anime?sort=highest_rated&page_size=6${selectedGenreHR}`,
       setAnimeHR
     );
+  }, [selectedGenreHR]);
+
+  useEffect(() => {
     getAnimeListing(
       `https://api-jet-lfoguxrv7q-uw.a.run.app/anime?sort=most_completed&page_size=6${selectedGenreMC}`,
       setAnimeMC
     );
+  }, [selectedGenreMC]);
+
+  useEffect(() => {
     getAnimeListing(
       `https://api-jet-lfoguxrv7q-uw.a.run.app/anime?sort=most_rated&page_size=6${selectedGenreMR}`,
       setAnimeMR
     );
+  }, [selectedGenreMR]);
+
+  useEffect(() => {
     getAnimeListing(
       `https://api-jet-lfoguxrv7q-uw.a.run.app/anime?sort=most_planned_to_watch&page_size=6${selectedGenreMPTW}`,
       setAnimeMPTW
     );
+  }, [selectedGenreMPTW]);
+
+  useEffect(() => {
     getAnimeListing(
       `https://api-jet-lfoguxrv7q-uw.a.run.app/anime?sort=most_planned_to_watch&page_size=6&page=410`,
       setAnimeMH
     );
+  }, []);
 
+  useEffect(() => {
     getRandomNumbers();
 
     getRandomAnimeListing(
@@ -185,13 +199,7 @@ export default function Home() {
       setAnimeRandom,
       refresh
     );
-  }, [
-    selectedGenreHR,
-    selectedGenreMC,
-    selectedGenreMPTW,
-    selectedGenreMR,
-    refresh,
-  ]);
+  }, [refresh]);
 
   useEffect(() => {
     if (loading) {


### PR DESCRIPTION
This reduces the number of reloads when the user taps a chip.  This makes the animation when chips get selected much less likely to be interrupted by re-render jank.

There still is the problem of the initial page load where each shelf comes in at a diff time and the page adjusts its layout like 8 times in rapid succession, but that can be fixed in a follow-up change.