### PR TITLE
Add a subtitle to ProfileListPage

### DIFF
--- a/src/Components/ProfileListPage.js
+++ b/src/Components/ProfileListPage.js
@@ -132,6 +132,11 @@ export default function ProfileListPage() {
     marginBottom: "12px",
   };
 
+  const subtitleStyle = {
+    fontFamily: "interSemiBold",
+    fontSize: "16px",
+  };
+
   return (
     <Box>
       {/* Header */}
@@ -152,8 +157,8 @@ export default function ProfileListPage() {
           <Typography variant="h3" sx={{ ...headStyle, margin: 0 }}>
             {name}
           </Typography>
-          <Typography variant="body1" sx={{ fontFamily: "interSemiBold" }}>
-            {getBylineText(typeName, items)}
+          <Typography variant="body1" sx={subtitleStyle}>
+            {getSubtitleText(typeName, items)}
           </Typography>
         </Box>
         {canEdit && canDelete && (
@@ -228,7 +233,7 @@ function findListWithSlug(lists, slug) {
   return lists.find((list) => slugifyListName(list.name) === slug);
 }
 
-function getBylineText(typeName, items) {
+function getSubtitleText(typeName, items) {
   const strings = [];
   strings.push(typeName);
   strings.push(getItemsText(items));

--- a/src/Components/ProfileListPage.js
+++ b/src/Components/ProfileListPage.js
@@ -46,6 +46,7 @@ export default function ProfileListPage() {
   let name = "";
   let desc = "";
   let index = null;
+  let typeName = "";
   let updateFn;
   let deleteFn;
   let canDelete = false;
@@ -58,10 +59,12 @@ export default function ProfileListPage() {
   if (listId.toLowerCase() === "likes") {
     items = profile.likes;
     name = "Likes";
+    typeName = "Watch History";
     updateFn = (newItems) => updateLikes(newItems);
   } else if (listId.toLowerCase() === "dislikes") {
     items = profile.dislikes;
     name = "Dislikes";
+    typeName = "Watch History";
     updateFn = (newItems) => updateDislikes(newItems);
   } else if (findListWithSlug(profile.lists, listId)) {
     listHasDesc = true;
@@ -70,6 +73,7 @@ export default function ProfileListPage() {
     index = profile.lists.indexOf(list);
     items = list.anime;
     name = list.name;
+    typeName = "Watchlist";
     desc = list.desc;
     updateFn = (newItems) =>
       updateList(index, { ...list, anime: newItems, desc: desc });
@@ -144,9 +148,14 @@ export default function ProfileListPage() {
             <CaretLeft />
           </IconButton>
         </Link>
-        <Typography variant="h3" sx={{ ...headStyle, margin: 0, flexGrow: 1 }}>
-          {name}
-        </Typography>
+        <Box sx={{ display: "flex", flexDirection: "column", flexGrow: 1 }}>
+          <Typography variant="h3" sx={{ ...headStyle, margin: 0 }}>
+            {name}
+          </Typography>
+          <Typography variant="body1" sx={{ fontFamily: "interSemiBold" }}>
+            {getBylineText(typeName, items)}
+          </Typography>
+        </Box>
         {canEdit && canDelete && (
           <Tooltip title="Delete list">
             <IconButton
@@ -217,4 +226,23 @@ export default function ProfileListPage() {
 
 function findListWithSlug(lists, slug) {
   return lists.find((list) => slugifyListName(list.name) === slug);
+}
+
+function getBylineText(typeName, items) {
+  const strings = [];
+  strings.push(typeName);
+  strings.push(getItemsText(items));
+  return strings.join(" • ");
+}
+
+function getItemsText(items) {
+  if (!items || !items.length) {
+    return "No items";
+  }
+
+  if (items.length == 1) {
+    return "1 item";
+  }
+
+  return `${items.length} items`;
 }

--- a/src/Components/WatchlistTile.js
+++ b/src/Components/WatchlistTile.js
@@ -47,7 +47,7 @@ export default function WatchlistTile({ userId, listId, name, items }) {
               marginLeft: "8px",
             }}
           >
-            {items?.length ?? "0"} {items?.length === 1 ? "video" : "videos"}
+            {items?.length ?? "0"} {items?.length === 1 ? "item" : "items"}
           </Typography>
         </Box>
         <Grid container columnSpacing={1}>


### PR DESCRIPTION
It currently has the type of list ("Watchlist", "Watch History" for likes/dislikes) and the number of items in the list. I figure it could be extended to have the number of likes or saves, if we let people like or save watchlists, and other stuff like the top genres in the lists or something. Lmk if you like this idea, we don't have to go with it if it feels redundant or clutter-y.  I do feel like it helps to explain what the page is a bit more, especially if someone lands on the page directly.