### PR TITLE
Feature/other profiles

### DIFF
--- a/src/Components/APICalls.js
+++ b/src/Components/APICalls.js
@@ -99,13 +99,8 @@ export function useGetTitles(url) {
   );
 }
 
-export function useFetchProfile(userID) {
-  return useGetProfile(
-    `https://api-jet-lfoguxrv7q-uw.a.run.app/profile/${userID}`
-  );
-}
-
-export function useGetProfile(url) {
+export function useProfile(userID) {
+  const url = `https://api-jet-lfoguxrv7q-uw.a.run.app/profile/${userID}`;
   return useQuery(
     [url],
     async () => {

--- a/src/Components/DetailedView.js
+++ b/src/Components/DetailedView.js
@@ -67,9 +67,6 @@ export default function DetailedView() {
   }, [location.pathname, anime]);
 
   function howManyItems(seeMore) {
-    console.log(seeMore);
-
-    console.log(animeReviews);
     if (seeMore === 1) return animeReviews?.slice(0, 4);
     if (seeMore > 1) return animeReviews?.slice(0, 4 * seeMore);
   }

--- a/src/Components/DropMenu.js
+++ b/src/Components/DropMenu.js
@@ -83,7 +83,7 @@ export default function DropMenu() {
 
   function sendToProfile(e) {
     handleClose(e);
-    navigate("/profile");
+    navigate(`/profile/${user.uid}`);
   }
 
   function sendToLogin(e) {

--- a/src/Components/Firestore.js
+++ b/src/Components/Firestore.js
@@ -6,7 +6,6 @@ import {
   collection,
   deleteDoc,
 } from "firebase/firestore";
-import { useFetchProfile } from "./APICalls";
 import { db } from "./Firebase";
 
 // Handle "users" collection on firestore

--- a/src/Components/Header.js
+++ b/src/Components/Header.js
@@ -10,8 +10,11 @@ import DropMenu from "./DropMenu";
 import { useTheme } from "@mui/material/styles";
 import EdwardMLLogo from "./EdwardMLLogo";
 import HeaderTab from "./HeaderTab";
+import { useAuthState } from "react-firebase-hooks/auth";
+import { auth } from "./Firebase";
 
 function Header() {
+  const [user] = useAuthState(auth);
   const theme = useTheme();
 
   const [showSearch, setShowSearch] = useState(false);
@@ -57,7 +60,11 @@ function Header() {
                 }}
               >
                 <HeaderTab text="Home" icon={<House />} path="/home" />
-                <HeaderTab text="Profile" icon={<User />} path="/profile" />
+                <HeaderTab
+                  text="Profile"
+                  icon={<User />}
+                  path={`/profile/${user.uid}`}
+                />
                 <HeaderTab
                   text="Search"
                   icon={<MagnifyingGlass />}

--- a/src/Components/Profile.js
+++ b/src/Components/Profile.js
@@ -1,18 +1,20 @@
 import "../Styles/Profile.css";
 
 import { Container, Grid, useMediaQuery, useTheme } from "@mui/material";
-import { matchPath, useLocation } from "react-router-dom";
+import { matchPath, useLocation, useParams } from "react-router-dom";
 import ProfileListPage from "./ProfileListPage";
 import ProfileMainPage from "./ProfileMainPage";
 import ProfileSidebar from "./ProfileSidebar";
 import { useContext, useEffect } from "react";
-import { LocalUserContext } from "./LocalUserContext";
 import { useAuthState } from "react-firebase-hooks/auth";
 import { PopulateFromFirestore } from "./Firestore";
 import { auth } from "./Firebase";
+import ProfilePageContextProvider from "./ProfilePageContextProvider";
+import { LocalUserContext } from "./LocalUserContext";
 
 export default function Profile() {
   const location = useLocation();
+  const params = useParams();
   const theme = useTheme();
 
   const [localUser, setLocalUser] = useContext(LocalUserContext);
@@ -25,7 +27,7 @@ export default function Profile() {
   }, [user, loading]);
 
   const isListPage = matchPath(
-    { path: "/profile/list/:listId" },
+    { path: "/profile/:userId/list/:listId" },
     location.pathname
   );
 
@@ -34,15 +36,17 @@ export default function Profile() {
   const compactSidebar = isListPage && !md;
 
   return (
-    <Container maxWidth="lg">
-      <Grid container sx={{ paddingTop: { xs: "25px", md: "50px" } }}>
-        <Grid item xs={12} md={3} sx={{ marginBottom: "24px" }}>
-          <ProfileSidebar hideDetails={compactSidebar} />
+    <ProfilePageContextProvider userId={params.userId}>
+      <Container maxWidth="lg">
+        <Grid container sx={{ paddingTop: { xs: "25px", md: "50px" } }}>
+          <Grid item xs={12} md={3} sx={{ marginBottom: "24px" }}>
+            <ProfileSidebar hideDetails={compactSidebar} />
+          </Grid>
+          <Grid item xs={12} md={9}>
+            {isListPage ? <ProfileListPage /> : <ProfileMainPage />}
+          </Grid>
         </Grid>
-        <Grid item xs={12} md={9}>
-          {isListPage ? <ProfileListPage /> : <ProfileMainPage />}
-        </Grid>
-      </Grid>
-    </Container>
+      </Container>
+    </ProfilePageContextProvider>
   );
 }

--- a/src/Components/ProfileListItem.js
+++ b/src/Components/ProfileListItem.js
@@ -10,7 +10,7 @@ import {
 import { X } from "phosphor-react";
 import { useNavigate } from "react-router-dom";
 
-export default function ProfileListItem({ item, onRemove }) {
+export default function ProfileListItem({ item, canEdit, onRemove }) {
   const navigate = useNavigate();
 
   return (
@@ -18,18 +18,20 @@ export default function ProfileListItem({ item, onRemove }) {
       disablePadding={true}
       disableGutters={true}
       secondaryAction={
-        <Tooltip title="Remove item">
-          <IconButton
-            edge="end"
-            aria-label="delete"
-            disabled={!onRemove}
-            onClick={() => {
-              onRemove();
-            }}
-          >
-            <X size={20} />
-          </IconButton>
-        </Tooltip>
+        canEdit && (
+          <Tooltip title="Remove item">
+            <IconButton
+              edge="end"
+              aria-label="delete"
+              disabled={!onRemove}
+              onClick={() => {
+                onRemove();
+              }}
+            >
+              <X size={20} />
+            </IconButton>
+          </Tooltip>
+        )
       }
     >
       <ListItemButton

--- a/src/Components/ProfileMainPage.js
+++ b/src/Components/ProfileMainPage.js
@@ -3,10 +3,10 @@ import NoResultsImage from "./NoResultsImage";
 import WatchlistTile from "./WatchlistTile";
 import { slugifyListName } from "../Util/ListUtil";
 import { useContext } from "react";
-import { LocalUserContext } from "./LocalUserContext";
+import ProfilePageContext from "./ProfilePageContext";
 
 export default function ProfileMainPage() {
-  const [localUser, setLocalUser] = useContext(LocalUserContext);
+  const { profile, isLoading } = useContext(ProfilePageContext);
 
   const subheadStyle = {
     fontFamily: "interBlack",
@@ -15,6 +15,16 @@ export default function ProfileMainPage() {
     marginTop: "26px",
     marginBottom: "12px",
   };
+
+  const bodyStyle = {
+    fontFamily: "interMedium",
+    fontSize: "16px",
+  };
+
+  // TODO Add a 'ghost' page for loading.
+  if (isLoading) {
+    return <></>;
+  }
 
   return (
     <Grid
@@ -28,13 +38,19 @@ export default function ProfileMainPage() {
         </Typography>
       </Grid>
       <Grid item xs={12} md={6}>
-        <WatchlistTile listId="likes" name="Likes" items={localUser.likes} />
+        <WatchlistTile
+          userId={profile?.uid}
+          listId="likes"
+          name="Likes"
+          items={profile?.likes}
+        />
       </Grid>
       <Grid item xs={12} md={6}>
         <WatchlistTile
+          userId={profile?.uid}
           listId="dislikes"
           name="Dislikes"
-          items={localUser.dislikes}
+          items={profile?.dislikes}
         />
       </Grid>
       <Grid item xs={12}>
@@ -42,16 +58,17 @@ export default function ProfileMainPage() {
           Watchlists
         </Typography>
       </Grid>
-      {localUser?.lists.map((list, index) => (
+      {profile?.lists.map((list, index) => (
         <Grid item xs={12} md={6} key={index}>
           <WatchlistTile
+            userId={profile?.uid}
             listId={slugifyListName(list.name)}
             name={list.name}
             items={list.anime}
           />
         </Grid>
       ))}
-      {!localUser?.lists?.length && (
+      {!profile?.lists?.length && (
         <Grid item xs={12}>
           <NoResultsImage />
         </Grid>

--- a/src/Components/ProfilePageContext.js
+++ b/src/Components/ProfilePageContext.js
@@ -1,0 +1,17 @@
+import { createContext } from "react";
+
+const ProfilePageContext = createContext({
+  profile: undefined,
+  profileUserId: undefined,
+  isOwnProfile: false,
+  isLoading: false,
+  updateBio: (bio) => {},
+  updateAvatar: (avatar) => {},
+  updateLikes: (likes) => {},
+  updateDislikes: (dislikes) => {},
+  updateList: (index, list) => {},
+  deleteList: (index) => {},
+  updateTop8: (top8) => {},
+});
+
+export default ProfilePageContext;

--- a/src/Components/ProfilePageContextProvider.js
+++ b/src/Components/ProfilePageContextProvider.js
@@ -1,0 +1,76 @@
+import { useContext } from "react";
+import { useAuthState } from "react-firebase-hooks/auth";
+import { useProfile } from "./APICalls";
+import { auth } from "./Firebase";
+import { SaveToFirestore } from "./Firestore";
+import { LocalUserContext } from "./LocalUserContext";
+import ProfilePageContext from "./ProfilePageContext";
+
+export default function ProfilePageContextProvider({ userId, children }) {
+  const [user, loading] = useAuthState(auth);
+  const { data: profile, isLoading: profileLoading } = useProfile(userId);
+  const [localUser, setLocalUser] = useContext(LocalUserContext);
+
+  const userOwnsProfile = user && profile && user.uid === profile.uid;
+
+  const value = {
+    profile: userOwnsProfile ? localUser : profile,
+    profileUserId: userId,
+    isOwnProfile: userOwnsProfile,
+    isLoading: loading || profileLoading || !localUser?.uid,
+    updateBio: (bio) => {
+      throwIfNotOwner();
+      const newLocalUser = { ...localUser, bio };
+      save(newLocalUser);
+    },
+    updateAvatar: (avatar) => {
+      throwIfNotOwner();
+      const newLocalUser = { ...localUser, avatar };
+      save(newLocalUser);
+    },
+    updateLikes: (likes) => {
+      throwIfNotOwner();
+      const newLocalUser = { ...localUser, likes };
+      save(newLocalUser);
+    },
+    updateDislikes: (dislikes) => {
+      throwIfNotOwner();
+      const newLocalUser = { ...localUser, dislikes };
+      save(newLocalUser);
+    },
+    updateList: (index, list) => {
+      throwIfNotOwner();
+      const newLocalUser = { ...localUser };
+      newLocalUser.lists[index] = list;
+      save(newLocalUser);
+    },
+    deleteList: (index) => {
+      throwIfNotOwner();
+      const newLocalUser = { ...localUser };
+      newLocalUser.lists.splice(index, 1);
+      save(newLocalUser);
+    },
+    updateTop8: (top8) => {
+      throwIfNotOwner();
+      const newLocalUser = { ...localUser, top8 };
+      save(newLocalUser);
+    },
+  };
+
+  const throwIfNotOwner = () => {
+    if (!userOwnsProfile) {
+      throw new Error("Trying to edit a profile without ownership.");
+    }
+  };
+
+  const save = (newLocalUser) => {
+    setLocalUser(newLocalUser);
+    SaveToFirestore(user, newLocalUser);
+  };
+
+  return (
+    <ProfilePageContext.Provider value={value}>
+      {children}
+    </ProfilePageContext.Provider>
+  );
+}

--- a/src/Components/ProfileSidebar.js
+++ b/src/Components/ProfileSidebar.js
@@ -1,24 +1,29 @@
 import { useContext } from "react";
 
-import { LocalUserContext } from "./LocalUserContext";
-import { Button } from "@mui/material";
+import { Box, Button, Skeleton } from "@mui/material";
 import { ArrowRight } from "phosphor-react";
 import { useNavigate } from "react-router-dom";
 import UserBio from "./UserBio";
 import Top8List from "./Top8List";
 import ProfileUserBanner from "./ProfileUserBanner";
+import ProfilePageContext from "./ProfilePageContext";
+import ProfileSidebarGhost from "./ProfileSidebarGhost";
 
 export default function ProfileSidebar({ hideDetails }) {
   const navigate = useNavigate();
 
-  const [localUser, setLocalUser] = useContext(LocalUserContext);
+  const { profile, isOwnProfile, isLoading } = useContext(ProfilePageContext);
+
+  if (isLoading) {
+    return <ProfileSidebarGhost />;
+  }
 
   return (
     <>
       <ProfileUserBanner />
       {!hideDetails && (
         <>
-          {localUser?.name === "guest" && (
+          {isOwnProfile && profile?.name === "guest" && (
             <div style={{ display: "flex", justifyContent: "center" }}>
               <Button
                 variant="contained"

--- a/src/Components/ProfileSidebarGhost.js
+++ b/src/Components/ProfileSidebarGhost.js
@@ -1,0 +1,15 @@
+import { Box, Skeleton } from "@mui/material";
+
+export default function ProfileSidebarGhost() {
+  return (
+    <>
+      <Box sx={{ display: "flex", alignItems: "center", width: "100%", mb: 4 }}>
+        <Skeleton width={80} height={80} variant="circular" sx={{ mr: 2 }} />
+        <Skeleton height={27} variant="rounded" sx={{ flexGrow: 1 }} />
+      </Box>
+      <Skeleton width={120} height={27} variant="rounded" sx={{ mb: 1 }} />
+      <Skeleton variant="text" sx={{ mb: 0.2 }} />
+      <Skeleton variant="text" sx={{ mb: 4.2 }} />
+    </>
+  );
+}

--- a/src/Components/ProfileUserBanner.js
+++ b/src/Components/ProfileUserBanner.js
@@ -4,20 +4,17 @@ import {
   ListItemButton,
   ListItemText,
   Tooltip,
-  useTheme,
 } from "@mui/material";
 import { Box } from "@mui/system";
 import { Camera, X } from "phosphor-react";
 import { useContext, useMemo, useState } from "react";
-import { useAuthState } from "react-firebase-hooks/auth";
 import { getAvatarSrc } from "./Avatars";
 import ChooseAvatar from "./ChooseAvatar";
-import { auth } from "./Firebase";
-import { LocalUserContext } from "./LocalUserContext";
+import ProfilePageContext from "./ProfilePageContext";
 
 export default function ProfileUserBanner() {
-  const [localUser, setLocalUser] = useContext(LocalUserContext);
-  const [user, loading, error] = useAuthState(auth);
+  const { profile, isOwnProfile } = useContext(ProfilePageContext);
+
   const [editAvatar, setEditAvatar] = useState(false);
 
   function handleAvatarToggle() {
@@ -25,54 +22,61 @@ export default function ProfileUserBanner() {
   }
 
   const avatarSrc = useMemo(
-    () => getAvatarSrc(localUser?.avatar),
-    [localUser?.avatar]
+    () => getAvatarSrc(profile?.avatar),
+    [profile?.avatar]
   );
 
   return (
     <>
       <div style={{ display: "flex", alignItems: "center" }}>
-        <Tooltip title="Change your avatar">
-          <ListItemButton
-            onClick={handleAvatarToggle}
-            sx={{ maxWidth: "96px", p: 1, borderRadius: "16px" }}
-          >
-            <Avatar
-              sx={{ width: "80px", height: "80px" }}
-              alt={user?.displayName}
-              src={avatarSrc}
-            />
-            <Box
-              sx={{
-                position: "absolute",
-                left: "63px",
-                top: "64px",
-                width: "30px",
-                height: "30px",
-                borderRadius: "20px",
-                backgroundColor: "custom.subtleCardBg",
-                boxSizing: "border-box",
-                padding: 0,
-                display: "flex",
-                justifyContent: "center",
-                alignItems: "center",
-              }}
+        {isOwnProfile ? (
+          <Tooltip title="Change your avatar">
+            <ListItemButton
+              onClick={handleAvatarToggle}
+              sx={{ maxWidth: "96px", p: 1, borderRadius: "16px" }}
             >
-              <Camera sx={{ color: "text" }} size={24} />
-            </Box>
-          </ListItemButton>
-        </Tooltip>
+              <Avatar
+                sx={{ width: "80px", height: "80px" }}
+                alt={profile?.name}
+                src={avatarSrc}
+              />
+              <Box
+                sx={{
+                  position: "absolute",
+                  left: "63px",
+                  top: "64px",
+                  width: "30px",
+                  height: "30px",
+                  borderRadius: "20px",
+                  backgroundColor: "custom.subtleCardBg",
+                  boxSizing: "border-box",
+                  padding: 0,
+                  display: "flex",
+                  justifyContent: "center",
+                  alignItems: "center",
+                }}
+              >
+                <Camera sx={{ color: "text" }} size={24} />
+              </Box>
+            </ListItemButton>
+          </Tooltip>
+        ) : (
+          <Avatar
+            sx={{ width: "80px", height: "80px", mr: 1 }}
+            alt={profile?.name}
+            src={avatarSrc}
+          />
+        )}
 
         <ListItemText
           sx={{ ml: 1 }}
-          primary={user?.displayName ? user.displayName : "Guest"}
+          primary={profile?.name ?? "Guest"}
           primaryTypographyProps={{
             fontFamily: "interBlack",
             fontSize: "1.66rem",
             overflow: "hidden",
             textOverflow: "ellipsis",
           }}
-          secondary={user?.email}
           secondaryTypographyProps={{
             fontFamily: "interMedium",
             fontSize: "1rem",

--- a/src/Components/Review.js
+++ b/src/Components/Review.js
@@ -16,7 +16,7 @@ import toDate from "date-fns/toDate";
 import { HandsClapping, Heart, Trash, X } from "phosphor-react";
 import { useContext, useEffect, useMemo } from "react";
 import { useAuthState } from "react-firebase-hooks/auth";
-import { useLocation } from "react-router-dom";
+import { Link, useLocation } from "react-router-dom";
 import { useProfile } from "./APICalls";
 import AvatarIcon from "./AvatarIcon";
 import EmojiReactionChip from "./EmojiReactionChip";
@@ -108,38 +108,47 @@ export default function Review({
       ) : (
         ""
       )}
-      <Box
-        component="div"
-        sx={{
-          minWidth: "150px",
-          display: "flex",
-          flexDirection: "column",
-          alignItems: "center",
-        }}
-      >
-        <Avatar sx={{ width: "80px", height: "80px" }} src={avatarSrc}></Avatar>
-        <Typography
-          component="span"
-          sx={{ fontFamily: "interSemiBold", fontSize: "1rem" }}
+      <Link to={`/profile/${item.uid}`}>
+        <Box
+          component="div"
+          sx={{
+            minWidth: "150px",
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            "&:hover": { color: "primary.main" },
+          }}
         >
-          {reviewerInfo?.name}
-        </Typography>
-        {reviewerInfo?.reviews ? (
+          <Avatar
+            sx={{ width: "80px", height: "80px" }}
+            src={avatarSrc}
+          ></Avatar>
           <Typography
             component="span"
             sx={{
-              fontFamily: "interMedium",
-              fontSize: "0.9rem",
-              color: "",
+              fontFamily: "interSemiBold",
+              fontSize: "1rem",
             }}
           >
-            ({reviewerInfo?.reviews?.length}
-            {reviewerInfo?.reviews?.length === 1 ? " review" : " reviews"})
+            {reviewerInfo?.name}
           </Typography>
-        ) : (
-          ""
-        )}
-      </Box>
+          {reviewerInfo?.reviews ? (
+            <Typography
+              component="span"
+              sx={{
+                fontFamily: "interMedium",
+                fontSize: "0.9rem",
+                color: "",
+              }}
+            >
+              ({reviewerInfo?.reviews?.length}
+              {reviewerInfo?.reviews?.length === 1 ? " review" : " reviews"})
+            </Typography>
+          ) : (
+            ""
+          )}
+        </Box>
+      </Link>
       <Box
         component="div"
         sx={{

--- a/src/Components/Review.js
+++ b/src/Components/Review.js
@@ -17,7 +17,7 @@ import { HandsClapping, Heart, Trash, X } from "phosphor-react";
 import { useContext, useEffect, useMemo } from "react";
 import { useAuthState } from "react-firebase-hooks/auth";
 import { useLocation } from "react-router-dom";
-import { useFetchProfile } from "./APICalls";
+import { useProfile } from "./APICalls";
 import AvatarIcon from "./AvatarIcon";
 import EmojiReactionChip from "./EmojiReactionChip";
 import ExpandableText from "./ExpandableText";
@@ -44,7 +44,7 @@ export default function Review({
   const confirm = useConfirm();
   let reviewerAvatar = undefined;
 
-  const { data: reviewerInfo } = useFetchProfile(item.uid);
+  const { data: reviewerInfo } = useProfile(item.uid);
   console.log(reviewerInfo);
 
   const avatarSrc = useMemo(

--- a/src/Components/RouteSwitch.js
+++ b/src/Components/RouteSwitch.js
@@ -35,10 +35,10 @@ const RouteSwitch = () => {
                     <Route element={<RoutingHelper />}>
                       <Route path="/reset" element={<Reset />} />
                       <Route
-                        path="/profile/list/:listId"
+                        path="/profile/:userId/list/:listId"
                         element={<Profile />}
                       />
-                      <Route path="/profile" element={<Profile />} />
+                      <Route path="/profile/:userId" element={<Profile />} />
                       <Route path="/search" element={<Search />} />
                       <Route
                         path="/anime/:animeId"

--- a/src/Components/RoutingHelper.js
+++ b/src/Components/RoutingHelper.js
@@ -18,8 +18,8 @@ export const RoutingHelper = () => {
   const headerRoutes = [
     "/home",
     "/search",
-    "/profile",
-    "/profile/list/:listId",
+    "/profile/:userId",
+    "/profile/:userId/list/:listId",
     "/sandbox",
     "/anime/:animeId",
   ];

--- a/src/Components/UserBio.js
+++ b/src/Components/UserBio.js
@@ -1,39 +1,21 @@
 import { useContext, useState } from "react";
-import { useAuthState } from "react-firebase-hooks/auth";
-import { LocalUserContext } from "./LocalUserContext";
-import { auth } from "./Firebase";
-import {
-  Avatar,
-  Button,
-  Divider,
-  IconButton,
-  ListItem,
-  ListItemButton,
-  TextField,
-  Typography,
-} from "@mui/material";
+import { Button, TextField, Typography } from "@mui/material";
 
-import { SaveToFirestore } from "./Firestore";
 import { Box } from "@mui/system";
-import { useTheme } from "@mui/material";
+import ProfilePageContext from "./ProfilePageContext";
 
 export default function UserBio() {
-  const [localUser, setLocalUser] = useContext(LocalUserContext);
-  const [user, loading, error] = useAuthState(auth);
-  const [editBio, setEditBio] = useState(false);
-  const [bio, setBio] = useState(localUser?.bio);
+  const { profile, isOwnProfile, updateBio } = useContext(ProfilePageContext);
 
-  const theme = useTheme();
+  const [editBio, setEditBio] = useState(false);
+  const [editedBio, setEditedBio] = useState(profile?.bio);
 
   function saveBio() {
-    let newLocalUser = { ...localUser };
-    newLocalUser.bio = bio;
-    setLocalUser(newLocalUser);
-    SaveToFirestore(user, newLocalUser);
+    updateBio(editedBio);
   }
 
   function handleBioToggle() {
-    setEditBio((editBio) => !editBio);
+    setEditBio(!editBio);
   }
 
   return (
@@ -51,14 +33,12 @@ export default function UserBio() {
             pt: 1,
             pb: 1,
             pl: 0,
-            cursor: "pointer",
+            cursor: isOwnProfile ? "pointer" : "unset",
           }}
-          onClick={(e) => {
-            handleBioToggle();
-          }}
+          onClick={isOwnProfile ? handleBioToggle : undefined}
         >
-          {localUser?.bio?.length > 0
-            ? localUser.bio
+          {profile?.bio?.length > 0
+            ? profile?.bio
             : "Tell us a bit about yourself..."}
         </Box>
       ) : (
@@ -79,10 +59,10 @@ export default function UserBio() {
             placeholder="Tell us a bit about yourself..."
             autoFocus
             multiline
-            value={bio}
+            value={editedBio}
             onClick={(e) => e.preventDefault()}
             onChange={(e) => {
-              setBio(e.target.value);
+              setEditedBio(e.target.value);
             }}
             sx={{ width: "100%", mb: 2 }}
             InputProps={{

--- a/src/Components/WatchlistTile.js
+++ b/src/Components/WatchlistTile.js
@@ -2,14 +2,14 @@ import { alpha, Box, Grid, Typography, useTheme } from "@mui/material";
 import { Link } from "react-router-dom";
 import NoResultsImage from "./NoResultsImage";
 
-export default function WatchlistTile({ listId, name, items }) {
+export default function WatchlistTile({ userId, listId, name, items }) {
   const theme = useTheme();
 
   const bgColor = theme.palette.custom.subtleCardBg;
   const gradient = `linear-gradient(270deg, ${bgColor} 0%, rgba(245, 245, 245, 0) 67.39%)`;
 
   return (
-    <Link to={`/profile/list/${listId}`}>
+    <Link to={`/profile/${userId}/list/${listId}`}>
       <Box
         sx={{
           padding: "18px",


### PR DESCRIPTION
This PR:
- Simplifies the hooks to get a profile from the API.
- Switches to use the `/profile/<userId>` path structure
- Adds links to user profiles via the avatars of review authors
- Introduces a new `ProfilePageContext` concept to abstract out logic around when the profile page controls should be editable, and what data to show (we use LocalUser for the user's own profile, and the fetched profile for others, but to program a profile page UI, you don't have to worry about that while using this context)

The last part is interesting, in specific. Since profile pages can now be rendered from localUser or fetched public profile data, and I didn't want to duplicate components to display these, I have abstracted all logic of getting profile data, determining whether the user can edit the profile, and applying these edits, to a context called ProfilePageContext. This means individual profile page components should not obtain localUser or write to localUser, but instead do all interaction with LocalUser through the ProfilePageContext. I'm migrated all components on the Profile page to use this context, except for the avatar selection, which still does some manual LocalUser manipulation when you choose avatars.