### PR TITLE
Add small margin beneath anime card header

### DIFF
--- a/src/Components/AnimeCard.js
+++ b/src/Components/AnimeCard.js
@@ -70,6 +70,7 @@ export default function AnimeCard({ anime, large, onChangeSelected }) {
                 textAlign: "center",
                 fontWeight: 600,
                 fontSize: large ? "1.2rem" : "unset",
+                mb: 1,
               }}
             >
               {anime.display_name}


### PR DESCRIPTION
I like that it gives a bit more breathing room between the title and the like buttons.