### PR TITLE
Add loading states to AnimeGrid/Shelf when no items

### DIFF
--- a/src/Components/AnimeGrid.js
+++ b/src/Components/AnimeGrid.js
@@ -1,4 +1,4 @@
-import { Box, Grid } from "@mui/material";
+import { Box, Grid, Skeleton } from "@mui/material";
 import { useState } from "react";
 import AnimeCard from "./AnimeCard";
 
@@ -6,6 +6,9 @@ export default function AnimeGrid({ items, large }) {
   items = items ?? [];
 
   const [selected, setSelected] = useState();
+
+  const ghosts = new Array(10).fill(0);
+  const showGhosts = !items.length;
 
   let columns = 12;
   let breakpoints = { xs: 6, sm: 3, md: 2 };
@@ -33,20 +36,30 @@ export default function AnimeGrid({ items, large }) {
       }}
     >
       <Grid container spacing={2} columns={columns}>
-        {items.map((anime, index) => (
-          <Grid
-            item
-            key={index}
-            {...breakpoints}
-            sx={{ aspectRatio: "0.7", zIndex: selected === index ? 1 : 0 }}
-          >
-            <AnimeCard
-              anime={anime}
-              large={large}
-              onChangeSelected={(v) => onChangeSelected(index, v)}
-            />
-          </Grid>
-        ))}
+        {showGhosts &&
+          ghosts.map((_, index) => (
+            <Grid item key={index} {...breakpoints} sx={{ aspectRatio: "0.7" }}>
+              <Skeleton
+                variant="rounded"
+                sx={{ height: "100%", borderRadius: "8px" }}
+              />
+            </Grid>
+          ))}
+        {!showGhosts &&
+          items.map((anime, index) => (
+            <Grid
+              item
+              key={index}
+              {...breakpoints}
+              sx={{ aspectRatio: "0.7", zIndex: selected === index ? 1 : 0 }}
+            >
+              <AnimeCard
+                anime={anime}
+                large={large}
+                onChangeSelected={(v) => onChangeSelected(index, v)}
+              />
+            </Grid>
+          ))}
       </Grid>
     </Box>
   );

--- a/src/Components/AnimeShelf.js
+++ b/src/Components/AnimeShelf.js
@@ -1,4 +1,11 @@
-import { Box, Grid, IconButton, useMediaQuery, useTheme } from "@mui/material";
+import {
+  Box,
+  Grid,
+  IconButton,
+  Skeleton,
+  useMediaQuery,
+  useTheme,
+} from "@mui/material";
 import { CaretLeft, CaretRight } from "phosphor-react";
 import { useState } from "react";
 import AnimeCard from "./AnimeCard";
@@ -26,6 +33,9 @@ export default function AnimeShelf({ items }) {
 
   const hasPrevious = startIndex > 0;
   const hasNext = startIndex < items.length - itemsPerPage;
+
+  const ghosts = new Array(itemsPerPage).fill(0);
+  const showGhosts = !items.length;
 
   const onChangeSelected = (index, value) => {
     if (value) {
@@ -58,19 +68,29 @@ export default function AnimeShelf({ items }) {
       }}
     >
       <Grid container spacing={2} columns={columns}>
-        {currentItems.map((anime, index) => (
-          <Grid
-            item
-            key={index}
-            {...breakpoints}
-            sx={{ aspectRatio: "0.7", zIndex: selected === index ? 1 : 0 }}
-          >
-            <AnimeCard
-              anime={anime}
-              onChangeSelected={(v) => onChangeSelected(index, v)}
-            />
-          </Grid>
-        ))}
+        {showGhosts &&
+          ghosts.map((_, index) => (
+            <Grid item key={index} {...breakpoints} sx={{ aspectRatio: "0.7" }}>
+              <Skeleton
+                variant="rounded"
+                sx={{ height: "100%", borderRadius: "8px" }}
+              />
+            </Grid>
+          ))}
+        {!showGhosts &&
+          currentItems.map((anime, index) => (
+            <Grid
+              item
+              key={index}
+              {...breakpoints}
+              sx={{ aspectRatio: "0.7", zIndex: selected === index ? 1 : 0 }}
+            >
+              <AnimeCard
+                anime={anime}
+                onChangeSelected={(v) => onChangeSelected(index, v)}
+              />
+            </Grid>
+          ))}
       </Grid>
       <IconButton
         onClick={onClickPrevious}

--- a/src/Components/Home.js
+++ b/src/Components/Home.js
@@ -148,10 +148,8 @@ export default function Home() {
         ) : (
           <h4>Like a show below to receive personalized recommendations!</h4>
         )}
-        {loadingRecs ? <div id="loading"></div> : ""}
         <AnimeGrid items={recommendation} large />
         <div className="gap" />
-        {loadingGeneric ? <div id="loading"></div> : ""}
       </Container>
 
       <ShelfTitle

--- a/src/Components/SimilarContent.js
+++ b/src/Components/SimilarContent.js
@@ -6,7 +6,6 @@ export default function SimilarContent({ animeId, amount }) {
 
   return (
     <div>
-      {loading ? <div id="loading"></div> : ""}
       <AnimeShelf items={similar ?? []} />
     </div>
   );


### PR DESCRIPTION
Right now, this just involves showing "ghost" cards in the grid or shelf.  It is still not perfect since when you like items in For You, it replaces them all with ghost cards very temporarily until the new recs come in, whereas I almost liked it more when the old cards stayed there until we got the new recs.  Maybe another loading indicator can be used.  I will address in a follow-up, but I want to get this in since it solves jankiness now that we use react-query.