### PR TITLE
Center title on anime cards

### DIFF
--- a/src/Components/AnimeCard.js
+++ b/src/Components/AnimeCard.js
@@ -67,7 +67,7 @@ export default function AnimeCard({ anime, large, onChangeSelected }) {
             <Typography
               sx={{
                 color: "#fff",
-                textAlign: "start",
+                textAlign: "center",
                 fontWeight: 600,
                 fontSize: large ? "1.2rem" : "unset",
               }}


### PR DESCRIPTION
A small change for your consideration.

I like the way the centered text looks if the only text we show on hover is the title.  However, if we're going to be adding additional lines of text with other info then I agree left-aligned makes more sense.