### PR TITLE
Move 'back' button up from beside title to beside avatar

### DIFF
--- a/src/Components/BackButton.js
+++ b/src/Components/BackButton.js
@@ -7,7 +7,7 @@ export default function BackButton({ sx }) {
 
   const onClick = (e) => {
     navigate(-1);
-    e.stopPropogation();
+    e.stopPropagation();
   };
 
   return (

--- a/src/Components/BackButton.js
+++ b/src/Components/BackButton.js
@@ -1,0 +1,18 @@
+import IconButton from "@mui/material/IconButton";
+import { CaretLeft } from "phosphor-react";
+import { useNavigate } from "react-router-dom";
+
+export default function BackButton({ sx }) {
+  const navigate = useNavigate();
+
+  const onClick = (e) => {
+    navigate(-1);
+    e.stopPropogation();
+  };
+
+  return (
+    <IconButton color="inherit" sx={sx} onClick={onClick}>
+      <CaretLeft />
+    </IconButton>
+  );
+}

--- a/src/Components/ClickAndEdit.js
+++ b/src/Components/ClickAndEdit.js
@@ -9,7 +9,6 @@ export default function ClickAndEdit({
   placeholder,
   isListOwner,
   onSave,
-  ml,
 }) {
   placeholder = placeholder ?? "Enter some text...";
 
@@ -36,7 +35,7 @@ export default function ClickAndEdit({
             color: data?.length > 0 ? "unset" : theme.palette.text.secondary,
             pb: 1,
             pl: 0,
-            ml: ml ? 6 : 0,
+            ml: 0,
             cursor: isListOwner ? "pointer" : "unset",
           }}
           onClick={isListOwner ? handleDescToggle : undefined}

--- a/src/Components/Profile.js
+++ b/src/Components/Profile.js
@@ -1,5 +1,6 @@
 import "../Styles/Profile.css";
 
+import Box from "@mui/material/Box";
 import Grid from "@mui/material/Grid";
 import Container from "@mui/material/Container";
 import useMediaQuery from "@mui/material/useMediaQuery";
@@ -9,6 +10,7 @@ import ProfileListPage from "./ProfileListPage";
 import ProfileMainPage from "./ProfileMainPage";
 import { useContext, useEffect } from "react";
 import { useAuthState } from "react-firebase-hooks/auth";
+import BackButton from "./BackButton";
 import { PopulateFromFirestore } from "./Firestore";
 import { auth } from "./Firebase";
 import ProfilePageContextProvider from "./ProfilePageContextProvider";
@@ -44,7 +46,14 @@ export default function Profile() {
       <Container maxWidth="lg">
         <Grid container sx={{ paddingTop: { xs: "25px", md: "50px" } }}>
           <Grid item xs={12}>
-            {isListPage ? <ProfileUserBannerSmall /> : <ProfileUserBanner />}
+            {isListPage ? (
+              <Box sx={{ display: "flex", alignItems: "center" }}>
+                <BackButton sx={{ flexShrink: 0, mr: 1 }} />
+                <ProfileUserBannerSmall />
+              </Box>
+            ) : (
+              <ProfileUserBanner />
+            )}
           </Grid>
           <Grid item xs={12}>
             {isListPage ? <ProfileListPage /> : <ProfileMainPage />}

--- a/src/Components/ProfileListPage.js
+++ b/src/Components/ProfileListPage.js
@@ -148,11 +148,6 @@ export default function ProfileListPage() {
           marginBottom: "8px",
         }}
       >
-        <Link to={`/profile/${userId}`}>
-          <IconButton color="inherit" sx={{ marginRight: "8px" }}>
-            <CaretLeft />
-          </IconButton>
-        </Link>
         <Box sx={{ display: "flex", flexDirection: "column", flexGrow: 1 }}>
           <Typography variant="h3" sx={{ ...headStyle, margin: 0 }}>
             {name}
@@ -172,7 +167,6 @@ export default function ProfileListPage() {
           data={desc}
           isListOwner={isListOwner}
           onSave={onDescSave}
-          ml={true}
           placeholder={"Tell us a bit about this list..."}
         />
       )}


### PR DESCRIPTION
On ProfileListPage, I don't really like how the back button shifted in the title and content below it.  Even worse, we had to add extra logic to `ClickAndEdit`, a general component, to support this extra left margin.  Overall, I like a design where the big titles are always flush with the left side of the content section they describe.  To do this, I:

- Removed the `ml` prop from `ClickAndEdit`
- Moved the back button up to be beside the `ProfileUserBannerSmall` on profile list pages.

As a part of this, I also created a new `BackButton` component.  The new `BackButton` component has an `sx` prop that is piped through to the mui `IconButton` inside, so it can be used to add style props just like with a mui component.  Sadly, it doesn't get the cool autocomplete features when you are filling out the style in vscode, though 😢.