### PR TITLE
Fix bug in updating analysis, add live updates

### DIFF
--- a/src/Components/BreathingLogo.js
+++ b/src/Components/BreathingLogo.js
@@ -1905,5 +1905,7 @@ export default function BreathingLogo({ type }) {
         <SVG style={{ scale: "1", margin: "300px 0px", maxWidth: "400px" }} />
       </Box>
     );
+  } else {
+    return <SVG style={{ scale: "1" }} />;
   }
 }

--- a/src/Components/DetailedView.js
+++ b/src/Components/DetailedView.js
@@ -11,6 +11,7 @@ import { useAuthState } from "react-firebase-hooks/auth";
 import { useLocation, useNavigate, useParams } from "react-router-dom";
 import useAnime from "../Hooks/useAnime";
 import useAnimeAnalysis from "../Hooks/useAnimeAnalysis";
+import BreathingLogo from "./BreathingLogo";
 import ExpandableText from "./ExpandableText";
 import { auth } from "./Firebase";
 import { PopulateFromFirestore } from "./Firestore";
@@ -33,7 +34,8 @@ export default function AnimePage() {
 
   const [anime, animeLoading, animeError] = useAnime(animeId, location.state);
 
-  const [analysis, analysisLoading, analysisError] = useAnimeAnalysis(animeId);
+  const [analysis, analysisLoading, analysisError, analysisFetching] =
+    useAnimeAnalysis(animeId);
 
   useEffect(() => {
     if (loading) return;
@@ -195,7 +197,31 @@ export default function AnimePage() {
                 borderRadius: "16px",
               }}
             >
-              <Grid container columnSpacing={3}>
+              <Grid container columnSpacing={3} sx={{ position: "relative" }}>
+                {analysisFetching && analysis?.anime_id !== anime.id && (
+                  <Box
+                    sx={{
+                      position: "absolute",
+                      top: 0,
+                      left: 0,
+                      width: "100%",
+                      height: "100%",
+                      display: "flex",
+                      alignItems: "center",
+                      justifyContent: "center",
+                      zIndex: 1,
+                    }}
+                  >
+                    <Box
+                      sx={{
+                        width: "60px",
+                        height: "60px",
+                      }}
+                    >
+                      <BreathingLogo />
+                    </Box>
+                  </Box>
+                )}
                 <Grid item xs={12} md={6} sx={bodyStyle}>
                   <Typography
                     variant="h5"
@@ -203,7 +229,7 @@ export default function AnimePage() {
                   >
                     Data From Edward
                   </Typography>
-                  <ScoreBars scores={analysis.scores} />
+                  <ScoreBars scores={analysis?.scores ?? []} />
                 </Grid>
                 <Grid item xs={12} md={6}>
                   <Typography
@@ -219,7 +245,7 @@ export default function AnimePage() {
                     What Do People Say?
                   </Typography>
                   <Typography variant="body1" sx={bodyStyle}>
-                    {analysis.review_summaries[0]}
+                    {analysis?.review_summaries[0]}
                   </Typography>
                 </Grid>
               </Grid>

--- a/src/Hooks/useAnimeAnalysis.js
+++ b/src/Hooks/useAnimeAnalysis.js
@@ -3,6 +3,11 @@ import { useContext, useMemo } from "react";
 import { APIGetAnimeAnalysis } from "../Components/APICalls";
 import { LocalUserContext } from "../Components/LocalUserContext";
 
+/**
+ * A hook that provides anime analysis for the given `animeId`.
+ * @param {string} animeId The anime id to get analysis for.
+ * @returns A list of `[anime, loading, error, fetching]`.
+ */
 export default function useAnimeAnalysis(animeId) {
   const [localUser] = useContext(LocalUserContext);
 
@@ -18,15 +23,16 @@ export default function useAnimeAnalysis(animeId) {
         status: "DROPPED",
       })),
     ],
-    []
+    [localUser]
   );
 
-  const { data, isLoading, error } = useQuery(
-    ["anime", animeId, "analysis"],
+  const { data, isLoading, error, isFetching } = useQuery(
+    ["anime", animeId, "analysis", history],
     () => {
       return APIGetAnimeAnalysis(animeId, history);
-    }
+    },
+    { keepPreviousData: true }
   );
 
-  return [data, isLoading, error];
+  return [data, isLoading, error, isFetching];
 }


### PR DESCRIPTION
This commit fixes a bug where changes to the user's likes or dislikes while on DetailedView would not be reflected in future analysis, and also adds the ability to reload analysis live on changes.  I've added a cool little loading indicator when you switch anime, using BreathingLogo, to make it clear when the analysis is outdated and pending updates.   The animations in score bars when the scores switch between anime is kinda cool in that it lets you compare them based on how much the bars move.