### PR TITLE
Fix colors and clicking on like buttons

### DIFF
--- a/src/Components/AnimeCard.js
+++ b/src/Components/AnimeCard.js
@@ -84,7 +84,7 @@ export default function AnimeCard({ anime, large, onChangeSelected }) {
               {anime.display_name}
             </Typography>
             <Box sx={{ display: "flex", justifyContent: "center" }}>
-              <LikeButtons anime={anime} />
+              <LikeButtons anime={anime} selected={true} />
             </Box>
           </Box>
         </Box>

--- a/src/Components/DislikeButton.js
+++ b/src/Components/DislikeButton.js
@@ -8,6 +8,7 @@ export default function DislikeButton({ anime, variant, selected }) {
 
   const onClick = (e) => {
     setDisliked(!disliked);
+    e.preventDefault();
     e.stopPropagation();
   };
   const disabled = !anime;

--- a/src/Components/LikeButton.js
+++ b/src/Components/LikeButton.js
@@ -8,6 +8,7 @@ export default function LikeButton({ anime, variant, selected }) {
 
   const onClick = (e) => {
     setLiked(!liked);
+    e.preventDefault();
     e.stopPropagation();
   };
   const disabled = !anime;


### PR DESCRIPTION
At head right now, like buttons on AnimeCards don't have a `selected` value passed in, so their icons are all background-colored.  Also, I noticed clicking on the like/dislike buttons on AnimeCards also navigates to the detail page, so I added back the `e.preventDefault()` to their click handlers.  The 'Add' button already has this, so it was still working and didn't need it.