### PR TITLE
Fix mismatch in cover image and button border radii

### DIFF
--- a/src/Components/DetailedView.js
+++ b/src/Components/DetailedView.js
@@ -163,6 +163,7 @@ export default function DetailedView() {
                     sx={{
                       width: "100%",
                       height: "100%",
+                      borderRadius: "16px",
                       "&:hover": {
                         background: alpha(theme.palette.common.black, 0.25),
                       },


### PR DESCRIPTION
Otherwise, on hover, the rounded corner of the button doesn't quite line up with the corner of the cover image.