### PR TITLE
Fix invalid tabIndex value

### DIFF
--- a/src/Components/HeaderTab.js
+++ b/src/Components/HeaderTab.js
@@ -64,7 +64,7 @@ export default function HeaderTab({
   return (
     <Link to={path} onKeyDown={onKeyDown}>
       {smallDevice ? (
-        <IconButton tabIndex="-1" sx={iconStyle} onClick={internalOnClick}>
+        <IconButton tabIndex={-1} sx={iconStyle} onClick={internalOnClick}>
           {icon}
         </IconButton>
       ) : (


### PR DESCRIPTION
Don't know how that got in there!  React complains like so:
```
react_devtools_backend.js:2655 Warning: Failed prop type: Invalid prop `tabIndex` of type `string` supplied to `ForwardRef(ButtonBase)`, expected `number`.
```