### PR TITLE
Update alpha imports to mui/system/colorManipulator

### DIFF
--- a/src/Components/DetailedView.js
+++ b/src/Components/DetailedView.js
@@ -4,7 +4,7 @@ import Typography from "@mui/material/Typography";
 import Box from "@mui/material/Box";
 import Grid from "@mui/material/Grid";
 import IconButton from "@mui/material/IconButton";
-import alpha from "@mui/material/styles/getOverlayAlpha";
+import { alpha } from "@mui/system/colorManipulator";
 import Button from "@mui/material/Button";
 import Chip from "@mui/material/Chip";
 import useTheme from "@mui/material/styles/useTheme";

--- a/src/Components/WatchlistTile.js
+++ b/src/Components/WatchlistTile.js
@@ -1,6 +1,6 @@
 import Box from "@mui/material/Box";
 import Grid from "@mui/material/Grid";
-import alpha from "@mui/material/styles/getOverlayAlpha";
+import { alpha } from "@mui/system/colorManipulator";
 import Typography from "@mui/material/Typography";
 import useTheme from "@mui/material/styles/useTheme";
 

--- a/src/Components/theme.js
+++ b/src/Components/theme.js
@@ -1,5 +1,5 @@
 import createTheme from "@mui/material/styles/createTheme";
-import alpha from "@mui/material/styles/getOverlayAlpha";
+import { alpha } from "@mui/system/colorManipulator";
 
 export function createAppTheme(darkMode) {
   // A custom theme for this app


### PR DESCRIPTION
Looks like there are quite a few alpha-y functions in mui, but the one we had been using for setting alpha values on color hexes is from `@mui/system/colorManipulator`.  Updating to this one fixes some stuff like the cool hover effect on the cover on DetailedView.