### PR TITLE
Fix/bugs in comments

### DIFF
--- a/src/Components/Firestore.js
+++ b/src/Components/Firestore.js
@@ -156,7 +156,6 @@ export async function GetPaginatedReviewsFromFirestore(
     const documentSnapshots = await getDocs(collectionQuery);
     if (documentSnapshots._snapshot.docChanges.length < 4) setSeeMore(false);
     else if (seeMore === false) setSeeMore(true);
-    console.log(documentSnapshots._snapshot.docChanges);
     let temp = [];
     if (reviews && lastVisible) temp = [...reviews];
     documentSnapshots.forEach((doc) => {

--- a/src/Components/Firestore.js
+++ b/src/Components/Firestore.js
@@ -83,9 +83,10 @@ export async function SaveReviewToFirestore(userID, userReview, animeID, type) {
   }
 }
 
-export async function DeleteReviewFromFirestore(user, animeID) {
+export async function DeleteReviewFromFirestore(user, animeID, type) {
+  let collectionName = type === "reviews" ? "animeData" : "watchlistData";
   const userID = user.uid.toString();
-  await deleteDoc(doc(db, "animeData", animeID, "reviews", userID));
+  await deleteDoc(doc(db, collectionName, animeID, "reviews", userID));
 }
 
 export async function PopulateReviewsFromFirestore(anime, setAnimeReviews) {

--- a/src/Components/Firestore.js
+++ b/src/Components/Firestore.js
@@ -155,7 +155,7 @@ export async function GetPaginatedReviewsFromFirestore(
     const documentSnapshots = await getDocs(collectionQuery);
     if (documentSnapshots._snapshot.docChanges.length < 4) setSeeMore(false);
     else if (seeMore === false) setSeeMore(true);
-
+    console.log(documentSnapshots._snapshot.docChanges);
     let temp = [];
     if (reviews && lastVisible) temp = [...reviews];
     documentSnapshots.forEach((doc) => {

--- a/src/Components/Review.js
+++ b/src/Components/Review.js
@@ -255,7 +255,7 @@ export default function Review({
             marginTop: "10px",
           }}
         >
-          <Tooltip title={`Applaude this ${type}`} followCursor>
+          <Tooltip title={`Applaude this ${typeSingular}`} followCursor>
             <div>
               <EmojiReactionChip
                 docId={docId}
@@ -270,7 +270,7 @@ export default function Review({
             </div>
           </Tooltip>
 
-          <Tooltip title={`Love this ${type}`} followCursor>
+          <Tooltip title={`Love this ${typeSingular}`} followCursor>
             <div>
               <EmojiReactionChip
                 docId={docId}
@@ -285,7 +285,7 @@ export default function Review({
             </div>
           </Tooltip>
 
-          <Tooltip title={`Disagree with this ${type}`} followCursor>
+          <Tooltip title={`Disagree with this ${typeSingular}`} followCursor>
             <div>
               <EmojiReactionChip
                 docId={docId}

--- a/src/Components/Review.js
+++ b/src/Components/Review.js
@@ -74,7 +74,7 @@ export default function Review({
 
       // Delete review from Firestore documents listing
       let docIdString = docId.toString();
-      DeleteReviewFromFirestore(user, docIdString);
+      DeleteReviewFromFirestore(user, docIdString, type);
     });
   }
 

--- a/src/Components/Review.js
+++ b/src/Components/Review.js
@@ -46,6 +46,8 @@ export default function Review({
 
   const { data: reviewerInfo } = useProfile(item.uid);
 
+  const typeSingular = type === "comments" ? "comment" : "review";
+
   const avatarSrc = useMemo(
     () => getAvatarSrc(reviewerInfo?.avatar),
     [reviewerInfo?.avatar]
@@ -53,8 +55,8 @@ export default function Review({
 
   function deleteReview(item, index) {
     confirm({
-      title: "Delete Review?",
-      content: "Deleting a review is permanent. There is no undo.",
+      title: `Delete ${typeSingular}`,
+      content: `Deleting a ${typeSingular} is permanent. There is no undo.`,
       titleProps: { sx: { fontFamily: "interExtraBold" } },
       contentProps: { sx: { fontFamily: "interMedium" } },
       confirmationText: "Delete",
@@ -84,7 +86,7 @@ export default function Review({
     <Paper
       elevation={0}
       tabIndex={user.uid === item.uid ? 0 : -1}
-      aria-label="Edit review"
+      aria-label={`Edit ${typeSingular}`}
       sx={{
         backgroundColor: "custom.subtleCardBg",
         borderRadius: "8px",
@@ -177,7 +179,7 @@ export default function Review({
             <Tooltip
               key={item.uid}
               followCursor
-              title={user.uid === item.uid ? "Edit review" : ""}
+              title={user.uid === item.uid ? `Edit ${typeSingular}` : ""}
             >
               <Grid
                 item
@@ -200,7 +202,7 @@ export default function Review({
             </Tooltip>
             {user.uid === item.uid ? (
               <Grid item xs={2} sx={{ position: "relative" }}>
-                <Tooltip followCursor title="Delete review">
+                <Tooltip followCursor title={`Delete ${typeSingular}`}>
                   <IconButton
                     sx={{
                       position: "absolute",
@@ -222,7 +224,7 @@ export default function Review({
           </Grid>
           <Tooltip
             followCursor
-            title={user.uid === item.uid ? "Edit review" : ""}
+            title={user.uid === item.uid ? `Edit ${typeSingular}` : ""}
           >
             <div style={{ display: "flex", flexDirection: "column" }}>
               <Rating
@@ -253,7 +255,7 @@ export default function Review({
             marginTop: "10px",
           }}
         >
-          <Tooltip title="Applaude this review" followCursor>
+          <Tooltip title={`Applaude this ${type}`} followCursor>
             <div>
               <EmojiReactionChip
                 docId={docId}
@@ -268,7 +270,7 @@ export default function Review({
             </div>
           </Tooltip>
 
-          <Tooltip title="Love this review" followCursor>
+          <Tooltip title={`Love this ${type}`} followCursor>
             <div>
               <EmojiReactionChip
                 docId={docId}
@@ -283,7 +285,7 @@ export default function Review({
             </div>
           </Tooltip>
 
-          <Tooltip title="Disagree with this review" followCursor>
+          <Tooltip title={`Disagree with this ${type}`} followCursor>
             <div>
               <EmojiReactionChip
                 docId={docId}

--- a/src/Components/ReviewContainer.js
+++ b/src/Components/ReviewContainer.js
@@ -79,9 +79,7 @@ export default function ReviewContainer({ user, docId, type }) {
             </Typography>
           )}
           {!showReviewForm ? (
-            <Tooltip
-              title={type === "Comments" ? "Add a comment" : "Add a review"}
-            >
+            <Tooltip title={`Add a ${type}`}>
               <Box sx={{ ml: 1 }}>
                 <IconButton
                   variant="contained"
@@ -96,7 +94,7 @@ export default function ReviewContainer({ user, docId, type }) {
               </Box>
             </Tooltip>
           ) : (
-            <Tooltip title="Close review">
+            <Tooltip title={`Close ${type}`}>
               <div style={{ marginLeft: "15px" }}>
                 {" "}
                 <IconButton

--- a/src/Components/ReviewContainer.js
+++ b/src/Components/ReviewContainer.js
@@ -24,6 +24,8 @@ export default function ReviewContainer({ user, docId, type }) {
   const [seeMore, setSeeMore] = useState(true);
   const [sortOption, setSortOption] = useState(["time", "desc"]);
 
+  const typeSingular = type === "comments" ? "comment" : "review";
+
   const subheadStyle = {
     fontFamily: "interBlack",
     fontSize: "22px",
@@ -79,7 +81,7 @@ export default function ReviewContainer({ user, docId, type }) {
             </Typography>
           )}
           {!showReviewForm ? (
-            <Tooltip title={`Add a ${type}`}>
+            <Tooltip title={`Add a ${typeSingular}`}>
               <Box sx={{ ml: 1 }}>
                 <IconButton
                   variant="contained"

--- a/src/Components/ReviewForm.js
+++ b/src/Components/ReviewForm.js
@@ -66,7 +66,6 @@ export default function ReviewForm({
     reValidateMode: "onChange",
     resolver: yupResolver(validationSchema),
   });
-  console.log(localUser);
 
   function populateForm() {
     if (localUser[type].includes(docId)) {

--- a/src/Components/ReviewForm.js
+++ b/src/Components/ReviewForm.js
@@ -43,13 +43,15 @@ export default function ReviewForm({
 
   let edited = false;
 
+  const typeSingular = type === "comments" ? "comment" : "Review";
+
   // Define Yup schema
   const validationSchema = Yup.object().shape({
     reviewTitle: Yup.string().required("*A title is required"),
     // .min(1, "*A title is required"),
     review: Yup.string()
-      .required("*A review is required")
-      .min(3, "*A review must be at least 3 characters long"),
+      .required(`*A ${typeSingular} is required`)
+      .min(3, `*A ${typeSingular} must be at least 3 characters long`),
   });
 
   //Use ReactHookForm hooks to validate Yup schema
@@ -64,6 +66,7 @@ export default function ReviewForm({
     reValidateMode: "onChange",
     resolver: yupResolver(validationSchema),
   });
+  console.log(localUser);
 
   function populateForm() {
     if (localUser[type].includes(docId)) {
@@ -201,7 +204,7 @@ export default function ReviewForm({
           }}
         />{" "}
         <TextField
-          label="Review"
+          label={typeSingular[0].toUpperCase() + typeSingular.slice(1)}
           name="review"
           id="review"
           variant="outlined"

--- a/src/Components/ReviewForm.js
+++ b/src/Components/ReviewForm.js
@@ -43,7 +43,7 @@ export default function ReviewForm({
 
   let edited = false;
 
-  const typeSingular = type === "comments" ? "comment" : "Review";
+  const typeSingular = type === "comments" ? "comment" : "review";
 
   // Define Yup schema
   const validationSchema = Yup.object().shape({


### PR DESCRIPTION
Cleans up some mess in the 'comments' section.
- Corrects wording of tooltips for 'comments' vs 'reviews'
- Allows comments to be deleted
- Keeps 'see more' button from rendering on page load.  

Note: I need to clean-up the 'see more' button behavior further.  Currently, if the # of reviews is divisible by 4 it won't hide the 'see more' button until it's clicked once more.  Will fix in an upcoming PR.