### PR TITLE
Add custom placeholders for ClickAndEdit

### DIFF
--- a/src/Components/ClickAndEdit.js
+++ b/src/Components/ClickAndEdit.js
@@ -2,8 +2,19 @@ import { useState } from "react";
 import Box from "@mui/material/Box";
 import TextField from "@mui/material/TextField";
 import Button from "@mui/material/Button";
+import useTheme from "@mui/material/styles/useTheme";
 
-export default function ClickAndEdit({ data, canEdit, onSave, ml }) {
+export default function ClickAndEdit({
+  data,
+  placeholder,
+  canEdit,
+  onSave,
+  ml,
+}) {
+  placeholder = placeholder ?? "Enter some text...";
+
+  const theme = useTheme();
+
   const [editDesc, setEditDesc] = useState(false);
   const [editedDesc, setEditedDesc] = useState(data);
 
@@ -22,6 +33,7 @@ export default function ClickAndEdit({ data, canEdit, onSave, ml }) {
           sx={{
             fontFamily: "interMedium",
             fontSize: "1rem",
+            color: data?.length > 0 ? "unset" : theme.palette.text.secondary,
             pb: 1,
             pl: 0,
             ml: ml ? 6 : 0,
@@ -29,7 +41,7 @@ export default function ClickAndEdit({ data, canEdit, onSave, ml }) {
           }}
           onClick={canEdit ? handleDescToggle : undefined}
         >
-          {data?.length > 0 ? data : "Tell us a bit about this list..."}
+          {data?.length > 0 ? data : canEdit ? placeholder : ""}
         </Box>
       ) : (
         <div
@@ -46,7 +58,7 @@ export default function ClickAndEdit({ data, canEdit, onSave, ml }) {
             variant="filled"
             autoComplete="off"
             color="text"
-            placeholder="Tell us a bit about this list..."
+            placeholder={placeholder}
             autoFocus
             multiline
             value={editedDesc}

--- a/src/Components/ProfileListPage.js
+++ b/src/Components/ProfileListPage.js
@@ -52,9 +52,6 @@ export default function ProfileListPage() {
   let listHasDesc = false;
   let showSuggestions = false;
 
-  //Extracts index from <ClickAndEdit/>
-  const onDescSave = (newDesc) => updateListDesc(newDesc, index);
-
   if (listId.toLowerCase() === "likes") {
     items = profile.likes;
     name = "Likes";
@@ -77,6 +74,9 @@ export default function ProfileListPage() {
     canDelete = true;
     showSuggestions = true;
   }
+
+  // Extracts index from <ClickAndEdit/>.
+  const onDescSave = (newDesc) => updateListDesc(newDesc, index);
 
   // Removes item at `index` from this list.
   const onRemove = (index) => {
@@ -167,6 +167,7 @@ export default function ProfileListPage() {
           canEdit={canEdit}
           onSave={onDescSave}
           ml={true}
+          placeholder={"Tell us a bit about this list..."}
         />
       )}
       {/* Items */}

--- a/src/Components/ProfileSidebar.js
+++ b/src/Components/ProfileSidebar.js
@@ -49,7 +49,8 @@ export default function ProfileSidebar({ hideDetails }) {
           <ClickAndEdit
             data={profile?.bio}
             canEdit={isOwnProfile}
-            update={updateBio}
+            onSave={updateBio}
+            placeholder={"Tell us a bit about yourself..."}
           />
 
           <Top8List />


### PR DESCRIPTION
This change:
- Allows for placeholders to be specified for `ClickAndEdit.`. This fixes an issue where bios say "Tell us a bit about this list..." when empty.
- Fixes an issue where `onSave` wasn't specified for bios.
- Provides a lighter text color for the placeholder text to better disambiguate it from an actual bio/description/etc.
- Doesn't show any placeholder text if the text is not editable (so the user doesn't see "Tell us about yourself..." on another user's bio page, etc.)