### PR TITLE
Set up system of avatar 'names' to store in LocalUser

### DIFF
--- a/src/Components/AvatarIcon.js
+++ b/src/Components/AvatarIcon.js
@@ -1,9 +1,10 @@
 import { Avatar, IconButton, useTheme } from "@mui/material";
-import { useContext } from "react";
+import { useContext, useMemo } from "react";
 import { useAuthState } from "react-firebase-hooks/auth";
 import { LocalUserContext } from "./LocalUserContext";
 import { auth } from "./Firebase";
 import { SaveToFirestore } from "./Firestore";
+import { getAvatarSrc } from "./Avatars";
 
 export default function AvatarIcon({ avatar, index }) {
   const [localUser, setLocalUser] = useContext(LocalUserContext);
@@ -16,6 +17,8 @@ export default function AvatarIcon({ avatar, index }) {
     setLocalUser(newLocalUser);
     SaveToFirestore(user, newLocalUser);
   }
+
+  const avatarSrc = useMemo(() => getAvatarSrc(avatar), [avatar]);
 
   return (
     <IconButton
@@ -34,7 +37,7 @@ export default function AvatarIcon({ avatar, index }) {
         },
       }}
     >
-      <Avatar sx={{ width: "80px", height: "80px" }} src={avatar}></Avatar>
+      <Avatar sx={{ width: "80px", height: "80px" }} src={avatarSrc}></Avatar>
     </IconButton>
   );
 }

