### PR TITLE
Firefox styling clean-up

### DIFF
--- a/src/Components/DropMenu.js
+++ b/src/Components/DropMenu.js
@@ -135,6 +135,7 @@ export default function DropMenu() {
           cursor: "pointer",
           width: "35px",
           height: "35px",
+          fontFamily: "interSemiBold",
         }}
       />
       <Popper

--- a/src/Components/DropMenu.js
+++ b/src/Components/DropMenu.js
@@ -173,7 +173,10 @@ export default function DropMenu() {
                       <Avatar
                         alt={user?.displayName}
                         src="purposefully bad link"
-                        sx={{ bgcolor: theme.palette.primary.main }}
+                        sx={{
+                          bgcolor: theme.palette.primary.main,
+                          fontFamily: "interSemiBold",
+                        }}
                       />
                     </ListItemAvatar>
 

--- a/src/Styles/index.css
+++ b/src/Styles/index.css
@@ -1,7 +1,7 @@
 body {
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen",
+    "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue",
     sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
@@ -9,11 +9,16 @@ body {
 }
 
 code {
-  font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
+  font-family: source-code-pro, Menlo, Monaco, Consolas, "Courier New",
     monospace;
 }
 
 a:-webkit-any-link {
+  text-decoration: none;
+  color: inherit;
+}
+
+a {
   text-decoration: none;
   color: inherit;
 }


### PR DESCRIPTION
Fixes (2) display issues with the app in Firefox:
1. Removes styling from all links.
2. Centers typography in Dropmenu Avatar (when it fails loading a link and displays an initial instead...ie, for a "guest" account).