### PR TITLE
Tighten margin of Data From Edward on mobile

### DIFF
--- a/src/Components/DetailedView.js
+++ b/src/Components/DetailedView.js
@@ -255,7 +255,7 @@ export default function DetailedView() {
               item
               xs={12}
               sx={{
-                padding: "32px 32px",
+                padding: { xs: 2, md: 3 },
                 background: theme.palette.custom.gradientCardBg,
                 borderRadius: "16px",
               }}


### PR DESCRIPTION
Was testing the site out more on mobile, and this was bugging me -- way too much margin on this box when on a phone screen.  I've reduced it to match other boxes lie top8, the watchlist cards, etc.