### PR TITLE
Add rudimentary AnimeShelf, use on /home, /anime

### DIFF
--- a/src/Components/AnimeShelf.js
+++ b/src/Components/AnimeShelf.js
@@ -1,0 +1,111 @@
+import { Box, Grid, IconButton, useMediaQuery, useTheme } from "@mui/material";
+import { CaretLeft, CaretRight } from "phosphor-react";
+import { useState } from "react";
+import AnimeCard from "./AnimeCard";
+
+export default function AnimeShelf({ items }) {
+  const [selected, setSelected] = useState();
+  const [startIndex, setStartIndex] = useState(0);
+  const theme = useTheme();
+
+  const sm = useMediaQuery(theme.breakpoints.up("sm"));
+  const sevenHundredFifty = useMediaQuery(
+    theme.breakpoints.up("sevenHundredFifty")
+  );
+  const md = useMediaQuery(theme.breakpoints.up("md"));
+  const lg = useMediaQuery(theme.breakpoints.up("lg"));
+
+  const itemsPerPage = lg ? 6 : md ? 5 : sevenHundredFifty ? 4 : sm ? 3 : 2;
+
+  const columns = 12;
+  const breakpoints = { xs: 12 / itemsPerPage };
+
+  const currentItems = items.slice(startIndex, startIndex + itemsPerPage);
+
+  const hasPrevious = startIndex > 0;
+  const hasNext = startIndex < items.length - itemsPerPage;
+
+  const onChangeSelected = (index, value) => {
+    if (value) {
+      setSelected(index);
+    } else if (!value && selected === index) {
+      setSelected(undefined);
+    }
+  };
+
+  const onClickNext = (e) => {
+    setStartIndex(
+      Math.min(startIndex + itemsPerPage, items.length - itemsPerPage)
+    );
+    e.preventDefault();
+  };
+
+  const onClickPrevious = (e) => {
+    setStartIndex(Math.max(startIndex - itemsPerPage, 0));
+    e.preventDefault();
+  };
+
+  return (
+    <Box
+      sx={{
+        display: "flex",
+        flexDirection: "column",
+        textAlign: "start",
+        mb: 1,
+        position: "relative",
+      }}
+    >
+      <Grid container spacing={2} columns={columns}>
+        {currentItems.map((anime, index) => (
+          <Grid
+            item
+            key={index}
+            {...breakpoints}
+            sx={{ aspectRatio: "0.7", zIndex: selected === index ? 1 : 0 }}
+          >
+            <AnimeCard
+              anime={anime}
+              onChangeSelected={(v) => onChangeSelected(index, v)}
+            />
+          </Grid>
+        ))}
+      </Grid>
+      <IconButton
+        onClick={onClickPrevious}
+        color="inherit"
+        sx={{
+          position: "absolute",
+          visibility: hasPrevious ? "visible" : "hidden",
+          left: "-24px",
+          top: "calc(50% - 24px)",
+          zIndex: 1,
+          backgroundColor: theme.palette.grey[100],
+          boxShadow: "0px 4px 16px rgba(0, 0, 0, 0.18 )",
+          "&:hover, &:focus": {
+            backgroundColor: theme.palette.grey[300],
+          },
+        }}
+      >
+        <CaretLeft size={24} />
+      </IconButton>
+      <IconButton
+        onClick={onClickNext}
+        color="inherit"
+        sx={{
+          position: "absolute",
+          visibility: hasNext ? "visible" : "hidden",
+          right: "-24px",
+          top: "calc(50% - 24px)",
+          zIndex: 1,
+          backgroundColor: theme.palette.grey[100],
+          boxShadow: "0px 4px 16px rgba(0, 0, 0, 0.18 )",
+          "&:hover, &:focus": {
+            backgroundColor: theme.palette.grey[300],
+          },
+        }}
+      >
+        <CaretRight size={24} />
+      </IconButton>
+    </Box>
+  );
+}

