### PR TITLE
Adds 'see more' button for reviews

### DIFF
--- a/src/Components/DetailedView.js
+++ b/src/Components/DetailedView.js
@@ -353,7 +353,7 @@ export default function DetailedView() {
             style={{ ...subheadStyle, display: "flex", alignItems: "baseline" }}
           >
             Reviews{" "}
-            {animeReviews.length > 2 ? (
+            {animeReviews?.length > 2 ? (
               <Typography
                 sx={{
                   fontFamily: "interMedium",
@@ -363,7 +363,7 @@ export default function DetailedView() {
                   ml: 1,
                 }}
               >
-                ({animeReviews.length} total)
+                ({animeReviews?.length} total)
               </Typography>
             ) : (
               ""

--- a/src/Components/DetailedView.js
+++ b/src/Components/DetailedView.js
@@ -10,7 +10,7 @@ import {
   Typography,
   useTheme,
 } from "@mui/material";
-import { Minus, Play, Plus } from "phosphor-react";
+import { CaretDown, Minus, Play, Plus } from "phosphor-react";
 import { useContext, useEffect, useState } from "react";
 import { useAuthState } from "react-firebase-hooks/auth";
 import { useLocation, useNavigate, useParams } from "react-router-dom";
@@ -49,6 +49,10 @@ export default function DetailedView() {
   const [animeReviews, setAnimeReviews] = useState(null);
   const [showReviewForm, setShowReviewForm] = useState(false);
 
+  const [seeMore, setSeeMore] = useState(0);
+  const shownItems = howManyItems(seeMore);
+  const showSeeMoreButton = shownItems?.length !== animeReviews?.length;
+
   const [analysis, analysisLoading, analysisError, analysisFetching] =
     useAnimeAnalysis(animeId);
 
@@ -61,6 +65,14 @@ export default function DetailedView() {
   useEffect(() => {
     PopulateReviewsFromFirestore(anime, setAnimeReviews);
   }, [location.pathname, anime]);
+
+  function howManyItems(seeMore) {
+    console.log(seeMore);
+
+    console.log(animeReviews);
+    if (seeMore === 0) return animeReviews?.slice(0, 3);
+    if (seeMore > 0) return animeReviews?.slice(0, 5 * seeMore);
+  }
 
   // TODO Use a shared loading display component.
   if (loading || animeLoading || analysisLoading) {
@@ -383,7 +395,7 @@ export default function DetailedView() {
           ) : (
             ""
           )}
-          {animeReviews?.map((item, index) => {
+          {shownItems?.map((item, index) => {
             return (
               <Review
                 key={item.uid}
@@ -396,6 +408,18 @@ export default function DetailedView() {
               />
             );
           })}
+          {showSeeMoreButton && (
+            <Grid item sx={{ display: "flex", justifyContent: "center" }}>
+              <Button
+                color="inherit"
+                variant="outlined"
+                onClick={() => setSeeMore(seeMore + 1)}
+                endIcon={<CaretDown />}
+              >
+                See more
+              </Button>
+            </Grid>
+          )}
         </Grid>
       </Grid>
       <div className="gap" />

--- a/src/Components/DetailedView.js
+++ b/src/Components/DetailedView.js
@@ -350,12 +350,27 @@ export default function DetailedView() {
           <Typography
             component="div"
             variant="h5"
-            style={{ ...subheadStyle, display: "flex", alignItems: "center" }}
+            style={{ ...subheadStyle, display: "flex", alignItems: "baseline" }}
           >
             Reviews{" "}
+            {animeReviews.length > 2 ? (
+              <Typography
+                sx={{
+                  fontFamily: "interMedium",
+                  fontSize: "1.0rem",
+                  marginL: "10px",
+                  color: "grey",
+                  ml: 1,
+                }}
+              >
+                ({animeReviews.length} total)
+              </Typography>
+            ) : (
+              ""
+            )}
             {!showReviewForm ? (
               <Tooltip title="Add a review">
-                <div style={{ marginLeft: "15px" }}>
+                <Box sx={{ ml: 1 }}>
                   <IconButton
                     variant="contained"
                     disabled={user.isAnonymous ? true : false}
@@ -366,7 +381,7 @@ export default function DetailedView() {
                   >
                     <Plus />
                   </IconButton>
-                </div>
+                </Box>
               </Tooltip>
             ) : (
               <Tooltip title="Close review">
@@ -385,6 +400,7 @@ export default function DetailedView() {
               </Tooltip>
             )}
           </Typography>
+
           {showReviewForm ? (
             <ReviewForm
               anime={anime}

--- a/src/Components/DetailedView.js
+++ b/src/Components/DetailedView.js
@@ -49,7 +49,7 @@ export default function DetailedView() {
   const [animeReviews, setAnimeReviews] = useState(null);
   const [showReviewForm, setShowReviewForm] = useState(false);
 
-  const [seeMore, setSeeMore] = useState(0);
+  const [seeMore, setSeeMore] = useState(1);
   const shownItems = howManyItems(seeMore);
   const showSeeMoreButton = shownItems?.length !== animeReviews?.length;
 
@@ -70,8 +70,8 @@ export default function DetailedView() {
     console.log(seeMore);
 
     console.log(animeReviews);
-    if (seeMore === 0) return animeReviews?.slice(0, 3);
-    if (seeMore > 0) return animeReviews?.slice(0, 5 * seeMore);
+    if (seeMore === 1) return animeReviews?.slice(0, 4);
+    if (seeMore > 1) return animeReviews?.slice(0, 4 * seeMore);
   }
 
   // TODO Use a shared loading display component.


### PR DESCRIPTION
- Detailed View page now displays (4) reviews on page load, and another (4) with each 'see more' click.
- I would like to add the ability to filter reviews in an upcoming commit.