### PR TITLE
Improve avatar shelf scrolling on slow connections

### DIFF
--- a/src/Components/AvatarIcon.js
+++ b/src/Components/AvatarIcon.js
@@ -9,7 +9,7 @@ import { auth } from "./Firebase";
 import { SaveToFirestore } from "./Firestore";
 import { getAvatarSrc } from "./Avatars";
 
-export default function AvatarIcon({ avatar, index }) {
+export default function AvatarIcon({ avatar }) {
   const [localUser, setLocalUser] = useContext(LocalUserContext);
   const [user, loading, error] = useAuthState(auth);
   const theme = useTheme();
@@ -25,7 +25,6 @@ export default function AvatarIcon({ avatar, index }) {
 
   return (
     <IconButton
-      key={index}
       onClick={(e) => {
         selectAvatar(avatar);
       }}
@@ -40,7 +39,14 @@ export default function AvatarIcon({ avatar, index }) {
         },
       }}
     >
-      <Avatar sx={{ width: "80px", height: "80px" }} src={avatarSrc}></Avatar>
+      <Avatar
+        sx={{
+          width: "80px",
+          height: "80px",
+          backgroundColor: theme.palette.divider,
+        }}
+        src={avatarSrc}
+      ></Avatar>
     </IconButton>
   );
 }

--- a/src/Components/AvatarShelf.js
+++ b/src/Components/AvatarShelf.js
@@ -85,6 +85,7 @@ export default function AvatarShelf({ items }) {
       <Grid container spacing={2} columns={columns}>
         {currentItems.map((avatar, index) => (
           <AvatarIcon
+            key={avatar}
             avatar={avatar}
             onChangeSelected={(v) => onChangeSelected(index, v)}
           />


### PR DESCRIPTION
This change:
- Adds a key to the AvatarIcon, which react lies.  I used the avatar name as the key so that new components will be instantiated on scroll.  Otherwise, the old image will still show while the new image is loading in, making scrolling more confusing.
- Adds a background color to the avatar image itself, which acts as a placeholder while the avatar image is being loaded in.
- Removes an unused prop and key value from inside AvatarIcon.