### PR TITLE
Enable flex-wrap so mini chips on DetailedView wrap

### DIFF
--- a/src/Components/DetailedView.js
+++ b/src/Components/DetailedView.js
@@ -130,7 +130,7 @@ export default function DetailedView() {
               />
             </ListItem>
             <ListItem
-              sx={{ paddingTop: 0, pb: 0, minHeight: "32px", flexWrap: "wrap" }}
+              sx={{ pt: 0, pb: 0, minHeight: "32px", flexWrap: "wrap" }}
             >
               {anime.genres.map((genre) => (
                 <Chip


### PR DESCRIPTION
It is rare, but in mobile layouts, the genre chips on `DetailedView` can be wider than can fit on one line.  Using flex-wrap allows these chips to wrap naturally and not go offscreen.