### PR TITLE
Style chips to match mock

### DIFF
--- a/src/Components/GenreChips.js
+++ b/src/Components/GenreChips.js
@@ -29,49 +29,38 @@ export default function GenreChips({ selectedGenre, setSelectedGenre }) {
   let [genreState, setGenreState] = useState([
     {
       genre: "Action",
-      color: undefined,
       selected: false,
     },
     {
       genre: "Award Winning",
-      color: undefined,
       selected: false,
     },
     {
       genre: "Comedy",
-      color: undefined,
-
       selected: false,
     },
     {
       genre: "Ecchi",
-      color: undefined,
       selected: false,
     },
-
     {
       genre: "Gourmet",
-      color: undefined,
       selected: false,
     },
     {
       genre: "Horror",
-      color: undefined,
       selected: false,
     },
     {
       genre: "Romance",
-      color: undefined,
       selected: false,
     },
     {
       genre: "Sci-Fi",
-      color: undefined,
       selected: false,
     },
     {
       genre: "Sports",
-      color: undefined,
       selected: false,
     },
   ]);
@@ -79,13 +68,12 @@ export default function GenreChips({ selectedGenre, setSelectedGenre }) {
   function handleClick(item, index) {
     const temp = [...genreState];
     if (!temp[index].selected) {
-      temp[index] = { ...temp[index], color: "primary", selected: true };
+      temp[index] = { ...temp[index], selected: true };
     } else {
-      temp[index] = { ...temp[index], color: undefined, selected: false };
+      temp[index] = { ...temp[index], selected: false };
     }
     for (let i = 0; i < genreState.length; i++) {
       if (index !== i) {
-        temp[i].color = undefined;
         temp[i].selected = false;
       }
     }
@@ -95,7 +83,6 @@ export default function GenreChips({ selectedGenre, setSelectedGenre }) {
     else {
       setSelectedGenre("");
     }
-    console.log(selectedGenre);
   }
 
   return (
@@ -103,11 +90,10 @@ export default function GenreChips({ selectedGenre, setSelectedGenre }) {
       {genreState?.map((item, index) => (
         <Chip
           sx={{ fontFamily: "interMedium" }}
-          variant="filled"
+          variant={item.selected ? "filled" : "outlined"}
           clickable={true}
           key={index}
           label={item.genre}
-          color={item.color}
           onClick={() => {
             handleClick(item, index);
           }}

--- a/src/Components/Home.js
+++ b/src/Components/Home.js
@@ -263,6 +263,7 @@ export default function Home() {
         <h4>Random</h4>{" "}
         <Chip
           // Triggers a re-render of the random anime shelf
+          variant="outlined"
           label="Surprise Me!"
           onClick={() => {
             refresh ? setRefresh(false) : setRefresh(true);

--- a/src/Components/theme.js
+++ b/src/Components/theme.js
@@ -30,7 +30,22 @@ const theme = createTheme({
     MuiChip: {
       styleOverrides: {
         root: {
+          borderColor: "#474747",
+          borderStyle: "solid",
           borderRadius: "8px",
+          borderWidth: "2px",
+          boxSizing: "border-box",
+        },
+        filledDefault: {
+          color: "#fff",
+          backgroundColor: "#474747",
+          "&:hover, &:focus": {
+            color: "#fff",
+            backgroundColor: "#626262",
+          },
+        },
+        label: {
+          fontFamily: "interSemiBold, sans-serif",
         },
       },
     },


### PR DESCRIPTION
Just an example of a way that we can apply default component styling in theme.js and have it be applied to all of a certain type of MUI component.  This can be tricky at times, and I had to consult the source at https://github.com/mui/material-ui/blob/v4.11.0/packages/material-ui/src/Chip/Chip.js#L127 in order to figure out the right way to override things.

Let me know what you think of this style.  It matches the mocks, and is a little more modern-feeling I think (makes me think of newer YT chips), but I am open to discussion around how we want our chips to look.  This is just one idea we can start with.