### PR TITLE
Fix some bugs with loading list reactions

### DIFF
--- a/src/Components/Firestore.js
+++ b/src/Components/Firestore.js
@@ -178,7 +178,13 @@ export async function GetListReactions(docId, setListRxns) {
   try {
     let animeRef = doc(db, "watchlistData", docId, "reactions", "emojis");
     let querySnapshot = await getDoc(animeRef);
-    if (!querySnapshot.data()) return;
+    // Use default value if the document doesn't exist yet.
+    if (!querySnapshot.data()) {
+      setListRxns({
+        emojis: { applause: [], heart: [], trash: [] },
+      });
+      return;
+    }
     let temp = querySnapshot.data();
     setListRxns(temp);
   } catch (error) {

--- a/src/Components/ProfileListPage.js
+++ b/src/Components/ProfileListPage.js
@@ -31,9 +31,7 @@ export default function ProfileListPage() {
   const confirm = useConfirm();
   const theme = useTheme();
   const [user, loading, error] = useAuthState(auth);
-  const [listRxns, setListRxns] = useState({
-    emojis: { applause: [], heart: [], trash: [] },
-  });
+  const [listRxns, setListRxns] = useState(undefined);
 
   const {
     profile,


### PR DESCRIPTION
This commit fixes an issue where the ghost chips won't show up many times while the list reactions are loading, and an issue where I couldn't add new reactions to my dislikes list.  The first was because the `useState` for listRxns provided a default value that wouldn't let the component know the data wasn't available yet.  I've solved by using undefined until the data is present.  And, `GetListReactions` will now return a default reaction object when the document is loaded but doesn't yet exist, which will allow for creating reactions on lists that don't have reactions yet.