### PR TITLE
Remove top-level MUI imports

### DIFF
--- a/src/Components/AddButton.js
+++ b/src/Components/AddButton.js
@@ -1,4 +1,4 @@
-import { Button } from "@mui/material";
+import Button from "@mui/material/Button";
 
 import useWatchlistState from "../Hooks/useWatchlistState";
 

--- a/src/Components/AddButtonForTop8.js
+++ b/src/Components/AddButtonForTop8.js
@@ -1,4 +1,4 @@
-import { Button } from "@mui/material";
+import Button from "@mui/material/Button";
 import useTop8ListState from "../Hooks/useTop8ListState";
 
 export default function AddButtonForTop8({ anime, list }) {

--- a/src/Components/AddToListDropMenu.js
+++ b/src/Components/AddToListDropMenu.js
@@ -11,17 +11,15 @@ import { useNavigate } from "react-router-dom";
 import { auth } from "./Firebase";
 import { LocalUserContext } from "./LocalUserContext";
 import { useAuthState } from "react-firebase-hooks/auth";
-import {
-  Divider,
-  IconButton,
-  ListItem,
-  ListItemButton,
-  ListItemIcon,
-  ListItemText,
-  TextField,
-  Tooltip,
-} from "@mui/material";
-import { useTheme } from "@mui/material/styles";
+import Divider from "@mui/material/Divider";
+import IconButton from "@mui/material/IconButton";
+import ListItem from "@mui/material/ListItem";
+import ListItemButton from "@mui/material/ListItemButton";
+import ListItemIcon from "@mui/material/ListItemIcon";
+import ListItemText from "@mui/material/ListItemText";
+import TextField from "@mui/material/TextField";
+import Tooltip from "@mui/material/Tooltip";
+import useTheme from "@mui/material/styles/useTheme";
 import { SaveToFirestore } from "./Firestore";
 import AddButton from "./AddButton";
 import * as Yup from "yup";

--- a/src/Components/AnimeCard.js
+++ b/src/Components/AnimeCard.js
@@ -1,4 +1,8 @@
-import { Box, Paper, Typography, useTheme } from "@mui/material";
+import Box from "@mui/material/Box";
+import Paper from "@mui/material/Paper";
+import Typography from "@mui/material/Typography";
+import useTheme from "@mui/material/styles/useTheme";
+
 import { useState } from "react";
 import { Link } from "react-router-dom";
 import LikeButtons from "./LikeButtons";

--- a/src/Components/AnimeGrid.js
+++ b/src/Components/AnimeGrid.js
@@ -1,4 +1,8 @@
-import { Box, Button, Grid, Skeleton } from "@mui/material";
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import Grid from "@mui/material/Grid";
+import Skeleton from "@mui/material/Skeleton";
+
 import { CaretDown } from "phosphor-react";
 import { useEffect, useState } from "react";
 import AnimeCard from "./AnimeCard";

--- a/src/Components/AnimeShelf.js
+++ b/src/Components/AnimeShelf.js
@@ -1,12 +1,11 @@
-import {
-  Box,
-  Grid,
-  IconButton,
-  Paper,
-  Skeleton,
-  useMediaQuery,
-  useTheme,
-} from "@mui/material";
+import Box from "@mui/material/Box";
+import Grid from "@mui/material/Grid";
+import IconButton from "@mui/material/IconButton";
+import Skeleton from "@mui/material/Skeleton";
+import Paper from "@mui/material/Paper";
+import useMediaQuery from "@mui/material/useMediaQuery";
+import useTheme from "@mui/material/styles/useTheme";
+
 import { CaretLeft, CaretRight } from "phosphor-react";
 import { useState } from "react";
 import { useSwipeable } from "react-swipeable";

--- a/src/Components/App.js
+++ b/src/Components/App.js
@@ -1,20 +1,18 @@
 import "../Styles/App.css";
 
-import { Autocomplete, TextField, Grid } from "@mui/material";
+import Autocomplete from "@mui/material/Autocomplete";
+import TextField from "@mui/material/TextField";
 
-import { Link } from "react-router-dom";
 import * as React from "react";
 
 import { useEffect, useState, useContext } from "react";
 import { LocalUserContext } from "./LocalUserContext";
 
 import Emoji from "./Emoji";
-import { User } from "firebase/auth";
 
 import { useAuthState } from "react-firebase-hooks/auth";
 import { auth } from "./Firebase";
-import { FirebaseError } from "firebase/app";
-import { flushSync } from "react-dom";
+
 import { GenericList } from "./GenericList";
 
 function App() {

--- a/src/Components/AppThemeProvider.js
+++ b/src/Components/AppThemeProvider.js
@@ -1,4 +1,6 @@
-import { CssBaseline, ThemeProvider } from "@mui/material";
+import CssBaseline from "@mui/material/CssBaseline";
+import ThemeProvider from "@mui/material/styles/ThemeProvider";
+
 import { useContext, useMemo } from "react";
 import AppSettingsContext from "./AppSettingsContext";
 import { createAppTheme } from "./theme";

--- a/src/Components/AvatarIcon.js
+++ b/src/Components/AvatarIcon.js
@@ -1,4 +1,7 @@
-import { Avatar, IconButton, useTheme } from "@mui/material";
+import Avatar from "@mui/material/Avatar";
+import IconButton from "@mui/material/IconButton";
+import useTheme from "@mui/material/styles/useTheme";
+
 import { useContext, useMemo } from "react";
 import { useAuthState } from "react-firebase-hooks/auth";
 import { LocalUserContext } from "./LocalUserContext";

--- a/src/Components/AvatarShelf.js
+++ b/src/Components/AvatarShelf.js
@@ -1,13 +1,10 @@
-import {
-  Box,
-  Grid,
-  IconButton,
-  Paper,
-  Skeleton,
-  Stack,
-  useMediaQuery,
-  useTheme,
-} from "@mui/material";
+import Grid from "@mui/material/Grid";
+import IconButton from "@mui/material/IconButton";
+import Paper from "@mui/material/Paper";
+import Stack from "@mui/material/Stack";
+import useMediaQuery from "@mui/material/useMediaQuery";
+import useTheme from "@mui/material/styles/useTheme";
+
 import { CaretLeft, CaretRight } from "phosphor-react";
 import { useState } from "react";
 import AvatarIcon from "./AvatarIcon";

--- a/src/Components/BreathingLogo.js
+++ b/src/Components/BreathingLogo.js
@@ -1,7 +1,6 @@
 /* eslint-disable */
 
-import { Container, Grid } from "@mui/material";
-import { Box, flexbox } from "@mui/system";
+import Box from "@mui/material/Box";
 import { useEffect } from "react";
 import { ReactComponent as SVG } from "../Styles/images/EdwardLogoAnimation.svg";
 

--- a/src/Components/ChooseAvatar.js
+++ b/src/Components/ChooseAvatar.js
@@ -1,4 +1,6 @@
-import { Typography, Button, Grid } from "@mui/material";
+import Typography from "@mui/material/Typography";
+import Button from "@mui/material/Button";
+
 import { useState } from "react";
 import { CaretDown } from "phosphor-react";
 

--- a/src/Components/DetailedView.js
+++ b/src/Components/DetailedView.js
@@ -1,20 +1,13 @@
-import {
-  alpha,
-  Box,
-  Button,
-  Chip,
-  Container,
-  FormControl,
-  Grid,
-  IconButton,
-  InputLabel,
-  MenuItem,
-  NativeSelect,
-  Select,
-  Tooltip,
-  Typography,
-  useTheme,
-} from "@mui/material";
+import Container from "@mui/material/Container";
+import Tooltip from "@mui/material/Tooltip";
+import Typography from "@mui/material/Typography";
+import Box from "@mui/material/Box";
+import Grid from "@mui/material/Grid";
+import IconButton from "@mui/material/IconButton";
+import alpha from "@mui/material/styles/getOverlayAlpha";
+import Button from "@mui/material/Button";
+import Chip from "@mui/material/Chip";
+import useTheme from "@mui/material/styles/useTheme";
 import { CaretDown, Minus, Play, Plus } from "phosphor-react";
 import { useContext, useEffect, useState } from "react";
 import { useAuthState } from "react-firebase-hooks/auth";

--- a/src/Components/DetailedViewGhost.js
+++ b/src/Components/DetailedViewGhost.js
@@ -1,4 +1,7 @@
-import { Box, Container, Grid, Skeleton } from "@mui/material";
+import Box from "@mui/material/Box";
+import Container from "@mui/material/Container";
+import Grid from "@mui/material/Grid";
+import Skeleton from "@mui/material/Skeleton";
 
 export default function DetailedViewGhost() {
   return (

--- a/src/Components/DropMenu.js
+++ b/src/Components/DropMenu.js
@@ -1,5 +1,4 @@
 import React, { useContext, useEffect, useMemo, useRef, useState } from "react";
-import Button from "@mui/material/Button";
 import ClickAwayListener from "@mui/material/ClickAwayListener";
 import Grow from "@mui/material/Grow";
 import Paper from "@mui/material/Paper";
@@ -7,28 +6,18 @@ import Popper from "@mui/material/Popper";
 import MenuItem from "@mui/material/MenuItem";
 import MenuList from "@mui/material/MenuList";
 import Stack from "@mui/material/Stack";
-import {
-  List,
-  Moon,
-  SignOut,
-  Sun,
-  User,
-  UserCircle,
-  UserCirclePlus,
-} from "phosphor-react";
+import Avatar from "@mui/material/Avatar";
+import ListItemAvatar from "@mui/material/ListItemAvatar";
+import ListItemButton from "@mui/material/ListItemButton";
+import ListItemIcon from "@mui/material/ListItemIcon";
+import ListItemText from "@mui/material/ListItemText";
+import useTheme from "@mui/material/styles/useTheme";
+import { Moon, SignOut, Sun, User, UserCirclePlus } from "phosphor-react";
 import { useNavigate } from "react-router-dom";
 import { auth, logout } from "./Firebase";
 import { LocalUserContext } from "./LocalUserContext";
 import { useAuthState } from "react-firebase-hooks/auth";
-import {
-  Avatar,
-  ListItem,
-  ListItemAvatar,
-  ListItemButton,
-  ListItemIcon,
-  ListItemText,
-} from "@mui/material";
-import { useTheme } from "@mui/material/styles";
+
 import AppSettingsContext from "./AppSettingsContext";
 import { getAvatarSrc } from "./Avatars";
 

--- a/src/Components/EdwardMLLogo.js
+++ b/src/Components/EdwardMLLogo.js
@@ -1,6 +1,6 @@
 import logo from "../Styles/images/logo.svg";
-import { useTheme } from "@mui/material/styles";
-import { Box } from "@mui/material";
+import useTheme from "@mui/material/styles/useTheme";
+import Box from "@mui/material/Box";
 
 export default function EdwardMLLogo() {
   const theme = useTheme();

--- a/src/Components/EmojiReactionChip.js
+++ b/src/Components/EmojiReactionChip.js
@@ -1,5 +1,6 @@
-import { Chip, useTheme } from "@mui/material";
-import { HandsClapping } from "phosphor-react";
+import Chip from "@mui/material/Chip";
+import useTheme from "@mui/material/styles/useTheme";
+
 import { useEffect, useState } from "react";
 import { useAuthState } from "react-firebase-hooks/auth";
 import { auth } from "./Firebase";

--- a/src/Components/ExpandableText.js
+++ b/src/Components/ExpandableText.js
@@ -1,4 +1,5 @@
-import { Box, Link } from "@mui/material";
+import Box from "@mui/material/Box";
+import Link from "@mui/material/Link";
 import { useMemo, useState } from "react";
 
 export default function ExpandableText({ text, sx }) {

--- a/src/Components/GenericList.js
+++ b/src/Components/GenericList.js
@@ -1,5 +1,6 @@
 import React, { useState, useContext } from "react";
-import { Box, Grid } from "@mui/material";
+import Box from "@mui/material/Box";
+import Grid from "@mui/material/Grid";
 import heart from "../Styles/images/favorite_border_black_24dp.svg";
 import frown from "../Styles/images/sentiment_dissatisfied_black_24dp.svg";
 import cancel from "../Styles/images/cancel_black_24dp.svg";

--- a/src/Components/GenreChips.js
+++ b/src/Components/GenreChips.js
@@ -1,15 +1,11 @@
-import {
-  Chip,
-  Grid,
-  IconButton,
-  Paper,
-  Stack,
-  useMediaQuery,
-  useTheme,
-} from "@mui/material";
-import { setPersistence } from "firebase/auth";
+import Stack from "@mui/material/Stack";
+import IconButton from "@mui/material/IconButton";
+import Chip from "@mui/material/Chip";
+import Paper from "@mui/material/Paper";
+import useMediaQuery from "@mui/material/useMediaQuery";
+import useTheme from "@mui/material/styles/useTheme";
 import { CaretLeft, CaretRight } from "phosphor-react";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 
 export default function GenreChips({ selectedGenre, setSelectedGenre }) {
   let genres = [

--- a/src/Components/Header.js
+++ b/src/Components/Header.js
@@ -1,13 +1,14 @@
 import "../Styles/Header.css";
 
 import { Link } from "react-router-dom";
-import { Container, Grid } from "@mui/material";
+import Container from "@mui/material/Container";
+import Grid from "@mui/material/Grid";
 
 import { useState } from "react";
 import TitleAutocomplete from "./TitleAutocomplete";
 import { MagnifyingGlass, House, User } from "phosphor-react";
 import DropMenu from "./DropMenu";
-import { useTheme } from "@mui/material/styles";
+import useTheme from "@mui/material/styles/useTheme";
 import EdwardMLLogo from "./EdwardMLLogo";
 import HeaderTab from "./HeaderTab";
 import { useAuthState } from "react-firebase-hooks/auth";

--- a/src/Components/HeaderTab.js
+++ b/src/Components/HeaderTab.js
@@ -1,10 +1,8 @@
-import {
-  Box,
-  IconButton,
-  Typography,
-  useMediaQuery,
-  useTheme,
-} from "@mui/material";
+import Box from "@mui/material/Box";
+import IconButton from "@mui/material/IconButton";
+import Typography from "@mui/material/Typography";
+import useMediaQuery from "@mui/material/useMediaQuery";
+import useTheme from "@mui/material/styles/useTheme";
 import { Link, useLocation, useNavigate } from "react-router-dom";
 
 export default function HeaderTab({

--- a/src/Components/Home.js
+++ b/src/Components/Home.js
@@ -1,6 +1,7 @@
 import "../Styles/App.css";
 
-import { Container, Button } from "@mui/material";
+import Container from "@mui/material/Container";
+import Button from "@mui/material/Button";
 import RefreshIcon from "@mui/icons-material/Refresh";
 import { useEffect, useState, useContext } from "react";
 import { LocalUserContext } from "./LocalUserContext";
@@ -9,7 +10,7 @@ import { auth } from "./Firebase";
 import { PopulateFromFirestore } from "./Firestore";
 import AnimeGrid from "./AnimeGrid";
 import ShelfTitle from "./ShelfTitle";
-import { Stack } from "@mui/system";
+import Stack from "@mui/material/Stack";
 import AnimeShelf from "./AnimeShelf";
 import {
   useAnimeHR,

--- a/src/Components/LandingPage.js
+++ b/src/Components/LandingPage.js
@@ -1,8 +1,13 @@
 import "../Styles/LandingPage.css";
 
-import { useTheme } from "@mui/material";
-import { Box, Button, Grid, Icon, Paper, Typography } from "@mui/material";
-import { Container } from "@mui/system";
+import useTheme from "@mui/material/styles/useTheme";
+import Container from "@mui/material/Container";
+import Box from "@mui/material/Box";
+import Grid from "@mui/material/Grid";
+import Button from "@mui/material/Button";
+import Icon from "@mui/material/Icon";
+import Paper from "@mui/material/Paper";
+import Typography from "@mui/material/Typography";
 import { Link } from "react-router-dom";
 import AnimeMosaic from "../Styles/images/animeMosaic2.opt.jpg";
 import BlackBackground from "../Styles/images/BlackBackground.svg";

--- a/src/Components/LandingPageHeader.js
+++ b/src/Components/LandingPageHeader.js
@@ -1,4 +1,8 @@
-import { Box, Button, Container, Grid, useTheme } from "@mui/material";
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import Container from "@mui/material/Container";
+import Grid from "@mui/material/Grid";
+import useTheme from "@mui/material/styles/useTheme";
 import { Link } from "react-router-dom";
 
 import logo from "../Styles/images/logo.svg";

--- a/src/Components/Login.js
+++ b/src/Components/Login.js
@@ -5,30 +5,24 @@ import {
   logInWithEmailAndPassword,
   signInWithGoogle,
   signInWithTwitter,
-  logInWithPhoneNumber,
-  logInAnon,
 } from "./Firebase";
 import { useAuthState } from "react-firebase-hooks/auth";
-import { getAuth, signInWithRedirect } from "firebase/auth";
-import { TwitterAuthProvider } from "firebase/auth";
 
 import "../Styles/Login.css";
-import { PopulateFromFirestore, SaveToFirestore } from "./Firestore";
+import { PopulateFromFirestore } from "./Firestore";
 
 import { LocalUserContext } from "./LocalUserContext";
-import {
-  Box,
-  Button,
-  Container,
-  Divider,
-  TextField,
-  Typography,
-  useTheme,
-} from "@mui/material";
+
+import Box from "@mui/material/Box";
+import Container from "@mui/material/Container";
+import Button from "@mui/material/Button";
+import Divider from "@mui/material/Divider";
+import TextField from "@mui/material/TextField";
+import Typography from "@mui/material/Typography";
+import useTheme from "@mui/material/styles/useTheme";
 
 import TwitterIcon from "@mui/icons-material/Twitter";
 import google from "../Styles/images/google.svg";
-import { User } from "phosphor-react";
 import EdwardMLLogo from "./EdwardMLLogo";
 
 export default function Login() {

--- a/src/Components/Logout.js
+++ b/src/Components/Logout.js
@@ -1,10 +1,13 @@
 import React from "react";
 import { Link } from "react-router-dom";
-import { Button, Container, Grid, Typography } from "@mui/material";
-import logo from "../Styles/images/logo.svg";
 import spike from "../Styles/images/spike-tile.png";
-import { useTheme } from "@mui/material/styles";
-import { Box } from "@mui/system";
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import Container from "@mui/material/Container";
+import Grid from "@mui/material/Grid";
+import Typography from "@mui/material/Typography";
+import useTheme from "@mui/material/styles/useTheme";
+
 import EdwardMLLogo from "./EdwardMLLogo";
 
 export default function Logout() {

--- a/src/Components/NoResultsImage.js
+++ b/src/Components/NoResultsImage.js
@@ -1,5 +1,5 @@
-import { Typography } from "@mui/material";
-import { Box } from "@mui/system";
+import Typography from "@mui/material/Typography";
+import Box from "@mui/material/Box";
 import Spike from "../Styles/images/distraughtSpike2.webp";
 
 export default function NoResultsImage({ noImage }) {

--- a/src/Components/NotFound404.js
+++ b/src/Components/NotFound404.js
@@ -1,16 +1,14 @@
-import {
-  Box,
-  Button,
-  Container,
-  Grid,
-  Paper,
-  Typography,
-  useTheme,
-} from "@mui/material";
+import Box from "@mui/material/Box";
+import Grid from "@mui/material/Grid";
+import Button from "@mui/material/Icon";
+import Container from "@mui/material/Container";
+import Paper from "@mui/material/Paper";
+import Typography from "@mui/material/Typography";
+import useTheme from "@mui/material/styles/useTheme";
 import EdwardMLLogo from "./EdwardMLLogo";
 import { Link, useLocation } from "react-router-dom";
 import EdGif from "../Styles/images/edGivingUp.gif";
-import { CaretLeft, House } from "phosphor-react";
+import { House } from "phosphor-react";
 
 export function NotFound404() {
   const theme = useTheme();

--- a/src/Components/Onboarding.js
+++ b/src/Components/Onboarding.js
@@ -9,14 +9,13 @@ import { LocalUserContext } from "./LocalUserContext";
 
 import { useAuthState } from "react-firebase-hooks/auth";
 import { auth } from "./Firebase";
-import { Button, Container, Typography } from "@mui/material";
-import { useTheme } from "@mui/material/styles";
+import Container from "@mui/material/Container";
+import Typography from "@mui/material/Typography";
+import useTheme from "@mui/material/styles/useTheme";
 
-import { SaveToFirestore } from "./Firestore";
 import OnboardingButton from "./OnboardingButton";
 import OnboardingAnimeGrid from "./OnboardingAnimeGrid";
 import OnboardingHeader from "./OnboardingHeader";
-import BreathingLogo from "./BreathingLogo";
 import CowboyBebop from "../Styles/images/onboarding/cowboybebop.jpg";
 import AttackOnTitan from "../Styles/images/onboarding/attackontitan.jpg";
 import Gintama from "../Styles/images/onboarding/gintama.jpg";

--- a/src/Components/OnboardingAnimeCard.js
+++ b/src/Components/OnboardingAnimeCard.js
@@ -1,4 +1,7 @@
-import { Box, Paper, Typography, useTheme } from "@mui/material";
+import Box from "@mui/material/Box";
+import Paper from "@mui/material/Paper";
+import Typography from "@mui/material/Typography";
+import useTheme from "@mui/material/styles/useTheme";
 import { ThumbsUp } from "phosphor-react";
 import useLikeState from "../Hooks/useLikeState";
 

--- a/src/Components/OnboardingAnimeGrid.js
+++ b/src/Components/OnboardingAnimeGrid.js
@@ -1,4 +1,5 @@
-import { Grid, Skeleton } from "@mui/material";
+import Skeleton from "@mui/material/Skeleton";
+import Grid from "@mui/material/Grid";
 import OnboardingAnimeCard from "./OnboardingAnimeCard";
 
 export default function OnboardingAnimeGrid({ items }) {

--- a/src/Components/OnboardingButton.js
+++ b/src/Components/OnboardingButton.js
@@ -1,9 +1,11 @@
-import { Button, Container, Grid } from "@mui/material";
+import Button from "@mui/material/Button";
+import Container from "@mui/material/Container";
+import Grid from "@mui/material/Grid";
+import useTheme from "@mui/material/styles/useTheme";
 import { SaveToFirestore } from "./Firestore";
 
 import { useAuthState } from "react-firebase-hooks/auth";
 import { auth } from "./Firebase";
-import { useTheme } from "@mui/material/styles";
 import { useContext } from "react";
 import { LocalUserContext } from "./LocalUserContext";
 import { Link } from "react-router-dom";

--- a/src/Components/OnboardingHeader.js
+++ b/src/Components/OnboardingHeader.js
@@ -1,5 +1,7 @@
-import { Box, Button, Grid, useTheme } from "@mui/material";
-import { Container } from "@mui/system";
+import Grid from "@mui/material/Grid";
+import Button from "@mui/material/Button";
+import Container from "@mui/material/Container";
+import useTheme from "@mui/material/styles/useTheme";
 import { Link } from "react-router-dom";
 import logo from "../Styles/images/logo.svg";
 

--- a/src/Components/Profile.js
+++ b/src/Components/Profile.js
@@ -1,6 +1,9 @@
 import "../Styles/Profile.css";
 
-import { Container, Grid, useMediaQuery, useTheme } from "@mui/material";
+import Grid from "@mui/material/Grid";
+import Container from "@mui/material/Container";
+import useMediaQuery from "@mui/material/useMediaQuery";
+import useTheme from "@mui/material/styles/useTheme";
 import { matchPath, useLocation, useParams } from "react-router-dom";
 import ProfileListPage from "./ProfileListPage";
 import ProfileMainPage from "./ProfileMainPage";

--- a/src/Components/ProfileListItem.js
+++ b/src/Components/ProfileListItem.js
@@ -1,12 +1,11 @@
-import {
-  Box,
-  IconButton,
-  ListItem,
-  ListItemAvatar,
-  ListItemButton,
-  ListItemText,
-  Tooltip,
-} from "@mui/material";
+import Box from "@mui/material/Box";
+import ListItemAvatar from "@mui/material/ListItemAvatar";
+import IconButton from "@mui/material/IconButton";
+import ListItem from "@mui/material/ListItem";
+import ListItemButton from "@mui/material/ListItemButton";
+import ListItemText from "@mui/material/ListItemText";
+import Tooltip from "@mui/material/Tooltip";
+
 import { X } from "phosphor-react";
 import { useNavigate } from "react-router-dom";
 

--- a/src/Components/ProfileListPage.js
+++ b/src/Components/ProfileListPage.js
@@ -1,4 +1,9 @@
-import { Box, IconButton, List, Tooltip, Typography } from "@mui/material";
+import Box from "@mui/material/Box";
+import IconButton from "@mui/material/IconButton";
+import List from "@mui/material/List";
+import Tooltip from "@mui/material/Tooltip";
+import Typography from "@mui/material/Typography";
+
 import { useConfirm } from "material-ui-confirm";
 import { CaretLeft, X } from "phosphor-react";
 import { useContext } from "react";

--- a/src/Components/ProfileListPageGhost.js
+++ b/src/Components/ProfileListPageGhost.js
@@ -1,4 +1,5 @@
-import { Box, Skeleton } from "@mui/material";
+import Box from "@mui/material/Box";
+import Skeleton from "@mui/material/Skeleton";
 
 export default function ProfileListPageGhost() {
   const rows = new Array(5).fill(0);

--- a/src/Components/ProfileMainPage.js
+++ b/src/Components/ProfileMainPage.js
@@ -1,4 +1,5 @@
-import { Grid, Typography } from "@mui/material";
+import Grid from "@mui/material/Grid";
+import Typography from "@mui/material/Typography";
 import NoResultsImage from "./NoResultsImage";
 import WatchlistTile from "./WatchlistTile";
 import { slugifyListName } from "../Util/ListUtil";

--- a/src/Components/ProfileMainPageGhost.js
+++ b/src/Components/ProfileMainPageGhost.js
@@ -1,4 +1,5 @@
-import { Grid, Skeleton } from "@mui/material";
+import Grid from "@mui/material/Grid";
+import Skeleton from "@mui/material/Skeleton";
 
 export default function ProfileMainPageGhost() {
   return (

--- a/src/Components/ProfileSidebar.js
+++ b/src/Components/ProfileSidebar.js
@@ -1,6 +1,7 @@
 import { useContext } from "react";
 
-import { Button } from "@mui/material";
+import Button from "@mui/material/Button";
+
 import { ArrowRight } from "phosphor-react";
 import { useNavigate } from "react-router-dom";
 import UserBio from "./UserBio";

--- a/src/Components/ProfileUserBanner.js
+++ b/src/Components/ProfileUserBanner.js
@@ -1,11 +1,9 @@
-import {
-  Avatar,
-  IconButton,
-  ListItemButton,
-  ListItemText,
-  Tooltip,
-} from "@mui/material";
-import { Box } from "@mui/system";
+import Avatar from "@mui/material/Avatar";
+import IconButton from "@mui/material/IconButton";
+import Tooltip from "@mui/material/Tooltip";
+import ListItemButton from "@mui/material/ListItemButton";
+import ListItemText from "@mui/material/ListItemText";
+import Box from "@mui/material/Box";
 import { Camera, X } from "phosphor-react";
 import { useContext, useMemo, useState } from "react";
 import { getAvatarSrc } from "./Avatars";

--- a/src/Components/ProfileUserBannerSmall.js
+++ b/src/Components/ProfileUserBannerSmall.js
@@ -1,4 +1,7 @@
-import { Avatar, Box, ListItemText } from "@mui/material";
+import Avatar from "@mui/material/Avatar";
+import ListItemText from "@mui/material/ListItemText";
+import Box from "@mui/material/Box";
+
 import { useContext, useMemo } from "react";
 import { Link } from "react-router-dom";
 import { getAvatarSrc } from "./Avatars";

--- a/src/Components/RecommendedList.js
+++ b/src/Components/RecommendedList.js
@@ -1,11 +1,11 @@
-import React, { useState, useContext, useEffect } from "react";
-import { Box, Grid } from "@mui/material";
+import React, { useContext, useEffect } from "react";
+import Grid from "@mui/material/Grid";
+
 import heart from "../Styles/images/favorite_border_black_24dp.svg";
 import frown from "../Styles/images/sentiment_dissatisfied_black_24dp.svg";
-import cancel from "../Styles/images/cancel_black_24dp.svg";
 
 import { useAuthState } from "react-firebase-hooks/auth";
-import { auth, db } from "./Firebase";
+import { auth } from "./Firebase";
 
 import { LocalUserContext } from "./LocalUserContext";
 import { SaveToFirestore } from "./Firestore";

--- a/src/Components/Register.js
+++ b/src/Components/Register.js
@@ -15,17 +15,16 @@ import {
 } from "./Firebase";
 import { SaveToFirestore } from "./Firestore";
 import { LocalUserContext } from "./LocalUserContext";
-import {
-  Button,
-  Container,
-  Divider,
-  TextField,
-  Typography,
-  useTheme,
-} from "@mui/material";
+
+import Container from "@mui/material/Container";
+import Divider from "@mui/material/Divider";
+import Button from "@mui/material/Button";
+import TextField from "@mui/material/TextField";
+import Typography from "@mui/material/Typography";
+import useTheme from "@mui/material/styles/useTheme";
 import TwitterIcon from "@mui/icons-material/Twitter";
 import { User } from "phosphor-react";
-import { Box } from "@mui/system";
+import Box from "@mui/material/Box";
 import google from "../Styles/images/google.svg";
 import * as Yup from "yup";
 import { yupResolver } from "@hookform/resolvers/yup";

--- a/src/Components/Reset.js
+++ b/src/Components/Reset.js
@@ -1,3 +1,5 @@
+import "../Styles/Reset.css";
+
 import React, { useEffect, useState } from "react";
 import { useAuthState } from "react-firebase-hooks/auth";
 import { useNavigate } from "react-router-dom";
@@ -7,17 +9,15 @@ import DialogActions from "@mui/material/DialogActions";
 import DialogContent from "@mui/material/DialogContent";
 import DialogContentText from "@mui/material/DialogContentText";
 import DialogTitle from "@mui/material/DialogTitle";
-import "../Styles/Reset.css";
-import {
-  Button,
-  Container,
-  Dialog,
-  Divider,
-  TextField,
-  Typography,
-  useTheme,
-} from "@mui/material";
+
 import logo from "../Styles/images/logo.svg";
+
+import Container from "@mui/material/Container";
+import Dialog from "@mui/material/Dialog";
+import Button from "@mui/material/Button";
+import Divider from "@mui/material/Divider";
+import TextField from "@mui/material/TextField";
+import useTheme from "@mui/material/styles/useTheme";
 
 export default function Reset() {
   const [email, setEmail] = useState("");

--- a/src/Components/Review.js
+++ b/src/Components/Review.js
@@ -1,16 +1,12 @@
-import {
-  Avatar,
-  Box,
-  Chip,
-  Divider,
-  Grid,
-  IconButton,
-  Paper,
-  Rating,
-  Tooltip,
-  Typography,
-  useTheme,
-} from "@mui/material";
+import Tooltip from "@mui/material/Tooltip";
+import Typography from "@mui/material/Typography";
+import Box from "@mui/material/Box";
+import Grid from "@mui/material/Grid";
+import IconButton from "@mui/material/IconButton";
+import Avatar from "@mui/material/Avatar";
+import Paper from "@mui/material/Paper";
+import Rating from "@mui/material/Rating";
+import useTheme from "@mui/material/styles/useTheme";
 import { useConfirm } from "material-ui-confirm";
 import format from "date-fns/format";
 import fromUnixTime from "date-fns/fromUnixTime";

--- a/src/Components/ReviewFilterDropMenu.js
+++ b/src/Components/ReviewFilterDropMenu.js
@@ -8,7 +8,8 @@ import MenuItem from "@mui/material/MenuItem";
 import MenuList from "@mui/material/MenuList";
 import Stack from "@mui/material/Stack";
 import { FunnelSimple } from "phosphor-react";
-import { useMediaQuery, useTheme } from "@mui/material";
+import useMediaQuery from "@mui/material/useMediaQuery";
+import useTheme from "@mui/material/styles/useTheme";
 
 export default function ReviewFilterDropMenu({
   setLastVisible,

--- a/src/Components/ReviewForm.js
+++ b/src/Components/ReviewForm.js
@@ -1,13 +1,10 @@
-import { useTheme } from "@emotion/react";
-import {
-  Avatar,
-  Box,
-  Button,
-  Paper,
-  Rating,
-  TextField,
-  Typography,
-} from "@mui/material";
+import useTheme from "@mui/material/styles/useTheme";
+import Box from "@mui/material/Box";
+import Avatar from "@mui/material/Avatar";
+import Button from "@mui/material/Button";
+import Rating from "@mui/material/Rating";
+import Paper from "@mui/material/Paper";
+import TextField from "@mui/material/TextField";
 import { useContext, useEffect, useState } from "react";
 import { useAuthState } from "react-firebase-hooks/auth";
 import { auth } from "./Firebase";
@@ -15,7 +12,7 @@ import { LocalUserContext } from "./LocalUserContext";
 import * as Yup from "yup";
 import { yupResolver } from "@hookform/resolvers/yup";
 import { useForm } from "react-hook-form";
-import { Fire, Heart } from "phosphor-react";
+import { Heart } from "phosphor-react";
 import {
   GetPaginatedReviewsFromFirestore,
   PopulateReviewsFromFirestore,

--- a/src/Components/Sandbox.js
+++ b/src/Components/Sandbox.js
@@ -1,4 +1,5 @@
-import { Box, Button } from "@mui/material";
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
 import Container from "@mui/material/Container";
 import { useEffect, useState } from "react";
 import LikeButtons from "./LikeButtons";

--- a/src/Components/ScoreBars.js
+++ b/src/Components/ScoreBars.js
@@ -1,4 +1,6 @@
-import { Box, LinearProgress, Typography } from "@mui/material";
+import Box from "@mui/material/Box";
+import LinearProgress from "@mui/material/LinearProgress";
+import Typography from "@mui/material/Typography";
 import { useEffect, useState } from "react";
 
 export default function ScoreBars({ scores }) {

--- a/src/Components/Search.js
+++ b/src/Components/Search.js
@@ -1,26 +1,18 @@
 import "../Styles/Search.css";
 import { useNavigate, useLocation } from "react-router-dom";
 import { useState, useEffect, useContext } from "react";
-import { GenericList } from "./GenericList";
-import {
-  Avatar,
-  Box,
-  Divider,
-  IconButton,
-  List,
-  ListItem,
-  ListItemAvatar,
-  ListItemButton,
-  ListItemText,
-  Paper,
-  Typography,
-  useMediaQuery,
-  useTheme,
-} from "@mui/material";
-import DeleteIcon from "@mui/icons-material/Delete";
-import Link from "@mui/material";
-import TitleAutocomplete from "./TitleAutocomplete";
-import { Container } from "@mui/system";
+import Box from "@mui/material/Box";
+import ListItemAvatar from "@mui/material/ListItemAvatar";
+import Divider from "@mui/material/Divider";
+import Avatar from "@mui/material/Avatar";
+import ListItemButton from "@mui/material/ListItemButton";
+import ListItemText from "@mui/material/ListItemText";
+import Typography from "@mui/material/Typography";
+import Paper from "@mui/material/Paper";
+import useMediaQuery from "@mui/material/useMediaQuery";
+import useTheme from "@mui/material/styles/useTheme";
+import Container from "@mui/material/Container";
+
 import { useAuthState } from "react-firebase-hooks/auth";
 import { auth } from "./Firebase";
 import { PopulateFromFirestore } from "./Firestore";

--- a/src/Components/ShelfTitle.js
+++ b/src/Components/ShelfTitle.js
@@ -1,4 +1,5 @@
-import { Container, useTheme } from "@mui/material";
+import Container from "@mui/material/Container";
+import useTheme from "@mui/material/styles/useTheme";
 import GenreChips from "./GenreChips";
 
 export default function ShelfTitle({ selectedGenre, setSelectedGenre, title }) {

--- a/src/Components/SkipOnboardDialog.js
+++ b/src/Components/SkipOnboardDialog.js
@@ -2,11 +2,10 @@ import * as React from "react";
 import Button from "@mui/material/Button";
 import Dialog from "@mui/material/Dialog";
 import DialogActions from "@mui/material/DialogActions";
-import DialogContent from "@mui/material/DialogContent";
-import DialogContentText from "@mui/material/DialogContentText";
 import DialogTitle from "@mui/material/DialogTitle";
 import { useNavigate } from "react-router-dom";
-import { Divider, useTheme } from "@mui/material";
+import Divider from "@mui/material//Divider";
+import useTheme from "@mui/material/styles/useTheme";
 
 export default function SkipOnboardDialog() {
   const navigate = useNavigate();

--- a/src/Components/TitleAutocomplete.js
+++ b/src/Components/TitleAutocomplete.js
@@ -1,12 +1,10 @@
 import { async } from "@firebase/util";
-import {
-  Autocomplete,
-  Box,
-  IconButton,
-  InputAdornment,
-  TextField,
-  Tooltip,
-} from "@mui/material";
+import Box from "@mui/material/Box";
+import Autocomplete from "@mui/material/Autocomplete";
+import IconButton from "@mui/material/IconButton";
+import InputAdornment from "@mui/material/InputAdornment";
+import TextField from "@mui/material/TextField";
+import Tooltip from "@mui/material/Tooltip";
 import { useState, useEffect, useRef } from "react";
 import { APISearch } from "./APICalls";
 import { useNavigate } from "react-router-dom";

--- a/src/Components/Top8List.js
+++ b/src/Components/Top8List.js
@@ -1,11 +1,9 @@
-import {
-  IconButton,
-  ListItemAvatar,
-  ListItemButton,
-  Typography,
-  useTheme,
-} from "@mui/material";
-import { Box } from "@mui/system";
+import ListItemAvatar from "@mui/material/ListItemAvatar";
+import IconButton from "@mui/material/IconButton";
+import ListItemButton from "@mui/material/ListItemButton";
+import Typography from "@mui/material/Typography";
+import Box from "@mui/material/Box";
+import useTheme from "@mui/material/styles/useTheme";
 import { X } from "phosphor-react";
 import { useContext } from "react";
 import { useNavigate } from "react-router-dom";

--- a/src/Components/UrlButtons.js
+++ b/src/Components/UrlButtons.js
@@ -1,4 +1,6 @@
-import { Box, IconButton, Tooltip, Typography } from "@mui/material";
+import Box from "@mui/material/Box";
+import IconButton from "@mui/material/IconButton";
+import Typography from "@mui/material/Typography";
 import { Fragment } from "react";
 import crunchyroll from "../Styles/images/crunchyroll.png";
 import funimation from "../Styles/images/funimation.png";

--- a/src/Components/UserBio.js
+++ b/src/Components/UserBio.js
@@ -1,7 +1,8 @@
 import { useContext, useState } from "react";
-import { Button, TextField, Typography } from "@mui/material";
-
-import { Box } from "@mui/system";
+import Box from "@mui/material/Box";
+import TextField from "@mui/material/TextField";
+import Typography from "@mui/material/Typography";
+import Button from "@mui/material/Button";
 import ProfilePageContext from "./ProfilePageContext";
 
 export default function UserBio() {

--- a/src/Components/WatchlistTile.js
+++ b/src/Components/WatchlistTile.js
@@ -1,4 +1,9 @@
-import { alpha, Box, Grid, Typography, useTheme } from "@mui/material";
+import Box from "@mui/material/Box";
+import Grid from "@mui/material/Grid";
+import alpha from "@mui/material/styles/getOverlayAlpha";
+import Typography from "@mui/material/Typography";
+import useTheme from "@mui/material/styles/useTheme";
+
 import { Link } from "react-router-dom";
 import NoResultsImage from "./NoResultsImage";
 

--- a/src/Components/YoutubeModalProvider.js
+++ b/src/Components/YoutubeModalProvider.js
@@ -1,4 +1,5 @@
-import { Box, Modal } from "@mui/material";
+import Box from "@mui/material/Box";
+import Modal from "@mui/material/Modal";
 import { useState } from "react";
 import YoutubeModalContext from "./YoutubeModalContext";
 

--- a/src/Components/theme.js
+++ b/src/Components/theme.js
@@ -1,4 +1,5 @@
-import { alpha, createTheme } from "@mui/material/styles";
+import createTheme from "@mui/material/styles/createTheme";
+import alpha from "@mui/material/styles/getOverlayAlpha";
 
 export function createAppTheme(darkMode) {
   // A custom theme for this app


### PR DESCRIPTION
Replaces all top-level imports of MUI with path imports to avoid pulling in unused modules and reduce build size.

`// 🚀 Fast`
`import Button from '@mui/material/Button';`
`import TextField from '@mui/material/TextField';`

`// 😭 Slow;`
`import { Button, TextField } from '@mui/material';`
