### PR TITLE
Set 'keepPreviousData' in useRecommendations query

### DIFF
--- a/src/Components/APICalls.js
+++ b/src/Components/APICalls.js
@@ -103,6 +103,6 @@ export function useRecommendations(viewHistory) {
       responseJson.items.map((item, index) => temp.push(item.anime));
       return temp;
     },
-    { staleTime: fiveMinutesMs }
+    { staleTime: fiveMinutesMs, keepPreviousData: true }
   );
 }


### PR DESCRIPTION
This will keep the previous data visible whenever the query key changes until the new response comes in, removing the brief snap back to ghost cards for recommendations after changing likes or dislikes on Home.

I still may want either an indicator showing that a refresh is in progress, or else maybe _not_ a refresh, but a UI saying that new recs are available if the user clicks somewhere, so that the experience is even less disruptive while interacting with recommendations.  I'll look into that in a follow-up.