--- a/src/Components/DetailedView.js
+++ b/src/Components/DetailedView.js
@@ -187,7 +187,7 @@ export default function DetailedView() {
           </Grid>
         </Grid>
         <h3 className="leftH3">Similar Titles</h3>
-        <SimilarContent animeId={anime.id} amount={6} />
+        <SimilarContent animeId={anime.id} amount={24} />
         <div className="gap" />
       </Container>
     </div>

--- a/src/Components/Home.js
+++ b/src/Components/Home.js
@@ -31,6 +31,7 @@ import AnimeGrid from "./AnimeGrid";
 import GenreChips from "./GenreChips";
 import ShelfTitle from "./ShelfTitle";
 import { Stack } from "@mui/system";
+import AnimeShelf from "./AnimeShelf";
 
 export default function Home() {
   let [animeHR, setAnimeHR] = useState([]); //highest rated
@@ -157,35 +158,35 @@ export default function Home() {
   //Get generic recommendations
   useEffect(() => {
     getAnimeListing(
-      `https://api-jet-lfoguxrv7q-uw.a.run.app/anime?sort=highest_rated&page_size=6${selectedGenreHR}`,
+      `https://api-jet-lfoguxrv7q-uw.a.run.app/anime?sort=highest_rated&page_size=24${selectedGenreHR}`,
       setAnimeHR
     );
   }, [selectedGenreHR]);
 
   useEffect(() => {
     getAnimeListing(
-      `https://api-jet-lfoguxrv7q-uw.a.run.app/anime?sort=most_completed&page_size=6${selectedGenreMC}`,
+      `https://api-jet-lfoguxrv7q-uw.a.run.app/anime?sort=most_completed&page_size=24${selectedGenreMC}`,
       setAnimeMC
     );
   }, [selectedGenreMC]);
 
   useEffect(() => {
     getAnimeListing(
-      `https://api-jet-lfoguxrv7q-uw.a.run.app/anime?sort=most_rated&page_size=6${selectedGenreMR}`,
+      `https://api-jet-lfoguxrv7q-uw.a.run.app/anime?sort=most_rated&page_size=24${selectedGenreMR}`,
       setAnimeMR
     );
   }, [selectedGenreMR]);
 
   useEffect(() => {
     getAnimeListing(
-      `https://api-jet-lfoguxrv7q-uw.a.run.app/anime?sort=most_planned_to_watch&page_size=6${selectedGenreMPTW}`,
+      `https://api-jet-lfoguxrv7q-uw.a.run.app/anime?sort=most_planned_to_watch&page_size=24${selectedGenreMPTW}`,
       setAnimeMPTW
     );
   }, [selectedGenreMPTW]);
 
   useEffect(() => {
     getAnimeListing(
-      `https://api-jet-lfoguxrv7q-uw.a.run.app/anime?sort=most_planned_to_watch&page_size=6&page=410`,
+      `https://api-jet-lfoguxrv7q-uw.a.run.app/anime?sort=most_planned_to_watch&page_size=24&page=101`,
       setAnimeMH
     );
   }, []);
@@ -238,27 +239,27 @@ export default function Home() {
         setSelectedGenre={setSelectedGenreHR}
         title={"Highest Rated"}
       />
-      <AnimeGrid items={animeHR} />
+      <AnimeShelf items={animeHR} />
       <ShelfTitle
         selectedGenre={selectedGenreMC}
         setSelectedGenre={setSelectedGenreMC}
         title={"Most Popular"}
       />
-      <AnimeGrid items={animeMC} />
+      <AnimeShelf items={animeMC} />
       <ShelfTitle
         selectedGenre={selectedGenreMR}
         setSelectedGenre={setSelectedGenreMR}
         title={"Most Viewed"}
       />
-      <AnimeGrid items={animeMR} />
+      <AnimeShelf items={animeMR} />
       <ShelfTitle
         selectedGenre={selectedGenreMPTW}
         setSelectedGenre={setSelectedGenreMPTW}
         title={"Hype Beasts"}
       />
-      <AnimeGrid items={animeMPTW} />
+      <AnimeShelf items={animeMPTW} />
       <h4>Most Obscure</h4>
-      <AnimeGrid items={animeMH} />
+      <AnimeShelf items={animeMH} />
       <Stack direction="row" spacing={3} sx={{ alignItems: "center" }}>
         <h4>Random</h4>{" "}
         <Chip

--- a/src/Components/SimilarContent.js
+++ b/src/Components/SimilarContent.js
@@ -1,5 +1,5 @@
 import useSimilarAnime from "../Hooks/useSimilarAnime";
-import AnimeGrid from "./AnimeGrid";
+import AnimeShelf from "./AnimeShelf";
 
 export default function SimilarContent({ animeId, amount }) {
   const [similar, loading, error] = useSimilarAnime(animeId, amount);
@@ -7,7 +7,7 @@ export default function SimilarContent({ animeId, amount }) {
   return (
     <div>
       {loading ? <div id="loading"></div> : ""}
-      <AnimeGrid items={similar ?? []} />
+      <AnimeShelf items={similar ?? []} />
     </div>
   );
 }

--- a/src/Components/theme.js
+++ b/src/Components/theme.js
@@ -21,6 +21,7 @@ const theme = createTheme({
       fourHundred: 400,
       fiveHundred: 500,
       sm: 600,
+      sevenHundredFifty: 750,
       md: 900,
       lg: 1200,
       xl: 1536,


### PR DESCRIPTION
This shelf allows for horizontal navigation of multiple pages of content, and I've installed it for the generic shelves on Home (except random) and the similar items shelf on DetailedView, as a demo.

In the future, I'd like this shelf to have a cool scrolling animation.  Right now it just instantly switches to the new page of content.  I'd also like to have it reset to the first page whenever the genre filter changes.

I've tried to make it responsive, in that the number of items onscreen will slowly be reduced as the screen size shrinks.  I did need to add a new breakpoint to bridge an awkward spot between sm and md.