### PR TITLE
Add ghosts cards for onboarding items

### DIFF
--- a/src/Components/Onboarding.js
+++ b/src/Components/Onboarding.js
@@ -78,7 +78,7 @@ export default function Onboarding() {
 
         <br />
         {loading ? <BreathingLogo /> : ""}
-        <OnboardingAnimeGrid items={animeMR ?? []} large onboarding />
+        <OnboardingAnimeGrid items={animeMR} large onboarding />
         <br />
         {localUser["likes"] && localUser["likes"].length < 1 ? (
           <OnboardingButton disabled={true} />

--- a/src/Components/OnboardingAnimeGrid.js
+++ b/src/Components/OnboardingAnimeGrid.js
@@ -1,17 +1,32 @@
-import { Grid } from "@mui/material";
+import { Grid, Skeleton } from "@mui/material";
 import OnboardingAnimeCard from "./OnboardingAnimeCard";
 
 export default function OnboardingAnimeGrid({ items }) {
+  items = items ?? [];
+
   const columns = 20;
   const breakpoints = { xs: 10, sm: 5, md: 4 };
 
+  const ghosts = new Array(10).fill(0);
+  const showGhosts = !items.length;
+
   return (
     <Grid container spacing={2} columns={columns}>
-      {items.map((anime, index) => (
-        <Grid item key={index} {...breakpoints} sx={{ aspectRatio: "0.7" }}>
-          <OnboardingAnimeCard anime={anime} />
-        </Grid>
-      ))}
+      {showGhosts &&
+        ghosts.map((anime, index) => (
+          <Grid item key={index} {...breakpoints} sx={{ aspectRatio: "0.7" }}>
+            <Skeleton
+              variant="rounded"
+              sx={{ height: "100%", borderRadius: "8px" }}
+            />
+          </Grid>
+        ))}
+      {!showGhosts &&
+        items.map((anime, index) => (
+          <Grid item key={index} {...breakpoints} sx={{ aspectRatio: "0.7" }}>
+            <OnboardingAnimeCard anime={anime} />
+          </Grid>
+        ))}
     </Grid>
   );
 }


### PR DESCRIPTION
This will make it a little nicer if the user has to wait for the anime to load in for onboarding.

Eventually, I think it would be a good idea to curate the anime shown in onboarding to represent a range of types of content (lots of action titles there right now), and maybe to extend the list to be 6-per-row, which would make the cards shorter so the "Let's go" button would be above the fold.