### PR TITLE
Use better truncation strategy for descriptions

### DIFF
--- a/src/Components/DetailedViewDescription.js
+++ b/src/Components/DetailedViewDescription.js
@@ -1,11 +1,11 @@
 import { Box, Button } from "@mui/material";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 
 export default function DetailedViewDescription({ text }) {
   const [expanded, setExpanded] = useState(false);
 
-  const shortText = text.split("\n")[0];
-  const canShorten = shortText.length < text.length && text.length > 400;
+  const shortText = useMemo(() => getShortText(text), [text]);
+  const canShorten = shortText.length < text.length;
 
   if (!canShorten) {
     return <Box component="span">{text}</Box>;
@@ -13,9 +13,16 @@ export default function DetailedViewDescription({ text }) {
 
   return (
     <>
-      <Box sx={{ display: "flex", flexDirection: "column" }}>
-        <Box component="span">{expanded ? text : shortText}</Box>
-        <Box sx={{ mt: 0, ml: -1 }}>
+      <Box sx={{}}>
+        <Box component="span">{expanded ? text : shortText + "..."}</Box>
+        <Box
+          component="span"
+          sx={{
+            mt: 0,
+            display: expanded ? "block" : "unset",
+            ml: expanded ? -1 : 0,
+          }}
+        >
           <Button
             color="inherit"
             onClick={() => setExpanded(!expanded)}
@@ -31,4 +38,12 @@ export default function DetailedViewDescription({ text }) {
       </Box>
     </>
   );
+}
+
+function getShortText(text) {
+  let i = 650;
+  while (i < text.length && i > 0 && text[i] !== " " && text[i] !== ".") {
+    i--;
+  }
+  return text.slice(0, i);
 }


### PR DESCRIPTION
Before, I cut the description off after the first paragraph.  Sometimes the first paragraph was really short, and this didn't look great, since there was space that could have been used to show more content.  Other times the first paragraph would end and it was ambiguous whether more text might follow, so users may not have even thought to look for a "read more" button.

Now I cut it off at about 650 characters, at the end of a word or sentence.  This creates a better visual, as the text area is fuller in shortened mode, and the text often ends on cliffhangers, making users more likely to click "read more" to finish reading.

I use React's 'useMemo' to only compute the cutoff point once for each block of text, regardless of re-renders for other reasons.