### PR TITLE
Update useAnimeMPTW to use planned_to_watch sort

### DIFF
--- a/src/Components/APICalls.js
+++ b/src/Components/APICalls.js
@@ -76,7 +76,7 @@ export function useAnimeMC(selectedGenre) {
 
 export function useAnimeMPTW(selectedGenre) {
   return useGetTitles(
-    `https://api-jet-lfoguxrv7q-uw.a.run.app/anime?sort=most_rated&page_size=24${selectedGenre}`
+    `https://api-jet-lfoguxrv7q-uw.a.run.app/anime?sort=most_planned_to_watch&page_size=24${selectedGenre}`
   );
 }
 


### PR DESCRIPTION
Not sure if this is a bug or if it is intended, but I was looking through APICalls.js and I realized that `useAnimeMPTW` uses the `most_rated` sort order, although tI think he title indicates that it was supposed to be `most_planned_to_watch`.  The results are shown on home under the 'Most Buzzed About' header.  If this is working as intended, then I'll just delete this branch, but otherwise, correcting this will add a little more diversity to Home.