--- a/src/Components/Avatars.js
+++ b/src/Components/Avatars.js
@@ -1,0 +1,173 @@
+import spike from "../Styles/images/userAvatars/spike.jpg";
+import faye from "../Styles/images/userAvatars/faye.jpg";
+import jet from "../Styles/images/userAvatars/jetblack.jpg";
+import julia from "../Styles/images/userAvatars/julia.jpg";
+import ein from "../Styles/images/userAvatars/ein.jpg";
+import vicious from "../Styles/images/userAvatars/vicious.jpg";
+
+import naruto from "../Styles/images/userAvatars/naruto.160.jpg";
+import kakashi from "../Styles/images/userAvatars/kakashi.160.jpg";
+import mightguy from "../Styles/images/userAvatars/mightguy.jpg";
+import sasuke from "../Styles/images/userAvatars/sasuke.jpg";
+import itachi from "../Styles/images/userAvatars/itachi.jpg";
+import sakura from "../Styles/images/userAvatars/sakura.jpg";
+import choji from "../Styles/images/userAvatars/choji.jpg";
+import rocklee from "../Styles/images/userAvatars/rocklee.jpg";
+import jiriaya from "../Styles/images/userAvatars/jiriaya.jpg";
+import ino from "../Styles/images/userAvatars/ino.jpg";
+
+import luffy from "../Styles/images/userAvatars/luffy.jpg";
+import franky from "../Styles/images/userAvatars/franky.jpg";
+import sanji from "../Styles/images/userAvatars/sanji.jpg";
+import usopp from "../Styles/images/userAvatars/usopp.jpg";
+import tonytony from "../Styles/images/userAvatars/tonytony.jpg";
+import charlotte from "../Styles/images/userAvatars/charlotte.jpg";
+
+import anya from "../Styles/images/userAvatars/anya.jpg";
+import loid from "../Styles/images/userAvatars/loid.jpg";
+import yor from "../Styles/images/userAvatars/yor.jpg";
+import yuri from "../Styles/images/userAvatars/yuri.jpg";
+import bond from "../Styles/images/userAvatars/bond.jpg";
+
+import gon from "../Styles/images/userAvatars/gon.jpg";
+import killua from "../Styles/images/userAvatars/killua.jpg";
+import kurapika from "../Styles/images/userAvatars/kurapika.jpg";
+import leorio from "../Styles/images/userAvatars/leorio.jpg";
+import hisoka from "../Styles/images/userAvatars/hisoka.jpg";
+
+import sailor1 from "../Styles/images/userAvatars/sailor1.jpg";
+import sailor2 from "../Styles/images/userAvatars/sailor2.jpg";
+import sailor3 from "../Styles/images/userAvatars/sailor3.jpg";
+import sailor4 from "../Styles/images/userAvatars/sailor4.jpg";
+import sailor5 from "../Styles/images/userAvatars/sailor5.jpg";
+import sailormoon from "../Styles/images/userAvatars/sailormoon.160.jpg";
+
+import david from "../Styles/images/userAvatars/david_martinez.160.jpg";
+import davidAngry from "../Styles/images/userAvatars/david.jpg";
+import lucy from "../Styles/images/userAvatars/LUCY.jpg";
+import mainegf from "../Styles/images/userAvatars/mainegf.jpg";
+import maine from "../Styles/images/userAvatars/maine.jpg";
+import kiwi from "../Styles/images/userAvatars/kiwi.jpg";
+import rebecca from "../Styles/images/userAvatars/rebecca.jpg";
+import pilar from "../Styles/images/userAvatars/pilar.jpg";
+import lucySmoking from "../Styles/images/userAvatars/lucySmoking.jpg";
+
+import ryuko from "../Styles/images/userAvatars/ryuko.160.jpg";
+import satsuki from "../Styles/images/userAvatars/satsuki.jpg";
+import mako from "../Styles/images/userAvatars/mako.jpg";
+
+// The mapping that will be built of name: url.
+const imageMapping = {};
+
+// Registers a list of {name, url} image definitions in the mapping.
+function registerImages(images) {
+  images.forEach((image) => (imageMapping[image.name] = image.url));
+}
+
+const cowboyBebop = [
+  { name: "spike", url: spike },
+  { name: "faye", url: faye },
+  { name: "jet", url: jet },
+  { name: "julia", url: julia },
+  { name: "ein", url: ein },
+  { name: "vicious", url: vicious },
+];
+
+const narutoAvatars = [
+  { name: "naruto", url: naruto },
+  { name: "sakura", url: sakura },
+  { name: "sasuke", url: sasuke },
+  { name: "itachi", url: itachi },
+  { name: "kakashi", url: kakashi },
+  { name: "jiriaya", url: jiriaya },
+  { name: "mightguy", url: mightguy },
+  { name: "rocklee", url: rocklee },
+  { name: "choji", url: choji },
+  { name: "ino", url: ino },
+];
+
+const onePiece = [
+  { name: "luffy", url: luffy },
+  { name: "franky", url: franky },
+  { name: "sanji", url: sanji },
+  { name: "usopp", url: usopp },
+  { name: "tonytony", url: tonytony },
+  { name: "charlotte", url: charlotte },
+];
+
+const spyxfamily = [
+  { name: "anya", url: anya },
+  { name: "loid", url: loid },
+  { name: "yor", url: yor },
+  { name: "yuri", url: yuri },
+  { name: "bond", url: bond },
+];
+
+const hunterxhunter = [
+  { name: "gon", url: gon },
+  { name: "killua", url: killua },
+  { name: "kurapika", url: kurapika },
+  { name: "leorio", url: leorio },
+  { name: "hisoka", url: hisoka },
+];
+
+const sailorMoonAvatars = [
+  { name: "sailor1", url: sailor1 },
+  { name: "sailor2", url: sailor2 },
+  { name: "sailor3", url: sailor3 },
+  { name: "sailor4", url: sailor4 },
+  { name: "sailor5", url: sailor5 },
+  { name: "sailormoon", url: sailormoon },
+];
+
+const cyberpunk = [
+  { name: "davidAngry", url: davidAngry },
+  { name: "lucySmoking", url: lucySmoking },
+  { name: "rebecca", url: rebecca },
+  { name: "mainegf", url: mainegf },
+  { name: "pilar", url: pilar },
+  { name: "maine", url: maine },
+  { name: "kiwi", url: kiwi },
+  { name: "lucy", url: lucy },
+  { name: "david", url: david },
+];
+
+const killLaKill = [
+  { name: "ryuko", url: ryuko },
+  { name: "satsuki", url: satsuki },
+  { name: "mako", url: mako },
+];
+
+registerImages(cowboyBebop);
+registerImages(narutoAvatars);
+registerImages(onePiece);
+registerImages(spyxfamily);
+registerImages(hunterxhunter);
+registerImages(sailorMoonAvatars);
+registerImages(cyberpunk);
+registerImages(killLaKill);
+
+const nameMapper = (item) => item.name;
+
+/**
+ * Lists of avatar names, grouped by show.
+ */
+export const avatars = {
+  cowboyBebop: cowboyBebop.map(nameMapper),
+  naruto: narutoAvatars.map(nameMapper),
+  onePiece: onePiece.map(nameMapper),
+  spyXFamily: spyxfamily.map(nameMapper),
+  hunterXHunter: hunterxhunter.map(nameMapper),
+  sailorMoon: sailorMoonAvatars.map(nameMapper),
+  cyberpunk: cyberpunk.map(nameMapper),
+  killLaKill: killLaKill.map(nameMapper),
+};
+
+/**
+ * Converts avatar names to urls for display.
+ * @param {string} avatar The name of the avatar to convert.
+ * @returns The url for the avatar, suitable for passing to `src` attributes.
+ */
+export function getAvatarSrc(avatar) {
+  return imageMapping[avatar];
+}

