### PR TITLE
Add watchlist reactions

### DIFF
--- a/src/Components/EmojiReactionChip.js
+++ b/src/Components/EmojiReactionChip.js
@@ -8,6 +8,7 @@ import {
   SaveListReactionsToFirestore,
   SaveReviewToFirestore,
 } from "./Firestore";
+import Skeleton from "@mui/material/Skeleton";
 
 export default function EmojiReactionChip({
   docId,
@@ -67,11 +68,21 @@ export default function EmojiReactionChip({
     }
   }
 
+  if (!item?.emojis)
+    return (
+      <Skeleton
+        variant="rounded"
+        width={65}
+        height={32}
+        sx={{ paddingLeft: 0.5, borderRadius: "20px", mr: 2 }}
+      />
+    );
+
   return (
     <Chip
       variant={selected ? "filled" : "outlined"}
       icon={emoji}
-      label={item?.emojis[reaction]?.length}
+      label={item.emojis[reaction].length}
       sx={{
         paddingLeft: 0.5,
         borderRadius: "20px",

--- a/src/Components/EmojiReactionChip.js
+++ b/src/Components/EmojiReactionChip.js
@@ -4,12 +4,16 @@ import useTheme from "@mui/material/styles/useTheme";
 import { useEffect, useState } from "react";
 import { useAuthState } from "react-firebase-hooks/auth";
 import { auth } from "./Firebase";
-import { SaveReviewToFirestore } from "./Firestore";
+import {
+  SaveListReactionsToFirestore,
+  SaveReviewToFirestore,
+} from "./Firestore";
 
 export default function EmojiReactionChip({
   docId,
   emoji,
   item,
+  setItem, // Note, only used for list reactions (and NOT reviews/comments)
   reviews,
   reaction,
   index,
@@ -21,7 +25,7 @@ export default function EmojiReactionChip({
   const theme = useTheme();
 
   useEffect(() => {
-    if (item.emojis[reaction]?.includes(user.uid)) setSelected(true);
+    if (item?.emojis[reaction]?.includes(user.uid)) setSelected(true);
     else setSelected(false);
   }, [item]);
 
@@ -46,12 +50,31 @@ export default function EmojiReactionChip({
     }
   }
 
+  function reactToList() {
+    if (!selected) {
+      let temp = { ...item };
+      temp.emojis[reaction].push(user.uid);
+      setItem(temp);
+      setSelected(true);
+      SaveListReactionsToFirestore(docId, temp);
+    } else if (selected) {
+      let temp = { ...item };
+      let indexInArray = temp.emojis[reaction].indexOf(user.uid);
+      temp.emojis[reaction].splice(indexInArray, 1);
+      setItem(temp);
+      setSelected(false);
+      SaveListReactionsToFirestore(docId, temp);
+    }
+  }
+
   return (
     <Chip
       variant={selected ? "filled" : "outlined"}
       icon={emoji}
-      label={item.emojis[reaction]?.length}
+      label={item?.emojis[reaction]?.length}
       sx={{
+        paddingLeft: 0.5,
+        borderRadius: "20px",
         mr: 2,
         "& .MuiChip-label": { fontFamily: "interMedium", fontSize: "1rem" },
         "& .MuiChip-icon": {
@@ -59,7 +82,8 @@ export default function EmojiReactionChip({
         },
       }}
       onClick={(e) => {
-        reactToReview();
+        if (type === "list") reactToList();
+        else reactToReview();
         e?.stopPropagation();
       }}
     />

--- a/src/Components/Firestore.js
+++ b/src/Components/Firestore.js
@@ -171,3 +171,27 @@ export async function GetPaginatedReviewsFromFirestore(
 export function generateId() {
   return doc(collection(db, "test")).id;
 }
+
+// Handle "watchlistData / reactions" on firestore
+
+export async function GetListReactions(docId, setListRxns) {
+  try {
+    let animeRef = collection(db, "watchlistData", docId, "reactions");
+    let querySnapshot = await getDocs(animeRef);
+    // It is assumed here that only the emojis document exists within this collection.
+    if (!querySnapshot.docs[0]) return;
+    let temp = querySnapshot.docs[0].data();
+    setListRxns(temp);
+  } catch (error) {
+    console.error("Error loading data from Firebase Database", error);
+  }
+}
+
+export async function SaveListReactionsToFirestore(docId, updatedRxns) {
+  let Ref = doc(db, "watchlistData", docId, "reactions", "emojis");
+  try {
+    await setDoc(Ref, updatedRxns, { merge: true });
+  } catch (error) {
+    console.error("Error writing review data to Firestore", error);
+  }
+}

--- a/src/Components/Firestore.js
+++ b/src/Components/Firestore.js
@@ -176,11 +176,10 @@ export function generateId() {
 
 export async function GetListReactions(docId, setListRxns) {
   try {
-    let animeRef = collection(db, "watchlistData", docId, "reactions");
-    let querySnapshot = await getDocs(animeRef);
-    // It is assumed here that only the emojis document exists within this collection.
-    if (!querySnapshot.docs[0]) return;
-    let temp = querySnapshot.docs[0].data();
+    let animeRef = doc(db, "watchlistData", docId, "reactions", "emojis");
+    let querySnapshot = await getDoc(animeRef);
+    if (!querySnapshot) return;
+    let temp = querySnapshot.data();
     setListRxns(temp);
   } catch (error) {
     console.error("Error loading data from Firebase Database", error);

--- a/src/Components/GenreChips.js
+++ b/src/Components/GenreChips.js
@@ -170,6 +170,7 @@ export default function GenreChips({ selectedGenre, setSelectedGenre }) {
         <Chip
           sx={{
             fontFamily: "interMedium",
+            borderRadius: "16px",
           }}
           variant={item.selected ? "filled" : "outlined"}
           clickable={true}

--- a/src/Components/ProfileListPage.js
+++ b/src/Components/ProfileListPage.js
@@ -187,7 +187,9 @@ export default function ProfileListPage() {
           xs={12}
           order={{ xs: 4, sevenHundredFifty: 2 }}
           sx={{
-            textAlign: {
+            mt: 1,
+            display: "flex",
+            justifyContent: {
               xs: "left",
               sevenHundredFifty: "right",
             },

--- a/src/Components/ProfileListPage.js
+++ b/src/Components/ProfileListPage.js
@@ -5,8 +5,8 @@ import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
 
 import { useConfirm } from "material-ui-confirm";
-import { CaretLeft, X } from "phosphor-react";
-import { useContext, useEffect } from "react";
+import { CaretLeft, HandsClapping, Heart, Trash, X } from "phosphor-react";
+import { useContext, useEffect, useState } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
 import { slugifyListName } from "../Util/ListUtil";
 import NoResultsImage from "./NoResultsImage";
@@ -20,11 +20,16 @@ import ProfileListDropMenu from "./ProfileListDropMenu";
 import ReviewContainer from "./ReviewContainer";
 import { auth } from "./Firebase";
 import { useAuthState } from "react-firebase-hooks/auth";
+import EmojiReactionChip from "./EmojiReactionChip";
+import { GetListReactions } from "./Firestore";
 
 export default function ProfileListPage() {
   const navigate = useNavigate();
   const confirm = useConfirm();
   const [user, loading, error] = useAuthState(auth);
+  const [listRxns, setListRxns] = useState({
+    emojis: { applause: [], heart: [], trash: [] },
+  });
 
   const {
     profile,
@@ -53,6 +58,10 @@ export default function ProfileListPage() {
   let deletableList = false;
   let listHasDesc = false;
   let showSuggestions = false;
+
+  useEffect(() => {
+    GetListReactions(`${userId}+${listId}`, setListRxns);
+  }, [listId]);
 
   if (isLoading) {
     return <ProfileListPageGhost />;
@@ -158,6 +167,30 @@ export default function ProfileListPage() {
             {getSubtitleText(typeName, items)}
           </Typography>
         </Box>
+        <EmojiReactionChip
+          docId={`${userId}+${listId}`}
+          item={listRxns}
+          setItem={setListRxns}
+          emoji={<HandsClapping size={24} />}
+          reaction="applause"
+          type="list"
+        ></EmojiReactionChip>
+        <EmojiReactionChip
+          docId={`${userId}+${listId}`}
+          item={listRxns}
+          setItem={setListRxns}
+          emoji={<Heart size={24} />}
+          reaction="heart"
+          type="list"
+        ></EmojiReactionChip>
+        <EmojiReactionChip
+          docId={`${userId}+${listId}`}
+          item={listRxns}
+          setItem={setListRxns}
+          emoji={<Trash size={24} />}
+          reaction="trash"
+          type="list"
+        ></EmojiReactionChip>
         <ProfileListDropMenu
           onDelete={onDelete}
           isOwnProfile={isOwnProfile}

--- a/src/Components/ProfileListPage.js
+++ b/src/Components/ProfileListPage.js
@@ -22,10 +22,14 @@ import { auth } from "./Firebase";
 import { useAuthState } from "react-firebase-hooks/auth";
 import EmojiReactionChip from "./EmojiReactionChip";
 import { GetListReactions } from "./Firestore";
+import Grid from "@mui/material/Grid";
+import useMediaQuery from "@mui/material/useMediaQuery";
+import useTheme from "@mui/material/styles/useTheme";
 
 export default function ProfileListPage() {
   const navigate = useNavigate();
   const confirm = useConfirm();
+  const theme = useTheme();
   const [user, loading, error] = useAuthState(auth);
   const [listRxns, setListRxns] = useState({
     emojis: { applause: [], heart: [], trash: [] },
@@ -62,6 +66,10 @@ export default function ProfileListPage() {
   useEffect(() => {
     GetListReactions(`${userId}+${listId}`, setListRxns);
   }, [listId]);
+
+  const sevenHundredFifty = useMediaQuery(
+    theme.breakpoints.up("sevenHundredFifty")
+  );
 
   if (isLoading) {
     return <ProfileListPageGhost />;
@@ -151,7 +159,8 @@ export default function ProfileListPage() {
   return (
     <Box>
       {/* Header */}
-      <Box
+      <Grid
+        container
         sx={{
           display: "flex",
           alignItems: "center",
@@ -159,54 +168,83 @@ export default function ProfileListPage() {
           marginBottom: "8px",
         }}
       >
-        <Box sx={{ display: "flex", flexDirection: "column", flexGrow: 1 }}>
+        <Grid
+          item
+          sevenHundredFifty={6}
+          xs={10}
+          sx={{ display: "flex", flexDirection: "column", flexGrow: 1 }}
+        >
           <Typography variant="h3" sx={{ ...headStyle, margin: 0 }}>
             {name}
           </Typography>
           <Typography variant="body1" sx={subtitleStyle}>
             {getSubtitleText(typeName, items)}
           </Typography>
-        </Box>
-        <EmojiReactionChip
-          docId={`${userId}+${listId}`}
-          item={listRxns}
-          setItem={setListRxns}
-          emoji={<HandsClapping size={24} />}
-          reaction="applause"
-          type="list"
-        ></EmojiReactionChip>
-        <EmojiReactionChip
-          docId={`${userId}+${listId}`}
-          item={listRxns}
-          setItem={setListRxns}
-          emoji={<Heart size={24} />}
-          reaction="heart"
-          type="list"
-        ></EmojiReactionChip>
-        <EmojiReactionChip
-          docId={`${userId}+${listId}`}
-          item={listRxns}
-          setItem={setListRxns}
-          emoji={<Trash size={24} />}
-          reaction="trash"
-          type="list"
-        ></EmojiReactionChip>
-        <ProfileListDropMenu
-          onDelete={onDelete}
-          isOwnProfile={isOwnProfile}
-          deletableList={deletableList}
-          userId={userId}
-          listId={listId}
-        />
-      </Box>
-      {listHasDesc && (
-        <ClickAndEdit
-          data={desc}
-          canEdit={isOwnProfile}
-          onSave={onDescSave}
-          placeholder={"Tell us a bit about this list..."}
-        />
-      )}
+        </Grid>
+        <Grid
+          item
+          sevenHundredFifty={5.25}
+          xs={12}
+          order={{ xs: 4, sevenHundredFifty: 2 }}
+          sx={{
+            textAlign: {
+              xs: "left",
+              sevenHundredFifty: "right",
+            },
+          }}
+        >
+          <EmojiReactionChip
+            docId={`${userId}+${listId}`}
+            item={listRxns}
+            setItem={setListRxns}
+            emoji={<HandsClapping size={24} />}
+            reaction="applause"
+            type="list"
+          ></EmojiReactionChip>
+          <EmojiReactionChip
+            docId={`${userId}+${listId}`}
+            item={listRxns}
+            setItem={setListRxns}
+            emoji={<Heart size={24} />}
+            reaction="heart"
+            type="list"
+          ></EmojiReactionChip>
+          <EmojiReactionChip
+            docId={`${userId}+${listId}`}
+            item={listRxns}
+            setItem={setListRxns}
+            emoji={<Trash size={24} />}
+            reaction="trash"
+            type="list"
+          ></EmojiReactionChip>
+        </Grid>
+        <Grid
+          item
+          xs={2}
+          sevenHundredFifty={0.75}
+          order={{ xs: 2, sevenHundredFifty: 3 }}
+          sx={{ textAlign: "right" }}
+        >
+          <ProfileListDropMenu
+            onDelete={onDelete}
+            isOwnProfile={isOwnProfile}
+            deletableList={deletableList}
+            userId={userId}
+            listId={listId}
+          />
+        </Grid>
+
+        {listHasDesc && (
+          <Grid item xs={12} order={{ xs: 3, sevenHundredFifty: 4 }}>
+            <ClickAndEdit
+              data={desc}
+              canEdit={isOwnProfile}
+              onSave={onDescSave}
+              placeholder={"Tell us a bit about this list..."}
+            />
+          </Grid>
+        )}
+      </Grid>
       {/* Items */}
       {items && (
         <DragDropContext onDragEnd={handleOnDragEnd}>


### PR DESCRIPTION
Lets users react to watchlists.

I separated the reaction data from the rest of the watchlist data as it lives within a localUsers list.  Honestly, I couldn't figure out whether this was really needed to prevent clients from being able to tinker with their reaction numbers, but it seemed like a good idea at the time. Lmk if we should stash it elsewhere.

Also, as a bonus, I styled the GenreChips to be more round.