### PR TITLE
Make link around ProfileUserBannerSmall fit content

### DIFF
--- a/src/Components/ProfileUserBannerSmall.js
+++ b/src/Components/ProfileUserBannerSmall.js
@@ -17,7 +17,7 @@ export default function ProfileUserBannerSmall() {
   );
 
   return (
-    <Link to={`/profile/${profileUserId}`}>
+    <Link to={`/profile/${profileUserId}`} style={{ display: "inline-block" }}>
       <Box
         sx={{
           display: "flex",


### PR DESCRIPTION
Before it was displaying as 'block' and so it would expand to cover the whole available width, not just the content.