--- a/src/Components/ChooseAvatar.js
+++ b/src/Components/ChooseAvatar.js
@@ -2,64 +2,7 @@ import { Typography, Button, Grid } from "@mui/material";
 import { useState } from "react";
 import { CaretDown } from "phosphor-react";
 
-import david from "../Styles/images/userAvatars/david_martinez.160.jpg";
-import davidAngry from "../Styles/images/userAvatars/david.jpg";
-import lucy from "../Styles/images/userAvatars/LUCY.jpg";
-import mainegf from "../Styles/images/userAvatars/mainegf.jpg";
-import maine from "../Styles/images/userAvatars/maine.jpg";
-import kiwi from "../Styles/images/userAvatars/kiwi.jpg";
-import rebecca from "../Styles/images/userAvatars/rebecca.jpg";
-import pilar from "../Styles/images/userAvatars/pilar.jpg";
-import lucySmoking from "../Styles/images/userAvatars/lucySmoking.jpg";
-
-import ryuko from "../Styles/images/userAvatars/ryuko.160.jpg";
-import mako from "../Styles/images/userAvatars/mako.jpg";
-import satsuki from "../Styles/images/userAvatars/satsuki.jpg";
-
-import naruto from "../Styles/images/userAvatars/naruto.160.jpg";
-import kakashi from "../Styles/images/userAvatars/kakashi.160.jpg";
-import mightguy from "../Styles/images/userAvatars/mightguy.jpg";
-import sasuke from "../Styles/images/userAvatars/sasuke.jpg";
-import itachi from "../Styles/images/userAvatars/itachi.jpg";
-import sakura from "../Styles/images/userAvatars/sakura.jpg";
-import choji from "../Styles/images/userAvatars/choji.jpg";
-import rocklee from "../Styles/images/userAvatars/rocklee.jpg";
-import jiriaya from "../Styles/images/userAvatars/jiriaya.jpg";
-import ino from "../Styles/images/userAvatars/ino.jpg";
-
-import luffy from "../Styles/images/userAvatars/luffy.jpg";
-import franky from "../Styles/images/userAvatars/franky.jpg";
-import sanji from "../Styles/images/userAvatars/sanji.jpg";
-import usopp from "../Styles/images/userAvatars/usopp.jpg";
-import tonytony from "../Styles/images/userAvatars/tonytony.jpg";
-import charlotte from "../Styles/images/userAvatars/charlotte.jpg";
-
-import spike from "../Styles/images/userAvatars/spike.jpg";
-import faye from "../Styles/images/userAvatars/faye.jpg";
-import jet from "../Styles/images/userAvatars/jetblack.jpg";
-import julia from "../Styles/images/userAvatars/julia.jpg";
-import ein from "../Styles/images/userAvatars/ein.jpg";
-import vicious from "../Styles/images/userAvatars/vicious.jpg";
-
-import yuri from "../Styles/images/userAvatars/yuri.jpg";
-import yor from "../Styles/images/userAvatars/yor.jpg";
-import loid from "../Styles/images/userAvatars/loid.jpg";
-import anya from "../Styles/images/userAvatars/anya.jpg";
-import bond from "../Styles/images/userAvatars/bond.jpg";
-
-import gon from "../Styles/images/userAvatars/gon.jpg";
-import hisoka from "../Styles/images/userAvatars/hisoka.jpg";
-import illumi from "../Styles/images/userAvatars/illumi.jpg";
-import killua from "../Styles/images/userAvatars/killua.jpg";
-import kurapika from "../Styles/images/userAvatars/kurapika.jpg";
-import leorio from "../Styles/images/userAvatars/leorio.jpg";
-
-import sailor1 from "../Styles/images/userAvatars/sailor1.jpg";
-import sailor2 from "../Styles/images/userAvatars/sailor2.jpg";
-import sailor3 from "../Styles/images/userAvatars/sailor3.jpg";
-import sailor4 from "../Styles/images/userAvatars/sailor4.jpg";
-import sailor5 from "../Styles/images/userAvatars/sailor5.jpg";
-import sailormoon from "../Styles/images/userAvatars/sailormoon.160.jpg";
+import { avatars } from "./Avatars";
 
 import AvatarShelf from "./AvatarShelf";
 
