### PR TITLE
Format header to have tabs

### DIFF
--- a/src/Components/DropMenu.js
+++ b/src/Components/DropMenu.js
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React, { useContext, useEffect, useRef, useState } from "react";
 import Button from "@mui/material/Button";
 import ClickAwayListener from "@mui/material/ClickAwayListener";
 import Grow from "@mui/material/Grow";
@@ -36,13 +36,13 @@ export default function DropMenu() {
   const [user] = useAuthState(auth);
   const theme = useTheme();
 
-  const [localUser, setLocalUser] = React.useContext(LocalUserContext);
+  const [localUser, setLocalUser] = useContext(LocalUserContext);
 
-  const [appSettings, setAppSettings] = React.useContext(AppSettingsContext);
+  const [appSettings, setAppSettings] = useContext(AppSettingsContext);
   const darkMode = appSettings.darkMode;
 
-  const [open, setOpen] = React.useState(false);
-  const anchorRef = React.useRef(null);
+  const [open, setOpen] = useState(false);
+  const anchorRef = useRef(null);
 
   const handleToggle = () => {
     setOpen((prevOpen) => !prevOpen);
@@ -66,8 +66,8 @@ export default function DropMenu() {
   }
 
   // return focus to the button when we transitioned from !open -> open
-  const prevOpen = React.useRef(open);
-  React.useEffect(() => {
+  const prevOpen = useRef(open);
+  useEffect(() => {
     if (prevOpen.current === true && open === false) {
       anchorRef.current.focus();
     }

--- a/src/Components/Header.js
+++ b/src/Components/Header.js
@@ -1,33 +1,43 @@
 import "../Styles/Header.css";
 
-import { Link } from "react-router-dom";
+import { Link, useLocation, useNavigate } from "react-router-dom";
 import {
   Button,
   Container,
   Grid,
   Icon,
+  IconButton,
   ListItemSecondaryAction,
   Typography,
 } from "@mui/material";
 import { useAuthState } from "react-firebase-hooks/auth";
 import { auth, logout } from "./Firebase";
 import { signOut } from "firebase/auth";
-import { useContext, useEffect } from "react";
+import { useContext, useEffect, useState } from "react";
 import { LocalUserContext } from "./LocalUserContext";
 import TitleAutocomplete from "./TitleAutocomplete";
-import { UserCircle, List, Palette } from "phosphor-react";
+import { UserCircle, List, Palette, MagnifyingGlass } from "phosphor-react";
 import DropMenu from "./DropMenu";
 import { useTheme } from "@mui/material/styles";
 import EdwardMLLogo from "./EdwardMLLogo";
+import { Box } from "@mui/system";
 
 function Header() {
   const [localUser, setLocalUser] = useContext(LocalUserContext);
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  const [showSearch, setShowSearch] = useState(false);
 
   const [user] = useAuthState(auth);
 
   const theme = useTheme();
 
   useEffect(() => {}, [user]);
+
+  const toggleSearch = (e) => {
+    setShowSearch(true);
+  };
 
   return (
     <div
@@ -49,11 +59,81 @@ function Header() {
             <Link to="/home">
               <EdwardMLLogo />
             </Link>
-            <div></div>
           </Grid>
-          <Grid item lg={8.5} md={8.5} sm={6} xs={7.5} sx={{ marginY: 0.75 }}>
-            {TitleAutocomplete()}
-          </Grid>
+          {!showSearch ? (
+            <>
+              <Grid
+                item
+                lg={8.5}
+                md={8.5}
+                sm={6}
+                xs={7.5}
+                sx={{
+                  marginY: 0.75,
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "space-evenly",
+                }}
+              >
+                <Link to="/home">
+                  <Typography
+                    onClick={(e) => {
+                      navigate("/home");
+                    }}
+                    sx={{
+                      fontFamily: "interSemiBold",
+                      fontSize: "1.125rem",
+                      "&:hover": {
+                        color: "primary.main",
+                      },
+                    }}
+                  >
+                    Home
+                  </Typography>
+                </Link>
+                <Link to="/profile">
+                  <Typography
+                    onKeyDown
+                    sx={{
+                      fontFamily: "interSemiBold",
+                      fontSize: "1.125rem",
+                      "&:hover": {
+                        color: "primary.main",
+                      },
+                    }}
+                  >
+                    Profile
+                  </Typography>
+                </Link>
+                <Box
+                  sx={{
+                    display: "flex",
+                    alignItems: "center",
+                    cursor: "pointer",
+                    "&:hover": {
+                      color: "primary.main",
+                    },
+                  }}
+                  onClick={toggleSearch}
+                >
+                  <MagnifyingGlass size={18} />
+                  <Typography
+                    sx={{
+                      fontFamily: "interSemiBold",
+                      fontSize: "1.125rem",
+                      ml: 0.75,
+                    }}
+                  >
+                    Search
+                  </Typography>{" "}
+                </Box>
+              </Grid>{" "}
+            </>
+          ) : (
+            <Grid item lg={8.5} md={8.5} sm={6} xs={7.5} sx={{ marginY: 0.75 }}>
+              <TitleAutocomplete setShowSearch={setShowSearch} />
+            </Grid>
+          )}
           <Grid
             item
             xs={2}

--- a/src/Components/Header.js
+++ b/src/Components/Header.js
@@ -9,6 +9,7 @@ import {
   IconButton,
   ListItemSecondaryAction,
   Typography,
+  useMediaQuery,
 } from "@mui/material";
 import { useAuthState } from "react-firebase-hooks/auth";
 import { auth, logout } from "./Firebase";
@@ -16,7 +17,14 @@ import { signOut } from "firebase/auth";
 import { useContext, useEffect, useState } from "react";
 import { LocalUserContext } from "./LocalUserContext";
 import TitleAutocomplete from "./TitleAutocomplete";
-import { UserCircle, List, Palette, MagnifyingGlass } from "phosphor-react";
+import {
+  UserCircle,
+  List,
+  Palette,
+  MagnifyingGlass,
+  House,
+  User,
+} from "phosphor-react";
 import DropMenu from "./DropMenu";
 import { useTheme } from "@mui/material/styles";
 import EdwardMLLogo from "./EdwardMLLogo";
@@ -26,17 +34,37 @@ function Header() {
   const [localUser, setLocalUser] = useContext(LocalUserContext);
   const navigate = useNavigate();
   const location = useLocation();
+  const theme = useTheme();
+  const [user] = useAuthState(auth);
 
   const [showSearch, setShowSearch] = useState(false);
 
-  const [user] = useAuthState(auth);
-
-  const theme = useTheme();
+  let smallDevice = useMediaQuery(theme.breakpoints.down("sm"));
 
   useEffect(() => {}, [user]);
 
   const toggleSearch = (e) => {
     setShowSearch(true);
+  };
+
+  function onSubmit(key) {
+    if (key === "Enter") {
+      toggleSearch();
+    }
+  }
+
+  const iconHoverStyle = {
+    "&:hover": {
+      color: { smallDevice } ? "primary.main" : "inherit",
+    },
+  };
+
+  const tabTypogStyle = {
+    fontFamily: "interSemiBold",
+    fontSize: "1.125rem",
+    "&:hover": {
+      color: "primary.main",
+    },
   };
 
   return (
@@ -76,34 +104,31 @@ function Header() {
                 }}
               >
                 <Link to="/home">
-                  <Typography
-                    onClick={(e) => {
-                      navigate("/home");
-                    }}
-                    sx={{
-                      fontFamily: "interSemiBold",
-                      fontSize: "1.125rem",
-                      "&:hover": {
-                        color: "primary.main",
-                      },
-                    }}
-                  >
-                    Home
-                  </Typography>
+                  {smallDevice ? (
+                    <IconButton tabIndex="-1" sx={iconHoverStyle}>
+                      <House size={24} />
+                    </IconButton>
+                  ) : (
+                    <Typography
+                      onClick={(e) => {
+                        navigate("/home");
+                      }}
+                      sx={tabTypogStyle}
+                    >
+                      Home
+                    </Typography>
+                  )}
                 </Link>
                 <Link to="/profile">
-                  <Typography
-                    onKeyDown
-                    sx={{
-                      fontFamily: "interSemiBold",
-                      fontSize: "1.125rem",
-                      "&:hover": {
-                        color: "primary.main",
-                      },
-                    }}
-                  >
-                    Profile
-                  </Typography>
+                  {smallDevice ? (
+                    <IconButton tabIndex="-1" sx={iconHoverStyle}>
+                      <User size={24} />
+                    </IconButton>
+                  ) : (
+                    <Typography onKeyDown sx={tabTypogStyle}>
+                      Profile
+                    </Typography>
+                  )}
                 </Link>
                 <Box
                   sx={{
@@ -115,17 +140,29 @@ function Header() {
                     },
                   }}
                   onClick={toggleSearch}
+                  tabIndex="0"
+                  onKeyDown={(e) => {
+                    onSubmit(e.key);
+                  }}
                 >
-                  <MagnifyingGlass size={18} />
-                  <Typography
-                    sx={{
-                      fontFamily: "interSemiBold",
-                      fontSize: "1.125rem",
-                      ml: 0.75,
-                    }}
-                  >
-                    Search
-                  </Typography>{" "}
+                  {smallDevice ? (
+                    <IconButton tabIndex="-1" sx={iconHoverStyle}>
+                      <MagnifyingGlass size={24} />
+                    </IconButton>
+                  ) : (
+                    <>
+                      <MagnifyingGlass size={18} />
+                      <Typography
+                        sx={{
+                          fontFamily: "interSemiBold",
+                          fontSize: "1.125rem",
+                          ml: 0.75,
+                        }}
+                      >
+                        Search
+                      </Typography>
+                    </>
+                  )}
                 </Box>
               </Grid>{" "}
             </>

--- a/src/Components/TitleAutocomplete.js
+++ b/src/Components/TitleAutocomplete.js
@@ -13,7 +13,7 @@ import { useNavigate } from "react-router-dom";
 import { useLocation } from "react-router-dom";
 import { MagnifyingGlass } from "phosphor-react";
 
-export default function TitleAutocomplete(search) {
+export default function TitleAutocomplete({ search, setShowSearch }) {
   const navigate = useNavigate();
   let location = useLocation();
 
@@ -23,14 +23,20 @@ export default function TitleAutocomplete(search) {
   let [options, setOptions] = useState([]);
   let [loading, setLoading] = useState(false);
 
+  let [open, setOpen] = useState(false);
+  const closePopper = () => setOpen(false);
+  const openPopper = () => setOpen(true);
+
   let focusElement = useRef(null);
 
   function onSubmit(key, input) {
     if (key === "Enter") {
-      focusElement.current.focus(); //removes focus, so the options list will close
-      focusElement.current.blur(); //removes focus, so the options list will close
+      // focusElement.current.focus(); //removes focus, so the options list will close
+      // focusElement.current.blur(); //removes focus, so the options list will close
       navigate("/search", { state: input });
+      closePopper();
     }
+    if (key === "Escape") setShowSearch(false);
   }
 
   useEffect(() => {
@@ -55,14 +61,20 @@ export default function TitleAutocomplete(search) {
         inputValue={inputValue}
         onInputChange={(event, newInputValue) => {
           setInputValue(newInputValue);
+          openPopper();
         }}
         forcePopupIcon={false}
         fullWidth={true}
         filterSelectedOptions
         options={options}
         handleHomeEndKeys={true}
+        open={open}
         openOnFocus={true}
         clearOnBlur={false}
+        blurOnSelect
+        onBlur={(e) => {
+          setShowSearch(false);
+        }}
         getOptionLabel={(option) => option.display_name || ""}
         renderOption={(props, options) => (
           <Box
@@ -92,6 +104,8 @@ export default function TitleAutocomplete(search) {
         renderInput={(params) => (
           <TextField
             {...params}
+            autoFocus
+            placeholder="Search"
             onKeyDown={(e) => {
               onSubmit(e.key, params["inputProps"]["value"]);
             }}

--- a/src/Components/TitleAutocomplete.js
+++ b/src/Components/TitleAutocomplete.js
@@ -31,8 +31,6 @@ export default function TitleAutocomplete({ search, setShowSearch }) {
 
   function onSubmit(key, input) {
     if (key === "Enter") {
-      // focusElement.current.focus(); //removes focus, so the options list will close
-      // focusElement.current.blur(); //removes focus, so the options list will close
       navigate("/search", { state: input });
       closePopper();
     }


### PR DESCRIPTION
This commit adds tab navigation to the header and hides the search bar behind a toggle.
- There is a mobile use case where guest accounts will have two "user" icons shown on the header (the profile tab and the dropMenu).  I'm thinking of adding a different default guest image for the dropMenu...maybe a "G" or a question mark... 