### PR TITLE
Fix bug where loading indicator shows too much

### DIFF
--- a/src/Components/DetailedView.js
+++ b/src/Components/DetailedView.js
@@ -198,7 +198,7 @@ export default function DetailedView() {
               }}
             >
               <Grid container columnSpacing={3} sx={{ position: "relative" }}>
-                {analysisFetching && analysis?.anime_id !== anime.id && (
+                {analysisFetching && analysis?.animeId !== anime.id && (
                   <Box
                     sx={{
                       position: "absolute",


### PR DESCRIPTION
The loading indicator on the "Data From Edward" section of DetailedView should only show if it is loading data for a new anime.  Updating analysis of an anime shouldn't show the indicator.  I renamed a field in the /analyze API response which broke this.  I thought it wasn't being used and forgot that I used it.  My bad!