### PR TITLE
Header tab styling

### DIFF
--- a/src/Components/Header.js
+++ b/src/Components/Header.js
@@ -14,7 +14,7 @@ import {
 import { useAuthState } from "react-firebase-hooks/auth";
 import { auth, logout } from "./Firebase";
 import { signOut } from "firebase/auth";
-import { useContext, useEffect, useState } from "react";
+import { useContext, useState } from "react";
 import { LocalUserContext } from "./LocalUserContext";
 import TitleAutocomplete from "./TitleAutocomplete";
 import {
@@ -40,8 +40,6 @@ function Header() {
   const [showSearch, setShowSearch] = useState(false);
 
   let smallDevice = useMediaQuery(theme.breakpoints.down("sm"));
-
-  useEffect(() => {}, [user]);
 
   const toggleSearch = (e) => {
     setShowSearch(true);

--- a/src/Components/Header.js
+++ b/src/Components/Header.js
@@ -37,7 +37,7 @@ function Header() {
             paddingBottom: 0,
           }}
         >
-          <Grid item lg={2.5} md={2.5} sm={4.75} xs={2.5}>
+          <Grid item md={2.5} sm={4.75} xs={2.5}>
             <Link to="/home">
               <EdwardMLLogo />
             </Link>
@@ -46,8 +46,7 @@ function Header() {
             <>
               <Grid
                 item
-                lg={8.5}
-                md={8.5}
+                md={7}
                 sm={6}
                 xs={7.5}
                 sx={{
@@ -68,7 +67,7 @@ function Header() {
               </Grid>
             </>
           ) : (
-            <Grid item lg={8.5} md={8.5} sm={6} xs={7.5} sx={{ marginY: 0.75 }}>
+            <Grid item md={7} sm={6} xs={7.5} sx={{ marginY: 0.75 }}>
               <TitleAutocomplete setShowSearch={setShowSearch} />
             </Grid>
           )}
@@ -76,7 +75,7 @@ function Header() {
             item
             xs={2}
             sm={1.25}
-            md={1}
+            md={2.5}
             textAlign="right"
             sx={{ display: "flex", justifyContent: "right" }}
           >

--- a/src/Components/Header.js
+++ b/src/Components/Header.js
@@ -53,7 +53,8 @@ function Header() {
     }
   }
 
-  const iconHoverStyle = {
+  const iconStyle = {
+    color: theme.palette.text.primary,
     "&:hover": {
       color: { smallDevice } ? "primary.main" : "inherit",
     },
@@ -105,7 +106,7 @@ function Header() {
               >
                 <Link to="/home">
                   {smallDevice ? (
-                    <IconButton tabIndex="-1" sx={iconHoverStyle}>
+                    <IconButton tabIndex="-1" sx={iconStyle}>
                       <House size={24} />
                     </IconButton>
                   ) : (
@@ -121,7 +122,7 @@ function Header() {
                 </Link>
                 <Link to="/profile">
                   {smallDevice ? (
-                    <IconButton tabIndex="-1" sx={iconHoverStyle}>
+                    <IconButton tabIndex="-1" sx={iconStyle}>
                       <User size={24} />
                     </IconButton>
                   ) : (
@@ -144,7 +145,7 @@ function Header() {
                   }}
                 >
                   {smallDevice ? (
-                    <IconButton tabIndex="-1" sx={iconHoverStyle}>
+                    <IconButton tabIndex="-1" sx={iconStyle}>
                       <MagnifyingGlass size={24} />
                     </IconButton>
                   ) : (

--- a/src/Components/Header.js
+++ b/src/Components/Header.js
@@ -125,9 +125,7 @@ function Header() {
                       <User size={24} />
                     </IconButton>
                   ) : (
-                    <Typography onKeyDown sx={tabTypogStyle}>
-                      Profile
-                    </Typography>
+                    <Typography sx={tabTypogStyle}>Profile</Typography>
                   )}
                 </Link>
                 <Box

--- a/src/Components/Header.js
+++ b/src/Components/Header.js
@@ -1,69 +1,24 @@
 import "../Styles/Header.css";
 
-import { Link, useLocation, useNavigate } from "react-router-dom";
-import {
-  Button,
-  Container,
-  Grid,
-  Icon,
-  IconButton,
-  ListItemSecondaryAction,
-  Typography,
-  useMediaQuery,
-} from "@mui/material";
-import { useAuthState } from "react-firebase-hooks/auth";
-import { auth, logout } from "./Firebase";
-import { signOut } from "firebase/auth";
-import { useContext, useState } from "react";
-import { LocalUserContext } from "./LocalUserContext";
+import { Link } from "react-router-dom";
+import { Container, Grid } from "@mui/material";
+
+import { useState } from "react";
 import TitleAutocomplete from "./TitleAutocomplete";
-import {
-  UserCircle,
-  List,
-  Palette,
-  MagnifyingGlass,
-  House,
-  User,
-} from "phosphor-react";
+import { MagnifyingGlass, House, User } from "phosphor-react";
 import DropMenu from "./DropMenu";
 import { useTheme } from "@mui/material/styles";
 import EdwardMLLogo from "./EdwardMLLogo";
-import { Box } from "@mui/system";
+import HeaderTab from "./HeaderTab";
 
 function Header() {
-  const [localUser, setLocalUser] = useContext(LocalUserContext);
-  const navigate = useNavigate();
-  const location = useLocation();
   const theme = useTheme();
-  const [user] = useAuthState(auth);
 
   const [showSearch, setShowSearch] = useState(false);
 
-  let smallDevice = useMediaQuery(theme.breakpoints.down("sm"));
-
   const toggleSearch = (e) => {
     setShowSearch(true);
-  };
-
-  function onSubmit(key) {
-    if (key === "Enter") {
-      toggleSearch();
-    }
-  }
-
-  const iconStyle = {
-    color: theme.palette.text.primary,
-    "&:hover": {
-      color: { smallDevice } ? "primary.main" : "inherit",
-    },
-  };
-
-  const tabTypogStyle = {
-    fontFamily: "interSemiBold",
-    fontSize: "1.125rem",
-    "&:hover": {
-      color: "primary.main",
-    },
+    e.preventDefault();
   };
 
   return (
@@ -102,66 +57,15 @@ function Header() {
                   justifyContent: "space-evenly",
                 }}
               >
-                <Link to="/home">
-                  {smallDevice ? (
-                    <IconButton tabIndex="-1" sx={iconStyle}>
-                      <House size={24} />
-                    </IconButton>
-                  ) : (
-                    <Typography
-                      onClick={(e) => {
-                        navigate("/home");
-                      }}
-                      sx={tabTypogStyle}
-                    >
-                      Home
-                    </Typography>
-                  )}
-                </Link>
-                <Link to="/profile">
-                  {smallDevice ? (
-                    <IconButton tabIndex="-1" sx={iconStyle}>
-                      <User size={24} />
-                    </IconButton>
-                  ) : (
-                    <Typography sx={tabTypogStyle}>Profile</Typography>
-                  )}
-                </Link>
-                <Box
-                  sx={{
-                    display: "flex",
-                    alignItems: "center",
-                    cursor: "pointer",
-                    "&:hover": {
-                      color: "primary.main",
-                    },
-                  }}
+                <HeaderTab text="Home" icon={<House />} path="/home" />
+                <HeaderTab text="Profile" icon={<User />} path="/profile" />
+                <HeaderTab
+                  text="Search"
+                  icon={<MagnifyingGlass />}
+                  alwaysShowIcon
                   onClick={toggleSearch}
-                  tabIndex="0"
-                  onKeyDown={(e) => {
-                    onSubmit(e.key);
-                  }}
-                >
-                  {smallDevice ? (
-                    <IconButton tabIndex="-1" sx={iconStyle}>
-                      <MagnifyingGlass size={24} />
-                    </IconButton>
-                  ) : (
-                    <>
-                      <MagnifyingGlass size={18} />
-                      <Typography
-                        sx={{
-                          fontFamily: "interSemiBold",
-                          fontSize: "1.125rem",
-                          ml: 0.75,
-                        }}
-                      >
-                        Search
-                      </Typography>
-                    </>
-                  )}
-                </Box>
-              </Grid>{" "}
+                />
+              </Grid>
             </>
           ) : (
             <Grid item lg={8.5} md={8.5} sm={6} xs={7.5} sx={{ marginY: 0.75 }}>

--- a/src/Components/HeaderTab.js
+++ b/src/Components/HeaderTab.js
@@ -15,7 +15,6 @@ export default function HeaderTab({
   alwaysShowIcon,
 }) {
   const location = useLocation();
-  const navigate = useNavigate();
   const theme = useTheme();
 
   const smallDevice = useMediaQuery(theme.breakpoints.down("sm"));
@@ -25,8 +24,13 @@ export default function HeaderTab({
   const internalOnClick = (e) => {
     if (onClick) {
       onClick();
-    } else if (path) {
-      navigate(path);
+    }
+  };
+
+  const onKeyDown = (e) => {
+    if (e.key === "Enter" && onClick) {
+      onClick();
+      e.preventDefault();
     }
   };
 
@@ -60,7 +64,7 @@ export default function HeaderTab({
   };
 
   return (
-    <Link to={path}>
+    <Link to={path} onKeyDown={onKeyDown}>
       {smallDevice ? (
         <IconButton tabIndex="-1" sx={iconStyle} onClick={internalOnClick}>
           {icon}

--- a/src/Components/HeaderTab.js
+++ b/src/Components/HeaderTab.js
@@ -54,7 +54,7 @@ export default function HeaderTab({
       content: "''",
       height: "4px",
       borderRadius: "2px",
-      bottom: "-4px",
+      bottom: "0px",
       margin: "0 auto",
       left: 0,
       right: 0,

--- a/src/Components/HeaderTab.js
+++ b/src/Components/HeaderTab.js
@@ -1,0 +1,67 @@
+import {
+  Box,
+  IconButton,
+  Typography,
+  useMediaQuery,
+  useTheme,
+} from "@mui/material";
+import { Link, useNavigate } from "react-router-dom";
+
+export default function HeaderTab({
+  icon,
+  text,
+  path,
+  onClick,
+  alwaysShowIcon,
+}) {
+  const navigate = useNavigate();
+  const theme = useTheme();
+
+  const smallDevice = useMediaQuery(theme.breakpoints.down("sm"));
+
+  const internalOnClick = (e) => {
+    if (onClick) {
+      onClick();
+    } else if (path) {
+      navigate(path);
+    }
+  };
+
+  const iconStyle = {
+    color: theme.palette.text.primary,
+    "&:hover": {
+      color: { smallDevice } ? "primary.main" : "inherit",
+    },
+  };
+
+  const tabStyle = {
+    fontFamily: "interSemiBold",
+    fontSize: "1.125rem",
+    marginLeft: alwaysShowIcon ? 0.75 : 0,
+    "&:hover": {
+      color: "primary.main",
+    },
+  };
+
+  return (
+    <Link to={path}>
+      {smallDevice ? (
+        <IconButton tabIndex="-1" sx={iconStyle} onClick={internalOnClick}>
+          {icon}
+        </IconButton>
+      ) : (
+        <Box
+          sx={{
+            display: "flex",
+            alignItems: "center",
+          }}
+        >
+          {alwaysShowIcon && icon}
+          <Typography onClick={internalOnClick} sx={tabStyle}>
+            {text}
+          </Typography>
+        </Box>
+      )}
+    </Link>
+  );
+}

--- a/src/Components/HeaderTab.js
+++ b/src/Components/HeaderTab.js
@@ -71,16 +71,18 @@ export default function HeaderTab({
         </IconButton>
       ) : (
         <Box
+          onClick={internalOnClick}
           sx={{
             display: "flex",
             alignItems: "center",
             position: "relative",
+            "&:hover": {
+              color: "primary.main",
+            },
           }}
         >
           {alwaysShowIcon && icon}
-          <Typography onClick={internalOnClick} sx={tabStyle}>
-            {text}
-          </Typography>
+          <Typography sx={tabStyle}>{text}</Typography>
         </Box>
       )}
     </Link>

--- a/src/Components/HeaderTab.js
+++ b/src/Components/HeaderTab.js
@@ -5,7 +5,7 @@ import {
   useMediaQuery,
   useTheme,
 } from "@mui/material";
-import { Link, useNavigate } from "react-router-dom";
+import { Link, useLocation, useNavigate } from "react-router-dom";
 
 export default function HeaderTab({
   icon,
@@ -14,10 +14,13 @@ export default function HeaderTab({
   onClick,
   alwaysShowIcon,
 }) {
+  const location = useLocation();
   const navigate = useNavigate();
   const theme = useTheme();
 
   const smallDevice = useMediaQuery(theme.breakpoints.down("sm"));
+
+  const isPathActive = location.pathname === path;
 
   const internalOnClick = (e) => {
     if (onClick) {
@@ -41,6 +44,19 @@ export default function HeaderTab({
     "&:hover": {
       color: "primary.main",
     },
+    "&:after": {
+      display: isPathActive ? "block" : "none",
+      position: "absolute",
+      content: "''",
+      height: "4px",
+      borderRadius: "2px",
+      bottom: "-4px",
+      margin: "0 auto",
+      left: 0,
+      right: 0,
+      width: "100%",
+      background: theme.palette.primary.main,
+    },
   };
 
   return (
@@ -54,6 +70,7 @@ export default function HeaderTab({
           sx={{
             display: "flex",
             alignItems: "center",
+            position: "relative",
           }}
         >
           {alwaysShowIcon && icon}


### PR DESCRIPTION
I was super inspired by these tabs!  This pr just tweaks the tabs slightly for various styling purposes:
- Icons on mobile are now text.primary
- Tabs are a bit more centers in large widths.
- Refactors tab code into a HeaderTab component to clean up Header a bit and enable 'active tab' styling more easily.
- Added an underline to the active tab.  Still messing with this one, not 100% sure how the active tab could be differentiated, but this is one idea.