### PR TITLE
Scroll window to top whenever the user navigates

### DIFF
--- a/src/Components/RoutingHelper.js
+++ b/src/Components/RoutingHelper.js
@@ -1,3 +1,4 @@
+import { useLayoutEffect } from "react";
 import { useAuthState } from "react-firebase-hooks/auth";
 import { matchPath, Outlet, useLocation, useMatch } from "react-router-dom";
 import Header from "./Header";
@@ -8,6 +9,11 @@ import BreathingLogo from "./BreathingLogo";
 export const RoutingHelper = () => {
   const [user, loading, error] = useAuthState(auth);
   const location = useLocation();
+
+  // Scroll to top if path changes.
+  useLayoutEffect(() => {
+    window.scrollTo(0, 0);
+  }, [location.pathname]);
 
   const headerRoutes = [
     "/home",


### PR DESCRIPTION
This will fix the issue where the window scroll position is maintained when switching pages, meaning that new pages can show up already scrolled partway down.