### PR TITLE
Remove dark hover colors from login buttons

### DIFF
--- a/src/Components/LandingPage.js
+++ b/src/Components/LandingPage.js
@@ -134,7 +134,7 @@ export default function LandingPage() {
         </Typography>
         <Link to="/login" tabindex="-1">
           <Button
-            variant="text"
+            variant="contained"
             size="large"
             color="inherit"
             sx={{
@@ -143,11 +143,6 @@ export default function LandingPage() {
                 fourHundred: "297px",
               },
               backgroundColor: theme.palette.common.white,
-              "&:hover, &:focus": {
-                color: "#fff",
-                backgroundColor: "#474747",
-                borderColor: "#474747",
-              },
             }}
           >
             Login

--- a/src/Components/LandingPageHeader.js
+++ b/src/Components/LandingPageHeader.js
@@ -90,11 +90,6 @@ export default function LandingPageHeader() {
               sx={{
                 fontSize: "0.875rem",
                 minWidth: "93px",
-                "&:hover, &:focus": {
-                  color: "#fff",
-                  backgroundColor: "#474747",
-                  borderColor: "#474747",
-                },
               }}
             >
               Login

--- a/src/Components/OnboardingHeader.js
+++ b/src/Components/OnboardingHeader.js
@@ -67,11 +67,6 @@ export default function OnboardingHeader() {
               sx={{
                 minWidth: "93px",
                 fontSize: ".875rem",
-                "&:hover, &:focus": {
-                  color: "#fff",
-                  backgroundColor: "#474747",
-                  borderColor: "#474747",
-                },
               }}
             >
               Login


### PR DESCRIPTION
As discussed in PR #38.

I may need to revisit these again when I implement dark mode to get the hover colors right in all contexts, especially the main Login button on the landing page.