### PR TITLE
Show registration upsell based on authProvider field

### DIFF
--- a/src/Components/ProfileSidebar.js
+++ b/src/Components/ProfileSidebar.js
@@ -18,7 +18,7 @@ export default function ProfileSidebar({ hideDetails }) {
     <>
       {!hideDetails && (
         <>
-          {isOwnProfile && profile?.name === "guest" && (
+          {isOwnProfile && profile?.authProvider === "anonymous" && (
             <div style={{ display: "flex", justifyContent: "center" }}>
               <Button
                 variant="contained"


### PR DESCRIPTION
Previously, it was shown based on the user name -- We recently capitalized the guest name, which broke this, but I imagine hypothetically someone's name could actually be 'Guest' which would trip up this logic too.  Using the profile authProvider seems more foolproof.