### PR TITLE
Fixes routing behavior

### DIFF
--- a/src/Components/DropMenu.js
+++ b/src/Components/DropMenu.js
@@ -86,6 +86,7 @@ export default function DropMenu() {
   }
 
   async function sendToLogout(e) {
+    navigate("/logout");
     await logout();
     setLocalUser({
       likes: [],
@@ -97,7 +98,6 @@ export default function DropMenu() {
       reviews: [],
     });
     handleClose(e);
-    navigate("/logout");
   }
 
   function toggleDarkMode() {

--- a/src/Components/Firebase.js
+++ b/src/Components/Firebase.js
@@ -186,7 +186,6 @@ export const logInAnon = async () => {
   try {
     const res = await signInAnonymously(auth);
     const user = res.user;
-    console.log(user);
     const q = query(collection(db, "users"), where("uid", "==", user.uid));
     const docs = await getDocs(q);
     if (docs.docs.length === 0) {

--- a/src/Components/Login.js
+++ b/src/Components/Login.js
@@ -61,7 +61,9 @@ export default function Login() {
     <div className="login">
       <Container maxWidth="lg">
         <div className="welcomeBanner">
-          <EdwardMLLogo />
+          <Link to="/">
+            <EdwardMLLogo />
+          </Link>
         </div>
       </Container>
       <Container

--- a/src/Components/Logout.js
+++ b/src/Components/Logout.js
@@ -32,7 +32,7 @@ export default function Logout() {
       >
         <Grid item md={9.5} sm={9} xs={9}>
           <div className="logo">
-            <Link to="/login" style={{ display: "flex" }}>
+            <Link to="/" style={{ display: "flex" }}>
               <EdwardMLLogo />
             </Link>
           </div>

--- a/src/Components/Logout.js
+++ b/src/Components/Logout.js
@@ -32,7 +32,7 @@ export default function Logout() {
       >
         <Grid item md={9.5} sm={9} xs={9}>
           <div className="logo">
-            <Link to="/home" style={{ display: "flex" }}>
+            <Link to="/login" style={{ display: "flex" }}>
               <EdwardMLLogo />
             </Link>
           </div>

--- a/src/Components/Register.js
+++ b/src/Components/Register.js
@@ -101,7 +101,9 @@ export default function Register() {
     <div className="register">
       <Container maxWidth="lg">
         <div className="welcomeBanner">
-          <EdwardMLLogo />
+          <Link to="/">
+            <EdwardMLLogo />
+          </Link>
         </div>
       </Container>
       {/* *******************Start of Registration Block************************** */}

--- a/src/Components/Reset.js
+++ b/src/Components/Reset.js
@@ -90,7 +90,7 @@ export default function Reset() {
           </DialogActions>
         </Dialog>
         <div className="welcomeBanner">
-          <Link to="/login">
+          <Link to="/">
             <EdwardMLLogo />
           </Link>
         </div>

--- a/src/Components/Reset.js
+++ b/src/Components/Reset.js
@@ -90,7 +90,7 @@ export default function Reset() {
           </DialogActions>
         </Dialog>
         <div className="welcomeBanner">
-          <Link to="/home">
+          <Link to="/login">
             <EdwardMLLogo />
           </Link>
         </div>


### PR DESCRIPTION
-Sends user to /login when clicking EdwardML logo from 'noHeaderRoutes' so it doesn't create a new guest account on accident. -Fixes bug where upon logging out, a guest account would get created as soon as the user was logged out of Firebase due to the sequencing of log out events temporarily satisfying RouterHelper's useEffect (!loading && !user && headerMatch).