### PR TITLE
Centers like buttons on their shelf.

### DIFF
--- a/src/Components/DetailedView.js
+++ b/src/Components/DetailedView.js
@@ -247,7 +247,8 @@ export default function DetailedView() {
               xs={12}
               md={3.5}
               sx={{
-                textAlign: { xs: "center", md: "end" },
+                display: "flex",
+                justifyContent: { xs: "center", md: "flex-end" },
                 marginTop: { xs: 0.5, md: 0 },
                 marginBottom: { xs: 2, md: 0 },
               }}

--- a/src/Components/LikeButtons.js
+++ b/src/Components/LikeButtons.js
@@ -5,7 +5,7 @@ import LikeButton from "./LikeButton";
 
 export default function LikeButtons({ anime, variant }) {
   return (
-    <Box>
+    <Box sx={{ display: "flex", justifyContent: "center" }}>
       <Box sx={{ mr: 1 }} component="span">
         <LikeButton anime={anime} variant={variant} />
       </Box>


### PR DESCRIPTION
This keeps them from breaking into (2) rows when the anime tiles get very small.  
This would occur right before the 600px {sm} breakpoint.