### PR TITLE
Animate ScoreBars to their initial positions

### DIFF
--- a/src/Components/ScoreBars.js
+++ b/src/Components/ScoreBars.js
@@ -1,6 +1,20 @@
 import { Box, LinearProgress, Typography } from "@mui/material";
+import { useEffect, useState } from "react";
 
 export default function ScoreBars({ scores }) {
+  const [multiplier, setMultiplier] = useState(0);
+
+  // LinearProgress components animate changes in value.  To get them to
+  // animate the bars to their initial positions, a multiplier is applied to
+  // each score, starting at 0 and set to 1 after a very short delay.
+  useEffect(() => {
+    if (scores.length > 0 && multiplier === 0) {
+      setTimeout(() => {
+        setMultiplier(1);
+      }, 100);
+    }
+  }, [scores]);
+
   return (
     <>
       {scores.map((score) => (
@@ -19,7 +33,7 @@ export default function ScoreBars({ scores }) {
           <LinearProgress
             variant="determinate"
             // Map the [0, 1] scores to [0.2, 1] for positive vibes.
-            value={(score.value * 0.8 + 0.2) * 100}
+            value={(score.value * 0.8 + 0.2) * 100 * multiplier}
             sx={{ height: 8, borderRadius: 4, flexGrow: 1 }}
           />
         </Box>


### PR DESCRIPTION
Since the LinearProgress components only animate _changes_ in value, once the scores are loaded, I start by multiplying all their values by a multiplier of 0, then change the multiplier to 1 after a short 100ms delay.  This causes a change in value, so the bars animate from 0 to the full score values.