### PR TITLE
Clean up Avatar display

### DIFF
--- a/src/Components/DropMenu.js
+++ b/src/Components/DropMenu.js
@@ -120,8 +120,8 @@ export default function DropMenu() {
       <Avatar
         ref={anchorRef}
         id="composition-button"
-        alt={user?.displayName}
-        src={avatarSrc}
+        alt={user?.displayName ?? "Guest"}
+        src={avatarSrc ?? "purposefully bad link"}
         aria-controls={open ? "composition-menu" : undefined}
         aria-expanded={open ? "true" : undefined}
         aria-haspopup="true"
@@ -171,13 +171,16 @@ export default function DropMenu() {
                   >
                     <ListItemAvatar>
                       <Avatar
-                        alt={user?.displayName}
-                        src="purposefully bad link"
+                        alt={user?.displayName ?? "Guest"}
+                        src={avatarSrc ?? "purposefully bad link"}
                         sx={{ bgcolor: theme.palette.primary.main }}
                       />
                     </ListItemAvatar>
 
                     <ListItemText
+                      sx={{
+                        color: user ? "primary" : theme.palette.text.primary,
+                      }}
                       primary={
                         user?.displayName ? `${user?.displayName}` : "Guest"
                       }


### PR DESCRIPTION
-Changes guest avatar to a "G" instead of the phosphor `User` icon.  This resolves having (2) User icons in the header for the compressed mobile view.

-Shows the users avatar in the Drop Menu's `ListItemButton` (the first item in the drop menu - now it shows the avatar instead of the first letter of the user's name)