### PR TITLE
Fix DetailedView like button wrapping, fix accidental renaming

### DIFF
--- a/src/Components/DetailedView.js
+++ b/src/Components/DetailedView.js
@@ -21,7 +21,7 @@ import ScoreBars from "./ScoreBars";
 import SimilarContent from "./SimilarContent";
 import UrlButtons from "./UrlButtons";
 
-export default function AnimePage() {
+export default function DetailedView() {
   const navigate = useNavigate();
   const location = useLocation();
   const theme = useTheme();

--- a/src/Components/DetailedView.js
+++ b/src/Components/DetailedView.js
@@ -166,7 +166,7 @@ export default function DetailedView() {
             <Grid
               item
               xs={12}
-              md={9}
+              md={8.5}
               sx={{ display: { xs: "none", md: "block" } }}
             >
               <Typography variant="h2" sx={headStyle}>
@@ -177,7 +177,7 @@ export default function DetailedView() {
             <Grid
               item
               xs={12}
-              md={3}
+              md={3.5}
               sx={{
                 textAlign: { xs: "center", md: "end" },
                 marginTop: { xs: 0.5, md: 0 },


### PR DESCRIPTION
Fixes an accidental renaming of the DetailedView component function, and fixes a situation where the LikeButtons can wrap when the window width is in the range of 900px to ~1000px.