### PR TITLE
Create 'ghost' versions of DetailedView, Profile

### DIFF
--- a/src/Components/DetailedView.js
+++ b/src/Components/DetailedView.js
@@ -23,6 +23,7 @@ import useAnime from "../Hooks/useAnime";
 import useAnimeAnalysis from "../Hooks/useAnimeAnalysis";
 import useYoutubeModal from "../Hooks/useYoutubeModal";
 import BreathingLogo from "./BreathingLogo";
+import DetailedViewGhost from "./DetailedViewGhost";
 import ExpandableText from "./ExpandableText";
 import { auth } from "./Firebase";
 import {
@@ -85,14 +86,7 @@ export default function DetailedView() {
 
   // TODO Use a shared loading display component.
   if (loading || animeLoading) {
-    return (
-      <div className="jsxWrapper">
-        <div className="gap" />
-        <Container maxWidth="lg">
-          <h4>Loading...</h4>
-        </Container>
-      </div>
-    );
+    return <DetailedViewGhost />;
   }
 
   // TODO Use a shared error display component.

--- a/src/Components/DetailedViewGhost.js
+++ b/src/Components/DetailedViewGhost.js
@@ -1,0 +1,72 @@
+import { Box, Container, Grid, Skeleton } from "@mui/material";
+
+export default function DetailedViewGhost() {
+  return (
+    <Container maxWidth="lg">
+      <Grid container sx={{ paddingTop: { xs: "25px", md: "50px" } }}>
+        <Grid item xs={12} md={3}>
+          <Box sx={{ display: "flex", justifyContent: "center" }}>
+            <Skeleton
+              variant="rounded"
+              width={250}
+              height={357}
+              sx={{ borderRadius: "16px", mb: 2 }}
+            />
+          </Box>
+          <Skeleton width={120} height={27} variant="rounded" sx={{ mb: 1 }} />
+          <Skeleton variant="text" sx={{ mb: 0.2 }} />
+          <Skeleton variant="text" sx={{ mb: 2 }} />
+        </Grid>
+        <Grid item xs={12} md={9}>
+          <Grid container sx={{ paddingLeft: { xs: 0, md: "46px" } }}>
+            {/*Desktop-only big title*/}
+            <Grid
+              item
+              xs={12}
+              md={8.5}
+              sx={{ display: { xs: "none", md: "block" } }}
+            >
+              <Skeleton variant="rounded" width={280} height={40} />
+            </Grid>
+            {/* LikeButtons */}
+            <Grid
+              item
+              xs={12}
+              md={3.5}
+              sx={{
+                display: "flex",
+                justifyContent: { xs: "center", md: "flex-end" },
+                marginTop: { xs: 0.5, md: 0 },
+                marginBottom: 2,
+              }}
+            >
+              <Skeleton
+                variant="circular"
+                width={50}
+                height={50}
+                sx={{ mr: 1 }}
+              />
+              <Skeleton
+                variant="circular"
+                width={50}
+                height={50}
+                sx={{ mr: 1 }}
+              />
+              <Skeleton variant="circular" width={50} height={50} />
+            </Grid>
+
+            {/* Data from Edward */}
+            <Grid item xs={12}>
+              <Skeleton
+                variant="rounded"
+                height={290}
+                sx={{ borderRadius: "16px" }}
+              />
+            </Grid>
+          </Grid>
+        </Grid>
+      </Grid>
+      <div className="gap" />
+    </Container>
+  );
+}

--- a/src/Components/ProfileListPage.js
+++ b/src/Components/ProfileListPage.js
@@ -6,6 +6,7 @@ import { Link, useNavigate, useParams } from "react-router-dom";
 import { slugifyListName } from "../Util/ListUtil";
 import NoResultsImage from "./NoResultsImage";
 import ProfileListItem from "./ProfileListItem";
+import ProfileListPageGhost from "./ProfileListPageGhost";
 import ProfileListSuggestions from "./ProfileListSuggestions";
 import ProfilePageContext from "./ProfilePageContext";
 
@@ -29,9 +30,8 @@ export default function ProfileListPage() {
 
   const canEdit = isOwnProfile;
 
-  // TODO Add a 'ghost' page for loading.
   if (isLoading) {
-    return <></>;
+    return <ProfileListPageGhost />;
   }
 
   let items = [];

--- a/src/Components/ProfileListPageGhost.js
+++ b/src/Components/ProfileListPageGhost.js
@@ -1,0 +1,16 @@
+import { Box, Skeleton } from "@mui/material";
+
+export default function ProfileListPageGhost() {
+  const rows = new Array(3).fill(0);
+  return (
+    <Box sx={{ paddingLeft: { xs: 0, md: "45px" } }}>
+      <Skeleton variant="rounded" width={160} height={40} sx={{ mb: 2 }} />
+      {rows.map((i, index) => (
+        <Box key={index} sx={{ display: "flex", alignItems: "center", mb: 2 }}>
+          <Skeleton variant="rounded" width={40} height={56} sx={{ mr: 2 }} />
+          <Skeleton variant="text" width={200} />
+        </Box>
+      ))}
+    </Box>
+  );
+}

--- a/src/Components/ProfileMainPage.js
+++ b/src/Components/ProfileMainPage.js
@@ -4,6 +4,7 @@ import WatchlistTile from "./WatchlistTile";
 import { slugifyListName } from "../Util/ListUtil";
 import { useContext } from "react";
 import ProfilePageContext from "./ProfilePageContext";
+import ProfileMainPageGhost from "./ProfileMainPageGhost";
 
 export default function ProfileMainPage() {
   const { profile, isLoading } = useContext(ProfilePageContext);
@@ -21,9 +22,8 @@ export default function ProfileMainPage() {
     fontSize: "16px",
   };
 
-  // TODO Add a 'ghost' page for loading.
   if (isLoading) {
-    return <></>;
+    return <ProfileMainPageGhost />;
   }
 
   return (

--- a/src/Components/ProfileMainPageGhost.js
+++ b/src/Components/ProfileMainPageGhost.js
@@ -1,0 +1,29 @@
+import { Grid, Skeleton } from "@mui/material";
+
+export default function ProfileMainPageGhost() {
+  return (
+    <Grid
+      container
+      columnSpacing={2}
+      sx={{ paddingLeft: { xs: 0, md: "45px" } }}
+    >
+      <Grid item xs={12} sx={{ mb: 2 }}>
+        <Skeleton variant="rounded" width={120} height={24} />
+      </Grid>
+      <Grid item xs={12} md={6}>
+        <Skeleton
+          variant="rounded"
+          height={162}
+          sx={{ borderRadius: "16px", mb: 2 }}
+        />
+      </Grid>
+      <Grid item xs={12} md={6}>
+        <Skeleton
+          variant="rounded"
+          height={162}
+          sx={{ borderRadius: "16px", mb: 2 }}
+        />
+      </Grid>
+    </Grid>
+  );
+}

--- a/src/Components/ProfileSidebarGhost.js
+++ b/src/Components/ProfileSidebarGhost.js
@@ -4,8 +4,17 @@ export default function ProfileSidebarGhost() {
   return (
     <>
       <Box sx={{ display: "flex", alignItems: "center", width: "100%", mb: 4 }}>
-        <Skeleton width={80} height={80} variant="circular" sx={{ mr: 2 }} />
-        <Skeleton height={27} variant="rounded" sx={{ flexGrow: 1 }} />
+        <Skeleton
+          width={80}
+          height={80}
+          variant="circular"
+          sx={{ mr: 2, flexShrink: 0 }}
+        />
+        <Skeleton
+          height={27}
+          variant="rounded"
+          sx={{ flexGrow: 1, maxWidth: "180px" }}
+        />
       </Box>
       <Skeleton width={120} height={27} variant="rounded" sx={{ mb: 1 }} />
       <Skeleton variant="text" sx={{ mb: 0.2 }} />


### PR DESCRIPTION
These will show while critical data dependencies are loading.  

The one tricky thing about these is that they do introduce a maintenance burden, since we have to update them if we update the layout of the pages, and they only are seen rarely, usually during cold-load of a url pointing to one of the pages, or one first load of a DetailedView while the analysis loads.  An alternative might be to just use a loading Edward on the page.