### PR TITLE
Compactify Login and Register

### DIFF
--- a/src/Components/Login.js
+++ b/src/Components/Login.js
@@ -26,10 +26,10 @@ import {
   useTheme,
 } from "@mui/material";
 
-import logo from "../Styles/images/logo.svg";
 import TwitterIcon from "@mui/icons-material/Twitter";
 import google from "../Styles/images/google.svg";
 import { User } from "phosphor-react";
+import EdwardMLLogo from "./EdwardMLLogo";
 
 export default function Login() {
   const [localUser, setLocalUser] = useContext(LocalUserContext);
@@ -67,33 +67,8 @@ export default function Login() {
     <div className="login">
       <Container maxWidth="lg">
         <div className="welcomeBanner">
-          <Link to="/home">
-            <img src={logo} alt="" className="welcomeLogo" />
-          </Link>
-          <Link to="/home">
-            <div className="welcomeTextBlock">
-              <h1
-                className="welcomeTitle"
-                style={{
-                  color: theme.palette.text.primary,
-                  paddingLeft: "10px",
-                }}
-              >
-                Edward
-              </h1>
-              <h1
-                className="welcomeTitle"
-                style={{ color: theme.palette.primary.main }}
-              >
-                ML
-              </h1>
-            </div>
-          </Link>
+          <EdwardMLLogo />
         </div>
-
-        <h4 className="H4" style={{ textAlign: "center" }}>
-          Let's Get Logged In!
-        </h4>
       </Container>
       <Container
         maxWidth="sm"
@@ -103,9 +78,15 @@ export default function Login() {
           alignItems: "center",
         }}
       >
+        <h4
+          className="H4"
+          style={{ textAlign: "center", margin: 0, marginBottom: "18px" }}
+        >
+          Let's Get Logged In!
+        </h4>
         <div
           className="register__container"
-          style={{ marginBottom: "50px", borderColor: theme.palette.divider }}
+          style={{ borderColor: theme.palette.divider }}
         >
           {/* *******************Google Button************************** */}
           <Button
@@ -151,6 +132,7 @@ export default function Login() {
             className="register__btn"
             sx={{
               ...regButtonStyling,
+              marginBottom: "0px",
               fontSize: {
                 xs: "0.9rem",
                 fourHundred: "1rem",
@@ -188,7 +170,7 @@ export default function Login() {
                 borderColor: theme.palette.text.primary,
               },
               fontFamily: "interMedium",
-              margin: "37.5px 0px",
+              margin: "16px 0px",
             }}
           >
             or
@@ -270,22 +252,23 @@ export default function Login() {
               fontSize: "1rem",
             }}
           />
-          <Typography
-            sx={{
-              color: "error.main",
-              fontFamily: "interExtraBold",
-              marginTop: "10px",
-            }}
-          >
-            {loginError ? loginError : ""}
-          </Typography>
+          {loginError && (
+            <Typography
+              sx={{
+                color: "error.main",
+                fontFamily: "interExtraBold",
+                marginY: "10px",
+              }}
+            >
+              {loginError}
+            </Typography>
+          )}
           {/* *******************EdwardML - 'Login' Button************************** */}
           <Button
             variant="contained"
             size="large"
             sx={{
               width: "211px",
-              marginTop: "20px",
             }}
             onClick={() => {
               logInWithEmailAndPassword(email, password, setLoginError);
@@ -298,8 +281,8 @@ export default function Login() {
             sx={{
               width: "100%",
               borderColor: theme.palette.text.primary,
-              marginTop: "32px",
-              marginBottom: "27px",
+              marginTop: "30px",
+              marginBottom: "30px",
             }}
           />
           {/* *******************Already Registered Section************************** */}

--- a/src/Components/Register.js
+++ b/src/Components/Register.js
@@ -15,7 +15,6 @@ import {
 } from "./Firebase";
 import { SaveToFirestore } from "./Firestore";
 import { LocalUserContext } from "./LocalUserContext";
-import logo from "../Styles/images/logo.svg";
 import {
   Button,
   Container,
@@ -34,6 +33,7 @@ import { useForm } from "react-hook-form";
 import LoadingFourdots from "./LoadingFourDots.json";
 import Lottie from "lottie-react";
 import BreathingLogo from "./BreathingLogo";
+import EdwardMLLogo from "./EdwardMLLogo";
 
 export default function Register() {
   const [email, setEmail] = useState("");
@@ -108,33 +108,8 @@ export default function Register() {
     <div className="register">
       <Container maxWidth="lg">
         <div className="welcomeBanner">
-          <Link to="/home">
-            <img src={logo} alt="" className="welcomeLogo" />
-          </Link>
-          <Link to="/home">
-            <div className="welcomeTextBlock">
-              <h1
-                className="welcomeTitle"
-                style={{
-                  color: theme.palette.text.primary,
-                  paddingLeft: "10px",
-                }}
-              >
-                Edward
-              </h1>
-              <h1
-                className="welcomeTitle"
-                style={{ color: theme.palette.primary.main }}
-              >
-                ML
-              </h1>
-            </div>
-          </Link>
+          <EdwardMLLogo />
         </div>
-
-        <h4 className="H4" style={{ textAlign: "center" }}>
-          Let's Get Registered!
-        </h4>
       </Container>
       {/* *******************Start of Registration Block************************** */}
       <Container
@@ -145,6 +120,12 @@ export default function Register() {
           alignItems: "center",
         }}
       >
+        <h4
+          className="H4"
+          style={{ textAlign: "center", margin: 0, marginBottom: "18px" }}
+        >
+          Let's Get Registered!
+        </h4>
         <div
           className="register__container"
           style={{
@@ -270,8 +251,7 @@ export default function Register() {
                 ""
               ) : (
                 <User
-                  size={42}
-                  weight="light"
+                  size={44}
                   style={{
                     paddingRight: "20px",
                     width: {
@@ -297,7 +277,7 @@ export default function Register() {
                 borderColor: theme.palette.text.primary,
               },
               fontFamily: "interMedium",
-              margin: "37.5px 0px",
+              margin: "18px 0px",
             }}
           >
             or
@@ -417,7 +397,6 @@ export default function Register() {
             size="large"
             sx={{
               width: "211px",
-              marginTop: "20px",
             }}
             onClick={handleSubmit(() => {
               setRegLoadingEmail(true);
@@ -447,28 +426,30 @@ export default function Register() {
               "Let's Go!"
             )}
           </Button>
-          <Typography
-            sx={{
-              color: "error.main",
-              marginTop: "10px",
-              fontFamily: "interExtraBold",
-            }}
-          >
-            {errors.username || errors.email || errors.password
-              ? "*Please resolve errors shown above."
-              : ""}
-          </Typography>
-          <Typography
-            sx={{ color: "error.main", fontFamily: "interExtraBold" }}
-          >
-            {emailError ? emailError : ""}
-          </Typography>
+          {(errors.username || errors.email || errors.password) && (
+            <Typography
+              sx={{
+                color: "error.main",
+                marginTop: "10px",
+                fontFamily: "interExtraBold",
+              }}
+            >
+              *Please resolve errors shown above.
+            </Typography>
+          )}
+          {emailError && (
+            <Typography
+              sx={{ color: "error.main", fontFamily: "interExtraBold" }}
+            >
+              {emailError}
+            </Typography>
+          )}
           <Divider
             sx={{
               width: "100%",
               borderColor: theme.palette.text.primary,
-              marginTop: "32px",
-              marginBottom: "27px",
+              marginTop: "30px",
+              marginBottom: "30px",
             }}
           />
           {/* *******************Already Registered Section************************** */}

--- a/src/Styles/Register.css
+++ b/src/Styles/Register.css
@@ -3,6 +3,8 @@
 .welcomeBanner {
   display: flex;
   justify-content: center;
+  margin-top: 25px;
+  margin-bottom: 25px;
 }
 
 /* Registration form styling */
@@ -14,20 +16,14 @@
   align-items: center;
   border: 1px solid;
   border-radius: 11px;
-  padding: 40px 50px 30px 50px;
+  padding: 30px 50px 30px 50px;
   max-width: 400px;
 }
 
-@media (max-width: 600px) {
-  .register__container {
-    max-width: 295px;
-  }
-}
-
-@media (max-width: 400px) {
+@media (max-width: 450px) {
   .register__container {
     border: none;
-    max-width: 280px;
+    padding-top: 8px;
     padding-left: 0px;
     padding-right: 0px;
   }


### PR DESCRIPTION
This commit swaps the jumbo EdwardML header for the common `EdwardMLLogo` component, and reduces spacing between form elements to make both forms fit better above the fold.  It also increases the threshold for border-less mobile forms to 450px since some devices (iPhone XR) have a width slightly over 400 logical pixels.