@@ -89,24 +32,24 @@ export default function ChooseAvatar() {
       >
         Cowboy Bebop:
       </Typography>
-      <AvatarShelf items={cowboyBebop} />
+      <AvatarShelf items={avatars.cowboyBebop} />
 
       <Typography sx={styling}>Naruto:</Typography>
-      <AvatarShelf items={narutoOriginal} />
+      <AvatarShelf items={avatars.naruto} />
 
       <Typography sx={styling}>One Piece:</Typography>
-      <AvatarShelf items={onePiece} />
+      <AvatarShelf items={avatars.onePiece} />
 
       {seeMore > 0 ? (
         <>
           <Typography sx={styling}>Spy x Family:</Typography>
-          <AvatarShelf items={spyxfamily} />
+          <AvatarShelf items={avatars.spyXFamily} />
 
           <Typography sx={styling}>Hunter x Hunter:</Typography>
-          <AvatarShelf items={hunterxhunter} />
+          <AvatarShelf items={avatars.hunterXHunter} />
 
           <Typography sx={styling}>Sailor Moon:</Typography>
-          <AvatarShelf items={sailormoonavatars} />
+          <AvatarShelf items={avatars.sailorMoon} />
         </>
       ) : (
         ""
@@ -115,10 +58,10 @@ export default function ChooseAvatar() {
       {seeMore > 1 ? (
         <>
           <Typography sx={styling}>Cyberpunk: Edgerunners:</Typography>
-          <AvatarShelf items={cyberpunk} />
+          <AvatarShelf items={avatars.cyberpunk} />
 
           <Typography sx={styling}>Kill La Kill:</Typography>
-          <AvatarShelf items={killLaKill} />
+          <AvatarShelf items={avatars.killLaKill} />
         </>
       ) : (
         ""
@@ -143,48 +86,3 @@ export default function ChooseAvatar() {
     </div>
   );
 }
-
-const killLaKill = [ryuko, satsuki, mako];
-
-const narutoOriginal = [
-  naruto,
-  sakura,
-  sasuke,
-  itachi,
-  kakashi,
-  jiriaya,
-  mightguy,
-
-  rocklee,
-  choji,
-  ino,
-];
-
-const onePiece = [luffy, franky, sanji, usopp, tonytony, charlotte];
-
-const cowboyBebop = [spike, faye, jet, julia, ein, vicious];
-
-const spyxfamily = [anya, loid, yor, yuri, bond];
-
-const hunterxhunter = [gon, killua, kurapika, leorio, illumi, hisoka];
-
-const cyberpunk = [
-  davidAngry,
-  lucySmoking,
-  rebecca,
-  mainegf,
-  pilar,
-  maine,
-  kiwi,
-  lucy,
-  david,
-];
-
-const sailormoonavatars = [
-  sailor1,
-  sailor2,
-  sailor3,
-  sailor4,
-  sailor5,
-  sailormoon,
-];

--- a/src/Components/DropMenu.js
+++ b/src/Components/DropMenu.js
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useRef, useState } from "react";
+import React, { useContext, useEffect, useMemo, useRef, useState } from "react";
 import Button from "@mui/material/Button";
 import ClickAwayListener from "@mui/material/ClickAwayListener";
 import Grow from "@mui/material/Grow";
@@ -30,6 +30,7 @@ import {
 } from "@mui/material";
 import { useTheme } from "@mui/material/styles";
 import AppSettingsContext from "./AppSettingsContext";
+import { getAvatarSrc } from "./Avatars";
 
 export default function DropMenu() {
   const navigate = useNavigate();
@@ -43,6 +44,11 @@ export default function DropMenu() {
 
   const [open, setOpen] = useState(false);
   const anchorRef = useRef(null);
+
+  const avatarSrc = useMemo(
+    () => getAvatarSrc(localUser?.avatar),
+    [localUser?.avatar]
+  );
 
   const handleToggle = () => {
     setOpen((prevOpen) => !prevOpen);
@@ -114,7 +120,7 @@ export default function DropMenu() {
         ref={anchorRef}
         id="composition-button"
         alt={user?.displayName}
-        src={localUser?.avatar}
+        src={avatarSrc}
         aria-controls={open ? "composition-menu" : undefined}
         aria-expanded={open ? "true" : undefined}
         aria-haspopup="true"

--- a/src/Components/ProfileUserBanner.js
+++ b/src/Components/ProfileUserBanner.js
@@ -8,8 +8,9 @@ import {
 } from "@mui/material";
 import { Box } from "@mui/system";
 import { Camera, X } from "phosphor-react";
-import { useContext, useState } from "react";
+import { useContext, useMemo, useState } from "react";
 import { useAuthState } from "react-firebase-hooks/auth";
+import { getAvatarSrc } from "./Avatars";
 import ChooseAvatar from "./ChooseAvatar";
 import { auth } from "./Firebase";
 import { LocalUserContext } from "./LocalUserContext";
@@ -22,6 +23,12 @@ export default function ProfileUserBanner() {
   function handleAvatarToggle() {
     setEditAvatar((editAvatar) => !editAvatar);
   }
+
+  const avatarSrc = useMemo(
+    () => getAvatarSrc(localUser?.avatar),
+    [localUser?.avatar]
+  );
+
   return (
     <>
       <div style={{ display: "flex", alignItems: "center" }}>
@@ -33,7 +40,7 @@ export default function ProfileUserBanner() {
             <Avatar
               sx={{ width: "80px", height: "80px" }}
               alt={user?.displayName}
-              src={localUser?.avatar}
+              src={avatarSrc}
             />
             <Box
               sx={{
@@ -90,11 +97,11 @@ export default function ProfileUserBanner() {
           >
             <IconButton
               color="inherit"
-              size="small"
+              size="large"
               sx={{ mr: 1, position: "absolute", top: "-5px" }}
               onClick={handleAvatarToggle}
             >
-              <X size={40} color="grey" />
+              <X color="grey" />
             </IconButton>
           </div>
           <ChooseAvatar />


### PR DESCRIPTION
Webpack has been configured to take all image names and append a hash to the end of them based on the image file contents (https://drive.google.com/file/d/1BLYsi8Xc9tbgNBaIjM7IIMJZDIZG0CCV/view?usp=sharing).  For example, `sakura.jpg` became `sakura.e3daff7eca305410d3c4.jpg`.  This hash will be stable, but will change if the image is changed, which busts browser caches since the browser will not have cached the new filename, so browsers will immediately download the new version.

Unfortunately, this means that if we store the filename in the `avatar` field of LocalUser, then we update the image for one of our avatars, their avatar will break.

I've solved for this by creating a simple 'name' string for each avatar, then creating a map of name -> url in a new file called `Avatar.js`.  That file exports a function called `getAvatarSrc(name)` which will convert each simple name into the full image path needed to display it in a given build.  This means you won't be able to do `src={localUser.avatar}` anymore, but instead, `src={getAvatarSrc(localUser.avatar)}`.

This is a *breaking change* that will make all existing users' avatars break until they update them.  But after they do, the avatars should never break again.  Unless we do something dumb like change remove an avatar or change its name.