### PR TITLE
Filtered Reviews

### DIFF
--- a/src/Components/DetailedView.js
+++ b/src/Components/DetailedView.js
@@ -28,7 +28,6 @@ import { auth } from "./Firebase";
 import {
   GetPaginatedReviewsFromFirestore,
   PopulateFromFirestore,
-  PopulateReviewsFromFirestore,
 } from "./Firestore";
 import LikeButtons from "./LikeButtons";
 import { LocalUserContext } from "./LocalUserContext";
@@ -72,8 +71,6 @@ export default function DetailedView() {
   }, [user, anime, loading]);
 
   useEffect(() => {
-    console.log(sortOption);
-
     GetPaginatedReviewsFromFirestore(
       anime,
       animeReviews,
@@ -81,6 +78,7 @@ export default function DetailedView() {
       sortOption,
       lastVisible,
       setLastVisible,
+      seeMore,
       setSeeMore
     );
   }, [location.pathname, anime, sortOption]);
@@ -375,7 +373,7 @@ export default function DetailedView() {
               }}
             >
               Reviews{" "}
-              {animeReviews?.length > 2 ? (
+              {animeReviews?.length > 2 && (
                 <Typography
                   sx={{
                     fontFamily: "interMedium",
@@ -387,8 +385,6 @@ export default function DetailedView() {
                 >
                   ({animeReviews?.length} total)
                 </Typography>
-              ) : (
-                ""
               )}
               {!showReviewForm ? (
                 <Tooltip title="Add a review">
@@ -434,15 +430,15 @@ export default function DetailedView() {
             )}
           </div>
 
-          {showReviewForm ? (
+          {showReviewForm && (
             <ReviewForm
               anime={anime}
               animeReviews={animeReviews}
               setAnimeReviews={setAnimeReviews}
               setShowReviewForm={setShowReviewForm}
+              setLastVisible={setLastVisible}
+              setSeeMore={setSeeMore}
             />
-          ) : (
-            ""
           )}
 
           {animeReviews?.map((item, index) => {
@@ -471,6 +467,7 @@ export default function DetailedView() {
                     sortOption,
                     lastVisible,
                     setLastVisible,
+                    seeMore,
                     setSeeMore
                   )
                 }

--- a/src/Components/Firestore.js
+++ b/src/Components/Firestore.js
@@ -132,6 +132,7 @@ export async function GetPaginatedReviewsFromFirestore(
   sortOption,
   lastVisible,
   setLastVisible,
+  seeMore,
   setSeeMore
 ) {
   try {
@@ -153,13 +154,13 @@ export async function GetPaginatedReviewsFromFirestore(
     }
     const documentSnapshots = await getDocs(collectionQuery);
     if (documentSnapshots._snapshot.docChanges.length < 4) setSeeMore(false);
+    else if (seeMore === false) setSeeMore(true);
 
     let temp = [];
     if (animeReviews && lastVisible) temp = [...animeReviews];
     documentSnapshots.forEach((doc) => {
       temp.push({ ...doc.data() });
     });
-    console.log(temp);
     setAnimeReviews(temp);
     setLastVisible(documentSnapshots.docs[documentSnapshots.docs.length - 1]);
   } catch (error) {

--- a/src/Components/Review.js
+++ b/src/Components/Review.js
@@ -47,7 +47,6 @@ export default function Review({
   let reviewerAvatar = undefined;
 
   const { data: reviewerInfo } = useProfile(item.uid);
-  console.log(reviewerInfo);
 
   const avatarSrc = useMemo(
     () => getAvatarSrc(reviewerInfo?.avatar),
@@ -89,7 +88,6 @@ export default function Review({
           xs: "column",
           sm: "flex",
         },
-        justifyContent: "center",
         position: "relative",
         pt: { xs: 1, sm: 2 },
         pr: { xs: 1, sm: 2 },
@@ -156,6 +154,7 @@ export default function Review({
         </Grid>
       </Link>
       <Grid
+        width="100%"
         component="div"
         sx={{
           display: "flex",

--- a/src/Components/ReviewFilterDropMenu.js
+++ b/src/Components/ReviewFilterDropMenu.js
@@ -1,0 +1,162 @@
+import React, { useContext, useEffect, useMemo, useRef, useState } from "react";
+import Button from "@mui/material/Button";
+import ClickAwayListener from "@mui/material/ClickAwayListener";
+import Grow from "@mui/material/Grow";
+import Paper from "@mui/material/Paper";
+import Popper from "@mui/material/Popper";
+import MenuItem from "@mui/material/MenuItem";
+import MenuList from "@mui/material/MenuList";
+import Stack from "@mui/material/Stack";
+import {
+  FunnelSimple,
+  List,
+  Moon,
+  SignOut,
+  Sun,
+  User,
+  UserCircle,
+  UserCirclePlus,
+} from "phosphor-react";
+import { useNavigate } from "react-router-dom";
+import { auth, logout } from "./Firebase";
+import { LocalUserContext } from "./LocalUserContext";
+import { useAuthState } from "react-firebase-hooks/auth";
+import {
+  Avatar,
+  ListItem,
+  ListItemAvatar,
+  ListItemButton,
+  ListItemIcon,
+  ListItemText,
+} from "@mui/material";
+import { useTheme } from "@mui/material/styles";
+import AppSettingsContext from "./AppSettingsContext";
+
+export default function ReviewFilterDropMenu({
+  setLastVisible,
+  setSortOption,
+}) {
+  const theme = useTheme();
+
+  const [open, setOpen] = useState(false);
+  const anchorRef = useRef(null);
+
+  const [selected, setSelected] = useState("newestFirst");
+
+  // const avatarSrc = useMemo(
+  //   () => getAvatarSrc(localUser?.avatar),
+  //   [localUser?.avatar]
+  // );
+
+  const handleToggle = () => {
+    setOpen((prevOpen) => !prevOpen);
+  };
+
+  function handleClose(event) {
+    if (anchorRef.current && anchorRef.current.contains(event.target)) {
+      return;
+    }
+
+    setOpen(false);
+  }
+
+  function handleListKeyDown(event) {
+    if (event.key === "Tab") {
+      event.preventDefault();
+      setOpen(false);
+    } else if (event.key === "Escape") {
+      setOpen(false);
+    }
+  }
+
+  // return focus to the button when we transitioned from !open -> open
+  const prevOpen = useRef(open);
+  useEffect(() => {
+    if (prevOpen.current === true && open === false) {
+      anchorRef.current.focus();
+    }
+
+    prevOpen.current = open;
+  }, [open]);
+
+  function handleSelection(e, option) {
+    handleClose(e);
+    // This triggers us to overwrite the current animeReviews list
+    setLastVisible(null);
+    setSortOption([option[0], option[1]]);
+    setSelected(option[2]);
+  }
+
+  return (
+    <Stack>
+      <Button
+        variant="outlined"
+        startIcon={<FunnelSimple />}
+        color="inherit"
+        ref={anchorRef}
+        id="composition-button"
+        aria-controls={open ? "composition-menu" : undefined}
+        aria-expanded={open ? "true" : undefined}
+        aria-haspopup="true"
+        onClick={handleToggle}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") handleToggle();
+        }}
+      >
+        {" "}
+        Filter By{" "}
+      </Button>
+      <Popper
+        open={open}
+        anchorEl={anchorRef.current}
+        role={undefined}
+        placement="bottom-start"
+        transition
+        style={{ zIndex: "4" }}
+      >
+        {({ TransitionProps, placement }) => (
+          <Grow
+            {...TransitionProps}
+            style={{
+              transformOrigin:
+                placement === "bottom-start" ? "left top" : "left bottom",
+            }}
+          >
+            <Paper elevation={6}>
+              <ClickAwayListener onClickAway={handleClose}>
+                <MenuList
+                  autoFocusItem={open}
+                  id="composition-menu"
+                  aria-labelledby="composition-button"
+                  onKeyDown={handleListKeyDown}
+                >
+                  <MenuItem
+                    divider
+                    sx={{ paddingTop: "10px", paddingBottom: "10px" }}
+                    onClick={(e) => {
+                      handleSelection(e, ["time", "asc"], "oldestFirst");
+                    }}
+                    selected={selected === "oldestFirst" ? true : false}
+                  >
+                    Date: Oldest first
+                  </MenuItem>
+
+                  <MenuItem
+                    value={["time", "desc"]}
+                    sx={{ marginTop: "10px" }}
+                    onClick={(e) => {
+                      handleSelection(e, ["time", "desc"], "newestFirst");
+                    }}
+                    selected={selected === "newestFirst" ? true : false}
+                  >
+                    Date: Newest first{" "}
+                  </MenuItem>
+                </MenuList>
+              </ClickAwayListener>
+            </Paper>
+          </Grow>
+        )}
+      </Popper>
+    </Stack>
+  );
+}

--- a/src/Components/ReviewFilterDropMenu.js
+++ b/src/Components/ReviewFilterDropMenu.js
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useMemo, useRef, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import Button from "@mui/material/Button";
 import ClickAwayListener from "@mui/material/ClickAwayListener";
 import Grow from "@mui/material/Grow";
@@ -7,46 +7,16 @@ import Popper from "@mui/material/Popper";
 import MenuItem from "@mui/material/MenuItem";
 import MenuList from "@mui/material/MenuList";
 import Stack from "@mui/material/Stack";
-import {
-  FunnelSimple,
-  List,
-  Moon,
-  SignOut,
-  Sun,
-  User,
-  UserCircle,
-  UserCirclePlus,
-} from "phosphor-react";
-import { useNavigate } from "react-router-dom";
-import { auth, logout } from "./Firebase";
-import { LocalUserContext } from "./LocalUserContext";
-import { useAuthState } from "react-firebase-hooks/auth";
-import {
-  Avatar,
-  ListItem,
-  ListItemAvatar,
-  ListItemButton,
-  ListItemIcon,
-  ListItemText,
-} from "@mui/material";
-import { useTheme } from "@mui/material/styles";
-import AppSettingsContext from "./AppSettingsContext";
+import { FunnelSimple } from "phosphor-react";
 
 export default function ReviewFilterDropMenu({
   setLastVisible,
   setSortOption,
 }) {
-  const theme = useTheme();
-
   const [open, setOpen] = useState(false);
   const anchorRef = useRef(null);
 
   const [selected, setSelected] = useState("newestFirst");
-
-  // const avatarSrc = useMemo(
-  //   () => getAvatarSrc(localUser?.avatar),
-  //   [localUser?.avatar]
-  // );
 
   const handleToggle = () => {
     setOpen((prevOpen) => !prevOpen);
@@ -56,7 +26,6 @@ export default function ReviewFilterDropMenu({
     if (anchorRef.current && anchorRef.current.contains(event.target)) {
       return;
     }
-
     setOpen(false);
   }
 
@@ -81,7 +50,6 @@ export default function ReviewFilterDropMenu({
 
   function handleSelection(e, option) {
     handleClose(e);
-    // This triggers us to overwrite the current animeReviews list
     setLastVisible(null);
     setSortOption([option[0], option[1]]);
     setSelected(option[2]);
@@ -129,27 +97,46 @@ export default function ReviewFilterDropMenu({
                   id="composition-menu"
                   aria-labelledby="composition-button"
                   onKeyDown={handleListKeyDown}
+                  sx={{ padding: 0 }}
                 >
                   <MenuItem
                     divider
-                    sx={{ paddingTop: "10px", paddingBottom: "10px" }}
                     onClick={(e) => {
-                      handleSelection(e, ["time", "asc"], "oldestFirst");
+                      handleSelection(e, ["time", "asc", "oldestFirst"]);
                     }}
                     selected={selected === "oldestFirst" ? true : false}
                   >
-                    Date: Oldest first
+                    Date: Oldest First
                   </MenuItem>
 
                   <MenuItem
-                    value={["time", "desc"]}
-                    sx={{ marginTop: "10px" }}
+                    divider
                     onClick={(e) => {
-                      handleSelection(e, ["time", "desc"], "newestFirst");
+                      handleSelection(e, ["time", "desc", "newestFirst"]);
                     }}
                     selected={selected === "newestFirst" ? true : false}
                   >
-                    Date: Newest first{" "}
+                    Date: Newest First{" "}
+                  </MenuItem>
+
+                  <MenuItem
+                    divider
+                    onClick={(e) => {
+                      handleSelection(e, ["rating", "desc", "highestRating"]);
+                    }}
+                    selected={selected === "highestRating" ? true : false}
+                  >
+                    Rating: Highest First{" "}
+                  </MenuItem>
+
+                  <MenuItem
+                    divider
+                    onClick={(e) => {
+                      handleSelection(e, ["rating", "asc", "lowestRating"]);
+                    }}
+                    selected={selected === "lowestRating" ? true : false}
+                  >
+                    Rating: Lowest First{" "}
                   </MenuItem>
                 </MenuList>
               </ClickAwayListener>

--- a/src/Components/ReviewForm.js
+++ b/src/Components/ReviewForm.js
@@ -17,9 +17,12 @@ import { yupResolver } from "@hookform/resolvers/yup";
 import { useForm } from "react-hook-form";
 import { Fire, Heart } from "phosphor-react";
 import {
+  GetPaginatedReviewsFromFirestore,
   PopulateReviewsFromFirestore,
   SaveReviewToFirestore,
   SaveToFirestore,
+  setLastVisible,
+  setSeeMore,
 } from "./Firestore";
 import { getAvatarSrc } from "./Avatars";
 
@@ -28,6 +31,8 @@ export default function ReviewForm({
   animeReviews,
   setAnimeReviews,
   setShowReviewForm,
+  setLastVisible,
+  setSeeMore,
 }) {
   const [localUser, setLocalUser] = useContext(LocalUserContext);
   const [user] = useAuthState(auth);
@@ -100,7 +105,17 @@ export default function ReviewForm({
       }
       const userID = user.uid.toString();
       SaveReviewToFirestore(userID, userReview, animeID);
-      PopulateReviewsFromFirestore(anime, setAnimeReviews);
+      // PopulateReviewsFromFirestore(anime, setAnimeReviews);
+      GetPaginatedReviewsFromFirestore(
+        anime,
+        animeReviews,
+        setAnimeReviews,
+        null,
+        null,
+        setLastVisible,
+        null,
+        setSeeMore
+      );
       setShowReviewForm(false);
     }
   };


### PR DESCRIPTION
ASK AND YE SHALL RECEIVE (I am expecting **HEAVY** site traffic once we launch, so let's minimize these Firestore reads!!)

Two updates, based on your comments:
1. Only reads (4) documents from Firestore at a time.
2. Adds a button to filter reviews.

Note:
- I couldn't figure out if it's worth caching these Firestore calls with a TanStack Query.  It seems unlikely someone would tinker with the filters enough to burn a significant number of reads....but I'm sure stranger things have happened...