### PR TITLE
Make review content grid grow to fill available width

### DIFF
--- a/src/Components/Review.js
+++ b/src/Components/Review.js
@@ -160,6 +160,7 @@ export default function Review({
         sx={{
           display: "flex",
           flexDirection: "column",
+          flexGrow: { xs: "unset", sm: 1 },
         }}
       >
         <div


### PR DESCRIPTION
Otherwise, when the review text is really short, the review content ends up being small and centered in the review card (the super short review coolman1 has on FMA Brotherhood will demonstrate this).  This change just makes the main grid of the review expand to fill available width.