### PR TITLE
Let search bar expand to full width on mobile

### DIFF
--- a/src/Components/Header.js
+++ b/src/Components/Header.js
@@ -3,12 +3,13 @@ import "../Styles/Header.css";
 import { Link } from "react-router-dom";
 import Container from "@mui/material/Container";
 import Grid from "@mui/material/Grid";
+import useMediaQuery from "@mui/material/useMediaQuery";
+import useTheme from "@mui/material/styles/useTheme";
 
 import { useState } from "react";
 import TitleAutocomplete from "./TitleAutocomplete";
 import { MagnifyingGlass, House, User } from "phosphor-react";
 import DropMenu from "./DropMenu";
-import useTheme from "@mui/material/styles/useTheme";
 import EdwardMLLogo from "./EdwardMLLogo";
 import HeaderTab from "./HeaderTab";
 import { useAuthState } from "react-firebase-hooks/auth";
@@ -19,6 +20,10 @@ function Header() {
   const theme = useTheme();
 
   const [showSearch, setShowSearch] = useState(false);
+
+  const isMobileWidth = useMediaQuery(theme.breakpoints.down("sm"));
+
+  const showMobileSearch = isMobileWidth && showSearch;
 
   const toggleSearch = (e) => {
     setShowSearch(true);
@@ -41,54 +46,62 @@ function Header() {
             paddingBottom: 0,
           }}
         >
-          <Grid item md={2.5} sm={4.75} xs={2.5}>
-            <Link to="/home">
-              <EdwardMLLogo />
-            </Link>
-          </Grid>
-          {!showSearch ? (
-            <>
-              <Grid
-                item
-                md={7}
-                sm={6}
-                xs={7.5}
-                sx={{
-                  marginY: 0.75,
-                  display: "flex",
-                  alignItems: "center",
-                  justifyContent: "space-evenly",
-                }}
-              >
-                <HeaderTab text="Home" icon={<House />} path="/home" />
-                <HeaderTab
-                  text="Profile"
-                  icon={<User />}
-                  path={user ? `/profile/${user.uid}` : "/login"}
-                />
-                <HeaderTab
-                  text="Search"
-                  icon={<MagnifyingGlass />}
-                  alwaysShowIcon
-                  onClick={toggleSearch}
-                />
-              </Grid>
-            </>
-          ) : (
-            <Grid item md={7} sm={6} xs={7.5} sx={{ marginY: 0.75 }}>
+          {showMobileSearch ? (
+            <Grid item xs={12} sx={{ margin: "11px 0" }}>
               <TitleAutocomplete setShowSearch={setShowSearch} />
             </Grid>
+          ) : (
+            <>
+              <Grid item md={2.5} sm={4.75} xs={2.5}>
+                <Link to="/home">
+                  <EdwardMLLogo />
+                </Link>
+              </Grid>
+              {!showSearch ? (
+                <>
+                  <Grid
+                    item
+                    md={7}
+                    sm={6}
+                    xs={7.5}
+                    sx={{
+                      marginY: 0.75,
+                      display: "flex",
+                      alignItems: "center",
+                      justifyContent: "space-evenly",
+                    }}
+                  >
+                    <HeaderTab text="Home" icon={<House />} path="/home" />
+                    <HeaderTab
+                      text="Profile"
+                      icon={<User />}
+                      path={user ? `/profile/${user.uid}` : "/login"}
+                    />
+                    <HeaderTab
+                      text="Search"
+                      icon={<MagnifyingGlass />}
+                      alwaysShowIcon
+                      onClick={toggleSearch}
+                    />
+                  </Grid>
+                </>
+              ) : (
+                <Grid item md={7} sm={6} xs={7.5} sx={{ marginY: 0.75 }}>
+                  <TitleAutocomplete setShowSearch={setShowSearch} />
+                </Grid>
+              )}
+              <Grid
+                item
+                xs={2}
+                sm={1.25}
+                md={2.5}
+                textAlign="right"
+                sx={{ display: "flex", justifyContent: "right" }}
+              >
+                <DropMenu />
+              </Grid>
+            </>
           )}
-          <Grid
-            item
-            xs={2}
-            sm={1.25}
-            md={2.5}
-            textAlign="right"
-            sx={{ display: "flex", justifyContent: "right" }}
-          >
-            {DropMenu()}
-          </Grid>
         </Grid>
       </Container>
     </div>


### PR DESCRIPTION
Right now, our header search bar is kind of small on mobile, which isn't terrible, but then the autocomplete panel beneath it is also very small, and this seems like a lost opportunity to make that thing the width of the whole screen, like search in mobile apps usually is.  See rotten tomatoes' mobile web search for an example of the bar expanding to full width on focus.  I don't do any cool animations here, nor do I provide a 'cancel' button to dismiss the search bar, but those could come as future improvements.