### PR TITLE
Fix bug in GenreChips where chips couldn't select

### DIFF
--- a/src/Components/GenreChips.js
+++ b/src/Components/GenreChips.js
@@ -130,7 +130,7 @@ export default function GenreChips({ selectedGenre, setSelectedGenre }) {
       };
     }
     for (let i = 0; i < genreState.length; i++) {
-      if (index !== i) {
+      if (index + startIndex !== i) {
         temp[i].selected = false;
       }
     }


### PR DESCRIPTION
If chips were paginated on a small screen and a chip wasn't on the first page, it wouldn't select.  This was due to code that reset the `selected` value for all chip objects that weren't the selected index that didn't take into account the fact that the index is in a windowed view of the whole list.