### PR TITLE
Set up fallback fonts, move all typography to theme

### DIFF
--- a/src/Components/AddToListDropMenu.js
+++ b/src/Components/AddToListDropMenu.js
@@ -199,7 +199,7 @@ export default function AddToListDropMenu({ anime, variant, selected }) {
                       primary="Add to Watchlists"
                       primaryTypographyProps={{
                         fontSize: "1rem",
-                        fontFamily: "interExtraBold",
+                        fontWeight: 800,
                       }}
                     />
                   </ListItemButton>
@@ -209,7 +209,7 @@ export default function AddToListDropMenu({ anime, variant, selected }) {
                       tabIndex={-1}
                       sx={{
                         margin: "10px 0px 10px",
-                        fontFamily: "interSemiBold",
+                        fontWeight: 600,
                       }}
                       secondaryAction={
                         <AddButtonForTop8 anime={anime} list={localUser.top8} />
@@ -230,7 +230,6 @@ export default function AddToListDropMenu({ anime, variant, selected }) {
                             tabIndex={-1}
                             sx={{
                               margin: "10px 0px 10px",
-                              fontFamily: "interMedium",
                             }}
                             secondaryAction={
                               <AddButton anime={anime} list={item.name} />
@@ -246,7 +245,7 @@ export default function AddToListDropMenu({ anime, variant, selected }) {
                   {/****************Create New List Button****************/}
                   {!newList ? (
                     <MenuItem
-                      sx={{ marginTop: "10px", fontFamily: "interSemiBold" }}
+                      sx={{ marginTop: "10px", fontWeight: 600 }}
                       tabIndex={0}
                       onClick={(e) => {
                         setNewList(true);
@@ -266,7 +265,7 @@ export default function AddToListDropMenu({ anime, variant, selected }) {
                         primary="New Watchlist"
                         primaryTypographyProps={{
                           fontSize: "1rem",
-                          fontFamily: "interExtraBold",
+                          fontWeight: 800,
                           mt: 1.5,
                           textAlign: "center",
                         }}
@@ -350,7 +349,6 @@ export default function AddToListDropMenu({ anime, variant, selected }) {
                         navigate(`/profile/${user?.uid}`);
                       }}
                       sx={{
-                        fontFamily: "interMedium",
                         fontSize: "0.8rem",
                         mt: 1,
                       }}

--- a/src/Components/ChooseAvatar.js
+++ b/src/Components/ChooseAvatar.js
@@ -10,7 +10,6 @@ import AvatarShelf from "./AvatarShelf";
 
 export default function ChooseAvatar() {
   let styling = {
-    fontFamily: "interMedium",
     pl: 1,
     fontSize: "0.75rem",
     marginTop: "-20px",
@@ -21,13 +20,12 @@ export default function ChooseAvatar() {
 
   return (
     <div>
-      <Typography sx={{ fontFamily: "interExtraBold", pl: 1, mb: 1 }}>
+      <Typography variant="h5" sx={{ pl: 1, mb: 1 }}>
         Select an Avatar:
       </Typography>
 
       <Typography
         sx={{
-          fontFamily: "interMedium",
           pl: 1,
           fontSize: "0.75rem",
         }}

--- a/src/Components/ClickAndEdit.js
+++ b/src/Components/ClickAndEdit.js
@@ -1,12 +1,16 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import Typography from "@mui/material/Typography";
 import TextField from "@mui/material/TextField";
 import Button from "@mui/material/Button";
 import useTheme from "@mui/material/styles/useTheme";
+import Tooltip from "@mui/material/Tooltip";
+import Box from "@mui/material/Box";
+import useMediaQuery from "@mui/material/useMediaQuery";
 
 export default function ClickAndEdit({
   data,
   placeholder,
+  label,
   canEdit,
   onSave,
   styling,
@@ -16,7 +20,21 @@ export default function ClickAndEdit({
   const theme = useTheme();
 
   const [editDesc, setEditDesc] = useState(false);
-  const [editedDesc, setEditedDesc] = useState(data);
+  const [editedDesc, setEditedDesc] = useState(undefined);
+
+  // TO-DO:
+  // Add in ghost cards for ProfileUserBanner, and only render ClickAndEdit
+  // when data has been loaded in.  Then below useEffect can
+  // be deleted and useState(data) for editDesc.
+
+  useEffect(() => {
+    setEditedDesc(data);
+  }, [data]);
+  const smallScreen = useMediaQuery(theme.breakpoints.down("sm"));
+
+  // TO-DO:
+  // Provide truncated name/description for lengthy entries so they
+  // don't break layout.
 
   function saveDesc() {
     onSave(editedDesc);
@@ -27,76 +45,99 @@ export default function ClickAndEdit({
     if (e?.key === "Enter") e.preventDefault();
   }
 
-  return (
-    <div>
-      {!editDesc ? (
-        <Typography
-          sx={{
-            fontFamily: styling?.fontFamily ?? "interMedium",
-            fontSize: styling?.fontSize ?? "1rem",
-            color: data?.length > 0 ? "unset" : theme.palette.text.secondary,
-            pb: styling?.pb ?? 1,
-            pl: 0,
-            ml: 0,
-            cursor: canEdit ? "pointer" : "unset",
-          }}
-          tabIndex={canEdit ? "0" : "-1"}
-          onClick={canEdit ? handleDescToggle : undefined}
-          onKeyDown={(e) => {
-            if (e.key === "Enter") handleDescToggle(e);
-          }}
-        >
-          {data?.length > 0 ? data : canEdit ? placeholder : ""}
-        </Typography>
-      ) : (
-        <div
-          style={{
-            display: "flex",
-            flexDirection: "column",
-            alignItems: "center",
-          }}
-        >
-          <TextField
-            name="Desc"
-            id="Desc"
-            size="small"
-            variant="filled"
-            autoComplete="off"
-            color="text"
-            placeholder={placeholder}
-            autoFocus
-            multiline
-            fullWidth={true}
-            value={editedDesc}
-            onClick={(e) => e.preventDefault()}
-            onChange={(e) => {
-              setEditedDesc(e.target.value);
-            }}
-            sx={{ mb: 2 }}
-            InputProps={{
-              style: {
-                padding: "10px 10px 10px 5px",
-              },
-            }}
-            inputProps={{
-              style: {
-                maxWidth: "none",
-              },
-            }}
-          ></TextField>
-          <Button
-            size="small"
-            variant="outlined"
-            color="inherit"
-            onClick={(e) => {
-              saveDesc();
-              handleDescToggle();
+  // TO-DO:
+  // Below if statement can be deleted upon implementation of ghost cards
+  // on ProfileUserBanner.
+
+  if (data !== undefined) {
+    return (
+      <div style={{ display: "flex", flex: "1" }}>
+        {!editDesc ? (
+          <Box sx={{ display: "flex" }}>
+            <Tooltip
+              title={canEdit ? label : ""}
+              placement="bottom"
+              PopperProps={{
+                modifiers: [{ name: "offset", options: { offset: [0, -10] } }],
+              }}
+            >
+              <Typography
+                sx={{
+                  fontFamily: styling?.fontFamily ?? "interMedium",
+                  fontSize: styling?.fontSize ?? "1rem",
+                  color:
+                    data?.length > 0 ? "unset" : theme.palette.text.secondary,
+                  pb: styling?.pb ?? 1,
+                  pl: 0,
+                  ml: 0,
+                  cursor: canEdit ? "pointer" : "unset",
+                }}
+                tabIndex={canEdit ? "0" : "-1"}
+                onClick={canEdit ? handleDescToggle : undefined}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") handleDescToggle(e);
+                }}
+              >
+                {data?.length > 0 ? data : canEdit ? placeholder : ""}
+              </Typography>
+            </Tooltip>
+          </Box>
+        ) : (
+          <div
+            style={{
+              display: "flex",
+              flexDirection: "column",
+              alignItems: "center",
+              flex: "1",
             }}
           >
-            Save
-          </Button>
-        </div>
-      )}
-    </div>
-  );
+            <TextField
+              name="Desc"
+              id="Desc"
+              size="small"
+              variant="outlined"
+              autoComplete="off"
+              color="text"
+              placeholder={placeholder}
+              autoFocus
+              multiline
+              fullWidth={true}
+              value={editedDesc}
+              onClick={(e) => e.preventDefault()}
+              onChange={(e) => {
+                setEditedDesc(e.target.value);
+              }}
+              sx={{ mb: 2 }}
+              InputProps={{
+                style: {
+                  padding: "10px 10px 10px 5px",
+                  lineHeight: "1.5",
+                },
+              }}
+              inputProps={{
+                style: {
+                  maxWidth: "none",
+                  fontFamily: styling?.fontFamily ?? "interMedium",
+                  fontSize: smallScreen
+                    ? styling?.fontSize?.xs ?? styling?.fontSize ?? "1rem"
+                    : styling?.fontSize?.md ?? styling?.fontSize ?? "1rem",
+                },
+              }}
+            ></TextField>
+            <Button
+              size="small"
+              variant="outlined"
+              color="inherit"
+              onClick={(e) => {
+                saveDesc();
+                handleDescToggle();
+              }}
+            >
+              Save
+            </Button>
+          </div>
+        )}
+      </div>
+    );
+  }
 }

--- a/src/Components/ClickAndEdit.js
+++ b/src/Components/ClickAndEdit.js
@@ -63,8 +63,8 @@ export default function ClickAndEdit({
             >
               <Typography
                 sx={{
-                  fontFamily: styling?.fontFamily ?? "interMedium",
                   fontSize: styling?.fontSize ?? "1rem",
+                  fontWeight: styling?.fontWeight,
                   color:
                     data?.length > 0 ? "unset" : theme.palette.text.secondary,
                   pb: styling?.pb ?? 1,

--- a/src/Components/ClickAndEdit.js
+++ b/src/Components/ClickAndEdit.js
@@ -117,7 +117,7 @@ export default function ClickAndEdit({
               inputProps={{
                 style: {
                   maxWidth: "none",
-                  fontFamily: styling?.fontFamily ?? "interMedium",
+                  fontWeight: styling?.fontWeight,
                   fontSize: smallScreen
                     ? styling?.fontSize?.xs ?? styling?.fontSize ?? "1rem"
                     : styling?.fontSize?.md ?? styling?.fontSize ?? "1rem",

--- a/src/Components/DetailedView.js
+++ b/src/Components/DetailedView.js
@@ -68,23 +68,15 @@ export default function DetailedView() {
   }
 
   const headStyle = {
-    fontFamily: "interBlack",
-    fontSize: "40px",
-    lineHeight: "48px",
     marginBottom: "24px",
   };
 
   const subheadStyle = {
-    fontFamily: "interBlack",
-    fontSize: "22px",
-    lineHeight: "27px",
     marginTop: "24px",
     marginBottom: "12px",
   };
 
   const bodyStyle = {
-    fontFamily: "interMedium",
-    fontSize: "16px",
     lineHeight: "21px",
   };
 
@@ -155,7 +147,7 @@ export default function DetailedView() {
           </Box>
 
           {/*Basic Info*/}
-          <Typography variant="h5" sx={subheadStyle}>
+          <Typography variant="h3" sx={subheadStyle}>
             {anime.display_name}
           </Typography>
           <Typography variant="body1" sx={bodyStyle}>
@@ -264,7 +256,7 @@ export default function DetailedView() {
                 )}
                 <Grid item xs={12} md={6} sx={bodyStyle}>
                   <Typography
-                    variant="h5"
+                    variant="h3"
                     style={{ ...subheadStyle, margin: "0 0 12px 0" }}
                   >
                     Data From Edward
@@ -273,11 +265,8 @@ export default function DetailedView() {
                 </Grid>
                 <Grid item xs={12} md={6}>
                   <Typography
-                    variant="h6"
+                    variant="h5"
                     sx={{
-                      fontFamily: "interExtraBold",
-                      fontSize: "16px",
-                      lineHeight: "19px",
                       marginTop: { xs: "24px", md: "7px" },
                       marginBottom: "12px",
                     }}
@@ -293,7 +282,7 @@ export default function DetailedView() {
 
             {/* Summary */}
             <Grid item xs={12}>
-              <Typography variant="h5" style={subheadStyle}>
+              <Typography variant="h3" style={subheadStyle}>
                 Summary
               </Typography>
               <ExpandableText
@@ -304,7 +293,7 @@ export default function DetailedView() {
 
             {/* Watch Links */}
             <Grid item xs={12}>
-              <Typography variant="h5" style={subheadStyle}>
+              <Typography variant="h3" style={subheadStyle}>
                 Watch
               </Typography>
               <Box sx={{ display: "block" }}>
@@ -314,7 +303,7 @@ export default function DetailedView() {
           </Grid>
         </Grid>
         <Grid item xs={12} md={12}>
-          <Typography variant="h5" style={subheadStyle}>
+          <Typography variant="h3" style={subheadStyle}>
             Similar Titles
           </Typography>
           <SimilarContent animeId={anime.id} amount={24} />

--- a/src/Components/DropMenu.js
+++ b/src/Components/DropMenu.js
@@ -126,7 +126,7 @@ export default function DropMenu() {
           cursor: "pointer",
           width: "35px",
           height: "35px",
-          fontFamily: "interSemiBold",
+          fontWeight: 600,
         }}
       />
       <Popper
@@ -167,7 +167,7 @@ export default function DropMenu() {
                         src={avatarSrc ?? "purposefully bad link"}
                         sx={{
                           bgcolor: theme.palette.primary.main,
-                          fontFamily: "interSemiBold",
+                          fontWeight: 600,
                         }}
                       />
                     </ListItemAvatar>
@@ -179,7 +179,7 @@ export default function DropMenu() {
                       primary={
                         user?.displayName ? `${user?.displayName}` : "Guest"
                       }
-                      primaryTypographyProps={{ fontFamily: "interSemiBold" }}
+                      primaryTypographyProps={{ fontWeight: 600 }}
                     />
                   </ListItemButton>
                   <MenuItem

--- a/src/Components/EmojiReactionChip.js
+++ b/src/Components/EmojiReactionChip.js
@@ -87,7 +87,7 @@ export default function EmojiReactionChip({
         paddingLeft: 0.5,
         borderRadius: "20px",
         mr: 2,
-        "& .MuiChip-label": { fontFamily: "interMedium", fontSize: "1rem" },
+        "& .MuiChip-label": { fontSize: "1rem" },
         "& .MuiChip-icon": {
           ...(selected && { color: "inherit" }),
         },

--- a/src/Components/ExpandableText.js
+++ b/src/Components/ExpandableText.js
@@ -1,8 +1,11 @@
 import Box from "@mui/material/Box";
 import Link from "@mui/material/Link";
+import useTheme from "@mui/material/styles/useTheme";
 import { useMemo, useState } from "react";
 
 export default function ExpandableText({ text, sx }) {
+  const theme = useTheme();
+
   const [expanded, setExpanded] = useState(false);
 
   const shortText = useMemo(() => getShortText(text), [text]);
@@ -29,6 +32,7 @@ export default function ExpandableText({ text, sx }) {
         >
           <Link
             color="inherit"
+            variant="body1"
             underline="none"
             onClick={(e) => {
               setExpanded(!expanded);
@@ -36,8 +40,10 @@ export default function ExpandableText({ text, sx }) {
             }}
             component="button"
             sx={{
-              fontFamily: "interSemiBold",
-              fontSize: "16px",
+              fontWeight: 600,
+              "&:hover": {
+                color: theme.palette.primary.main,
+              },
             }}
           >
             {expanded ? "Read less" : "Read more"}

--- a/src/Components/Firebase.js
+++ b/src/Components/Firebase.js
@@ -116,7 +116,6 @@ export const signInWithTwitter = async () => {
     // const token = credential.accessToken;
     // const secret = credential.secret;
     const user = res.user;
-    console.log(user);
     const q = query(collection(db, "users"), where("uid", "==", user.uid));
     const docs = await getDocs(q);
     if (docs.docs.length === 0) {
@@ -127,18 +126,7 @@ export const signInWithTwitter = async () => {
             uid: user.uid,
             name: user.displayName,
             authProvider: "twitter",
-            email: user.email,
-          },
-          { merge: true }
-        );
-      } else {
-        await setDoc(
-          doc(db, "users", user.uid),
-          {
-            uid: user.uid,
-            name: user.displayName,
-            authProvider: "twitter",
-            email: user.email,
+            email: user?.email,
           },
           { merge: true }
         );

--- a/src/Components/Firestore.js
+++ b/src/Components/Firestore.js
@@ -53,6 +53,7 @@ export async function SaveToFirestore(user, localUser) {
       await setDoc(
         doc(db, "users", user.uid),
         {
+          name: localUser.name ?? null,
           likes: [...localUser.likes],
           dislikes: [...localUser.dislikes],
           lists: [...localUser.lists],

--- a/src/Components/GenreChips.js
+++ b/src/Components/GenreChips.js
@@ -169,7 +169,6 @@ export default function GenreChips({ selectedGenre, setSelectedGenre }) {
       {currentItems?.map((item, index) => (
         <Chip
           sx={{
-            fontFamily: "interMedium",
             borderRadius: "16px",
           }}
           variant={item.selected ? "filled" : "outlined"}

--- a/src/Components/HeaderTab.js
+++ b/src/Components/HeaderTab.js
@@ -44,7 +44,7 @@ export default function HeaderTab({
   };
 
   const tabStyle = {
-    fontFamily: "interSemiBold",
+    fontWeight: 600,
     fontSize: "1.125rem",
     marginLeft: alwaysShowIcon ? 0.75 : 0,
     "&:hover": {

--- a/src/Components/Home.js
+++ b/src/Components/Home.js
@@ -2,6 +2,7 @@ import "../Styles/App.css";
 
 import Container from "@mui/material/Container";
 import Button from "@mui/material/Button";
+import Typography from "@mui/material/Typography";
 import RefreshIcon from "@mui/icons-material/Refresh";
 import { useEffect, useState, useContext } from "react";
 import { LocalUserContext } from "./LocalUserContext";
@@ -94,34 +95,36 @@ export default function Home() {
     }
   }, [user, loading]);
 
+  const shelfTitleStyles = {
+    marginTop: "1.6em",
+    marginBottom: "0.5em",
+  };
+
   return (
     <div>
       <Container maxWidth="lg">
         <div className="gap" />
         {localUser && localUser?.likes.length > 0 ? (
           <>
-            <h2
+            <Typography
+              variant="h2"
               style={{
-                fontSize: "2.5rem",
-                fontFamily: "interBlack, Arial, Helvetica, sans-serif",
-                textAlign: "left",
                 marginBlockStart: 0,
                 marginBlockEnd: "0.5rem",
               }}
             >
               For You
-            </h2>
+            </Typography>
             <AnimeGrid items={recommendation} large />
           </>
         ) : (
           ""
         )}
         {localUser.uid && localUser?.likes.length === 0 ? (
-          <h2
+          <Typography
+            variant="h2"
             style={{
               fontSize: "2.0rem",
-              fontFamily: "interBlack, Arial, Helvetica, sans-serif",
-              textAlign: "left",
               marginBlockStart: 0,
               marginBlockEnd: "0.5rem",
             }}
@@ -129,7 +132,7 @@ export default function Home() {
             Like a show to receive{" "}
             <span className="rainbow_text_animated">personalized</span>{" "}
             recommendations!
-          </h2>
+          </Typography>
         ) : (
           ""
         )}
@@ -143,25 +146,33 @@ export default function Home() {
       />
 
       <Container maxWidth="lg">
-        <h4 className="shelfTitle"> Highest Rated {selectedGenre.slice(7)} </h4>
+        <Typography variant="h4" sx={shelfTitleStyles}>
+          Highest Rated {selectedGenre.slice(7)}{" "}
+        </Typography>
         <AnimeShelf items={animeHR} />
 
-        <h4 className="shelfTitle">Most Popular {selectedGenre.slice(7)}</h4>
+        <Typography variant="h4" sx={shelfTitleStyles}>
+          Most Popular {selectedGenre.slice(7)}
+        </Typography>
         <AnimeShelf items={animeMC} />
         {/* 
       <h4>All time Best</h4>
       <AnimeShelf items={animeMR} /> */}
 
-        <h4 className="shelfTitle">
+        <Typography variant="h4" sx={shelfTitleStyles}>
           Most Buzzed About {selectedGenre.slice(7)}
-        </h4>
+        </Typography>
         <AnimeShelf items={animeMPTW} />
 
-        <h4 className="shelfTitle">Most Obscure</h4>
+        <Typography variant="h4" sx={shelfTitleStyles}>
+          Most Obscure
+        </Typography>
         <AnimeShelf items={animeMH} />
 
         <Stack direction="row" spacing={3} sx={{ alignItems: "baseline" }}>
-          <h4 className="shelfTitle">Random</h4>
+          <Typography variant="h4" sx={shelfTitleStyles}>
+            Random
+          </Typography>
           <Button
             color="inherit"
             variant="outlined"

--- a/src/Components/LandingPage.js
+++ b/src/Components/LandingPage.js
@@ -74,16 +74,17 @@ export default function LandingPage() {
         }}
       >
         <Typography
+          variant="h1"
           sx={{
             marginTop: {
               xs: "80px",
               sm: "145px",
             },
-            fontFamily: "montserrat",
             fontSize: {
               xs: "3rem",
               sm: "4.0rem",
             },
+            lineHeight: 1.5,
             color: "white",
             zIndex: "1",
             maxWidth: "550px",
@@ -95,7 +96,6 @@ export default function LandingPage() {
         <Typography
           sx={{
             marginTop: "27px",
-            fontFamily: "interMedium",
             fontSize: { xs: "1.1rem", sm: "1.5rem" },
             color: "white",
             zIndex: "1",
@@ -127,8 +127,6 @@ export default function LandingPage() {
           sx={{
             marginTop: "17px",
             marginBottom: "10px",
-            fontFamily: "interMedium",
-            fontSize: "1.0rem",
             color: "white",
             zIndex: "1",
             maxWidth: "600px",
@@ -239,8 +237,6 @@ export default function LandingPage() {
               </div>
               <Typography
                 sx={{
-                  fontFamily: "interMedium",
-                  fontSize: "1rem",
                   margin: "0px 34px 20px 27px",
                 }}
               >
@@ -310,14 +306,12 @@ export default function LandingPage() {
               </div>
               <Typography
                 sx={{
-                  fontFamily: "interMedium",
-                  fontSize: "1rem",
                   margin: "0px 34px 0px 27px",
                 }}
               >
                 Edward understands anime relationships and can help you discover
                 new content similar to your existing favorites.
-              </Typography>{" "}
+              </Typography>
             </Paper>
           </Grid>
           {/******************************Card #3****************************/}
@@ -380,19 +374,17 @@ export default function LandingPage() {
                     lineHeight: "1.25",
                   }}
                 >
-                  Get personalized recs{" "}
+                  Get personalized recs
                 </Typography>
               </div>
               <Typography
                 sx={{
-                  fontFamily: "interMedium",
-                  fontSize: "1rem",
                   margin: "0px 34px 20px 27px",
                 }}
               >
                 Edward learns your personal taste profile and can make new
                 suggestions that are just for you.
-              </Typography>{" "}
+              </Typography>
             </Paper>
           </Grid>
           <Grid item xs={12}></Grid>

--- a/src/Components/Login.js
+++ b/src/Components/Login.js
@@ -42,8 +42,7 @@ export default function Login() {
     textTransform: "none",
     borderRadius: "24px",
     width: "350px",
-    fontFamily: "interExtraBold",
-    fontSize: "1rem",
+    fontWeight: 800,
     marginBottom: "17px",
   };
 
@@ -74,12 +73,12 @@ export default function Login() {
           alignItems: "center",
         }}
       >
-        <h4
-          className="H4"
+        <Typography
+          variant="h3"
           style={{ textAlign: "center", margin: 0, marginBottom: "18px" }}
         >
           Let's Get Logged In!
-        </h4>
+        </Typography>
         <div
           className="register__container"
           style={{ borderColor: theme.palette.divider }}
@@ -165,7 +164,6 @@ export default function Login() {
               "&::before, &::after": {
                 borderColor: theme.palette.text.primary,
               },
-              fontFamily: "interMedium",
               margin: "16px 0px",
             }}
           >
@@ -181,16 +179,12 @@ export default function Login() {
             required
             inputProps={{
               style: {
-                fontSize: "1.0rem",
-                fontFamily: "interMedium",
                 paddingTop: "12.5px",
                 paddingBottom: "12.5px",
               },
             }}
             InputLabelProps={{
               style: {
-                fontSize: "1.0rem",
-                fontFamily: "interMedium",
                 marginBottom: "88.5px",
               },
             }}
@@ -215,16 +209,8 @@ export default function Login() {
             required
             inputProps={{
               style: {
-                fontSize: "1.0rem",
-                fontFamily: "interMedium",
                 paddingTop: "12.5px",
                 paddingBottom: "12.5px",
-              },
-            }}
-            InputLabelProps={{
-              style: {
-                fontSize: "1.0rem",
-                fontFamily: "interMedium",
               },
             }}
             FormHelperTextProps={{
@@ -244,15 +230,13 @@ export default function Login() {
               },
               borderRadius: "9px",
               marginBottom: "20px",
-              fontFamily: "interMedium",
-              fontSize: "1rem",
             }}
           />
           {loginError && (
             <Typography
               sx={{
                 color: "error.main",
-                fontFamily: "interExtraBold",
+                fontWeight: 600,
                 marginY: "10px",
               }}
             >
@@ -282,15 +266,11 @@ export default function Login() {
             }}
           />
           {/* *******************Already Registered Section************************** */}
-          <div style={{ fontFamily: "interMedium" }}>
+          <div>
             Need an account?{" "}
-            <Link to="/register">
-              <span
-                style={{ fontFamily: "interExtraBold", fontWeight: "bold" }}
-              >
-                Register here!
-              </span>
-            </Link>
+            <Typography component="span" sx={{ fontWeight: 800 }}>
+              <Link to="/register"> Register here!</Link>
+            </Typography>
           </div>
         </div>
       </Container>

--- a/src/Components/Logout.js
+++ b/src/Components/Logout.js
@@ -77,8 +77,8 @@ export default function Logout() {
           }}
         >
           <Typography
+            variant="h1"
             sx={{
-              fontFamily: "montserrat, Arial, Helvetica, sans-serif",
               fontSize: {
                 xs: "2.5rem",
                 sevenHundredFifty: "3rem",
@@ -91,8 +91,8 @@ export default function Logout() {
             Logout Complete.
           </Typography>
           <Typography
+            variant="h4"
             sx={{
-              fontFamily: "interSemiBold, Arial, Helvetica, sans-serif",
               fontSize: {
                 xs: "1.5rem",
                 sevenHundredFifty: "1.75rem",

--- a/src/Components/NoResultsImage.js
+++ b/src/Components/NoResultsImage.js
@@ -13,8 +13,6 @@ export default function NoResultsImage({ noImage }) {
     >
       <Typography
         sx={{
-          fontFamily: "interMedium",
-          fontSize: "1rem",
           color: "text.secondary",
           marginBottom: "14px",
         }}

--- a/src/Components/Onboarding.js
+++ b/src/Components/Onboarding.js
@@ -46,27 +46,17 @@ export default function Onboarding() {
       <OnboardingHeader />
       <Container maxWidth="lg">
         <Typography
-          className="leftH4"
+          variant="h2"
           sx={{
-            fontFamily: "montserratExtraBold",
-            fontSize: "2rem",
             marginTop: "30px",
             marginBottom: "23px",
           }}
         >
           Let's Get Started
         </Typography>
-        <span
-          style={{
-            fontFamily: "interSemiBold",
-            fontSize: "1.5rem",
-          }}
-        >
+        <Typography variant="h4" sx={{ mb: 4 }}>
           Pick at least one item you like
-        </span>
-        <br />
-
-        <br />
+        </Typography>
         <OnboardingAnimeGrid items={onboardingAnime} large onboarding />
         <br />
         {localUser["likes"] && localUser["likes"].length < 1 ? (

--- a/src/Components/PrivacySwitch.js
+++ b/src/Components/PrivacySwitch.js
@@ -29,11 +29,7 @@ export function PrivacySwitch({ privateList, setPrivateList }) {
               }}
             >
               <LockSimple size={20} />
-              <Typography
-                sx={{ fontFamily: "interMedium", fontSize: "1rem", ml: 0.5 }}
-              >
-                Private
-              </Typography>{" "}
+              <Typography sx={{ ml: 0.5 }}>Private</Typography>{" "}
             </div>
           ) : (
             <div
@@ -43,11 +39,7 @@ export function PrivacySwitch({ privateList, setPrivateList }) {
               }}
             >
               <GlobeHemisphereWest size={20} />{" "}
-              <Typography
-                sx={{ fontFamily: "interMedium", fontSize: "1rem", ml: 0.5 }}
-              >
-                Public
-              </Typography>{" "}
+              <Typography sx={{ ml: 0.5 }}>Public</Typography>{" "}
             </div>
           )
         }

--- a/src/Components/ProfileListDropMenu.js
+++ b/src/Components/ProfileListDropMenu.js
@@ -58,11 +58,6 @@ export default function ProfileListDropMenu({
     prevOpen.current = open;
   }, [open]);
 
-  const listItemStyling = {
-    fontSize: "1rem",
-    fontFamily: "interMedium",
-  };
-
   return (
     <>
       {/**********************DROP MENU ICON**********************/}
@@ -127,7 +122,6 @@ export default function ProfileListDropMenu({
                       enqueueSnackbar("Link copied to clipboard", {
                         variant: "success",
                         style: {
-                          fontFamily: "interMedium",
                           fontSize: "0.9rem",
                           background: theme.palette.primary.main,
                         },
@@ -148,10 +142,7 @@ export default function ProfileListDropMenu({
                     <ListItemIcon>
                       <Link size={24} />
                     </ListItemIcon>
-                    <ListItemText
-                      primary="Copy Link"
-                      primaryTypographyProps={listItemStyling}
-                    />
+                    <ListItemText primary="Copy Link" />
                   </ListItemButton>
 
                   {/* Save watchlist button */}
@@ -169,7 +160,6 @@ export default function ProfileListDropMenu({
                           {
                             variant: "success",
                             style: {
-                              fontFamily: "interMedium",
                               fontSize: "0.9rem",
                               background: theme.palette.primary.main,
                             },
@@ -193,7 +183,6 @@ export default function ProfileListDropMenu({
                       </ListItemIcon>
                       <ListItemText
                         primary={saved ? "Unsave Watchlist" : "Save Watchlist"}
-                        primaryTypographyProps={listItemStyling}
                       />
                     </ListItemButton>
                   )}
@@ -208,10 +197,7 @@ export default function ProfileListDropMenu({
                       <ListItemIcon>
                         <Trash size={24} />
                       </ListItemIcon>
-                      <ListItemText
-                        primary="Delete List"
-                        primaryTypographyProps={listItemStyling}
-                      ></ListItemText>
+                      <ListItemText primary="Delete List"></ListItemText>
                     </ListItemButton>
                   )}
                 </MenuList>

--- a/src/Components/ProfileListItem.js
+++ b/src/Components/ProfileListItem.js
@@ -62,10 +62,7 @@ export default function ProfileListItem({
             sx={{ height: "56px" }}
           ></Box>{" "}
         </ListItemAvatar>
-        <ListItemText
-          primary={item.display_name}
-          primaryTypographyProps={{ fontFamily: "interMedium" }}
-        />
+        <ListItemText primary={item.display_name} />
         {smallScreen ? (
           <LikeButtonsDropMenu
             anime={item}

--- a/src/Components/ProfileListPage.js
+++ b/src/Components/ProfileListPage.js
@@ -118,8 +118,7 @@ export default function ProfileListPage() {
     confirm({
       title: "Delete Watchlist?",
       content: "Deleting a watchlist is permanent. There is no undo.",
-      titleProps: { sx: { fontFamily: "interExtraBold" } },
-      contentProps: { sx: { fontFamily: "interMedium" } },
+      titleProps: { sx: { fontWeight: 800 } },
       confirmationText: "Delete",
       cancellationButtonProps: { color: "inherit" },
       cancellationText: "Cancel",
@@ -140,22 +139,18 @@ export default function ProfileListPage() {
   }
 
   const headStyle = {
-    fontFamily: "interBlack",
+    fontWeight: 900,
     fontSize: { xs: "1.66rem", md: "2.5rem" },
     pb: 0,
   };
 
   const subheadStyle = {
-    fontFamily: "interBlack",
-    fontSize: "22px",
-    lineHeight: "27px",
     marginTop: "26px",
     marginBottom: "12px",
   };
 
   const subtitleStyle = {
-    fontFamily: "interSemiBold",
-    fontSize: "16px",
+    fontWeight: 600,
   };
 
   return (
@@ -293,7 +288,7 @@ export default function ProfileListPage() {
       {/*Suggestions*/}
       {showSuggestions && (
         <>
-          <Typography variant="h5" style={subheadStyle}>
+          <Typography variant="h3" style={subheadStyle}>
             Suggested
           </Typography>
           <ProfileListSuggestions items={items} amount={12} />

--- a/src/Components/ProfileListPage.js
+++ b/src/Components/ProfileListPage.js
@@ -69,6 +69,7 @@ export default function ProfileListPage() {
   const sevenHundredFifty = useMediaQuery(
     theme.breakpoints.up("sevenHundredFifty")
   );
+  const elevenHundred = useMediaQuery(theme.breakpoints.up("elevenHundred"));
 
   if (isLoading) {
     return <ProfileListPageGhost />;
@@ -171,12 +172,14 @@ export default function ProfileListPage() {
       >
         <Grid
           item
+          elevenHundred={8}
           sevenHundredFifty={6}
           xs={10}
           sx={{ display: "flex", flexDirection: "column", flexGrow: 1 }}
         >
           <ClickAndEdit
             data={name}
+            label={"Edit watchlist name"}
             placeholder="Watchlist Name"
             canEdit={isOwnProfile && typeName === "Watchlist"}
             styling={headStyle}
@@ -188,6 +191,7 @@ export default function ProfileListPage() {
         </Grid>
         <Grid
           item
+          elevenHundred={3.25}
           sevenHundredFifty={5.25}
           xs={12}
           order={{ xs: 4, sevenHundredFifty: 2 }}
@@ -245,6 +249,7 @@ export default function ProfileListPage() {
           <Grid item xs={12} order={{ xs: 3, sevenHundredFifty: 4 }}>
             <ClickAndEdit
               data={desc}
+              label={"Edit watchlist description"}
               canEdit={isOwnProfile}
               onSave={onDescSave}
               placeholder={"Tell us a bit about this list..."}

--- a/src/Components/ProfileMainPage.js
+++ b/src/Components/ProfileMainPage.js
@@ -11,16 +11,8 @@ export default function ProfileMainPage() {
   const { profile, animeObjects, isLoading } = useContext(ProfilePageContext);
 
   const subheadStyle = {
-    fontFamily: "interBlack",
-    fontSize: "22px",
-    lineHeight: "27px",
     marginTop: "26px",
     marginBottom: "12px",
-  };
-
-  const bodyStyle = {
-    fontFamily: "interMedium",
-    fontSize: "16px",
   };
 
   // To-do: Error screen on error.

--- a/src/Components/ProfilePageContext.js
+++ b/src/Components/ProfilePageContext.js
@@ -6,6 +6,7 @@ const ProfilePageContext = createContext({
   profileUserId: undefined,
   isOwnProfile: false,
   isLoading: false,
+  updateDisplayName: (name) => {},
   updateBio: (bio) => {},
   updateAvatar: (avatar) => {},
   updateLikes: (likes) => {},

--- a/src/Components/ProfilePageContextProvider.js
+++ b/src/Components/ProfilePageContextProvider.js
@@ -24,6 +24,11 @@ export default function ProfilePageContextProvider({ userId, children }) {
     profileUserId: userId,
     isOwnProfile: userOwnsProfile,
     isLoading: loading || profileLoading || !localUser?.uid || isLoadingAnime,
+    updateDisplayName: (name) => {
+      throwIfNotOwner();
+      const newLocalUser = { ...localUser, name };
+      save(newLocalUser);
+    },
     updateBio: (bio) => {
       throwIfNotOwner();
       const newLocalUser = { ...localUser, bio };

--- a/src/Components/ProfileSidebar.js
+++ b/src/Components/ProfileSidebar.js
@@ -48,6 +48,7 @@ export default function ProfileSidebar({ hideDetails }) {
           </Typography>
           <ClickAndEdit
             data={profile?.bio}
+            label={"Edit bio"}
             canEdit={isOwnProfile}
             onSave={updateBio}
             placeholder={"Tell us a bit about yourself..."}

--- a/src/Components/ProfileSidebar.js
+++ b/src/Components/ProfileSidebar.js
@@ -37,9 +37,8 @@ export default function ProfileSidebar({ hideDetails }) {
             </div>
           )}
           <Typography
+            variant="h3"
             sx={{
-              fontFamily: "interBlack",
-              fontSize: "1.375rem",
               mt: 3,
               pb: 1,
             }}

--- a/src/Components/ProfileUserBanner.js
+++ b/src/Components/ProfileUserBanner.js
@@ -75,7 +75,7 @@ export default function ProfileUserBanner() {
           placeholder={"Your display name"}
           styling={{
             pb: "0px",
-            fontFamily: "interBlack",
+            fontWeight: 900,
             fontSize: { xs: "1.66rem", md: "2.5rem" },
           }}
         />

--- a/src/Components/ProfileUserBanner.js
+++ b/src/Components/ProfileUserBanner.js
@@ -9,9 +9,11 @@ import { useContext, useMemo, useState } from "react";
 import { getAvatarSrc } from "./Avatars";
 import ChooseAvatar from "./ChooseAvatar";
 import ProfilePageContext from "./ProfilePageContext";
+import ClickAndEdit from "./ClickAndEdit";
 
 export default function ProfileUserBanner() {
-  const { profile, isOwnProfile } = useContext(ProfilePageContext);
+  const { profile, isOwnProfile, updateDisplayName } =
+    useContext(ProfilePageContext);
 
   const [editAvatar, setEditAvatar] = useState(false);
 
@@ -65,22 +67,16 @@ export default function ProfileUserBanner() {
             src={avatarSrc}
           />
         )}
-
-        <ListItemText
-          sx={{ ml: 1 }}
-          primary={profile?.name}
-          primaryTypographyProps={{
+        <ClickAndEdit
+          data={profile?.name}
+          label={"Edit display name"}
+          canEdit={isOwnProfile}
+          onSave={updateDisplayName}
+          placeholder={"Your display name"}
+          styling={{
+            pb: "0px",
             fontFamily: "interBlack",
             fontSize: { xs: "1.66rem", md: "2.5rem" },
-            overflow: "hidden",
-            textOverflow: "ellipsis",
-          }}
-          secondaryTypographyProps={{
-            fontFamily: "interMedium",
-            fontSize: "1rem",
-            color: "text",
-            overflow: "hidden",
-            textOverflow: "ellipsis",
           }}
         />
       </div>

--- a/src/Components/ProfileUserBannerSmall.js
+++ b/src/Components/ProfileUserBannerSmall.js
@@ -33,13 +33,12 @@ export default function ProfileUserBannerSmall() {
         <ListItemText
           primary={profile?.name}
           primaryTypographyProps={{
-            fontFamily: "interSemiBold",
+            fontWeight: 600,
             fontSize: "1.125rem",
             overflow: "hidden",
             textOverflow: "ellipsis",
           }}
           secondaryTypographyProps={{
-            fontFamily: "interMedium",
             fontSize: "0.875rem",
             color: "text",
             overflow: "hidden",

--- a/src/Components/Register.js
+++ b/src/Components/Register.js
@@ -115,12 +115,12 @@ export default function Register() {
           alignItems: "center",
         }}
       >
-        <h4
-          className="H4"
+        <Typography
+          variant="h3"
           style={{ textAlign: "center", margin: 0, marginBottom: "18px" }}
         >
           Let's Get Registered!
-        </h4>
+        </Typography>
         <div
           className="register__container"
           style={{

--- a/src/Components/Register.js
+++ b/src/Components/Register.js
@@ -53,7 +53,7 @@ export default function Register() {
     textTransform: "none",
     borderRadius: "24px",
     width: "350px",
-    fontFamily: "interExtraBold",
+    fontWeight: 800,
     fontSize: "1rem",
     marginBottom: "17px",
   };
@@ -271,7 +271,6 @@ export default function Register() {
               "&::before, &::after": {
                 borderColor: theme.palette.text.primary,
               },
-              fontFamily: "interMedium",
               margin: "18px 0px",
             }}
           >
@@ -290,16 +289,8 @@ export default function Register() {
             helperText={errors.username?.message}
             inputProps={{
               style: {
-                fontSize: "1.0rem",
-                fontFamily: "interMedium",
                 paddingTop: "12.5px",
                 paddingBottom: "12.5px",
-              },
-            }}
-            InputLabelProps={{
-              style: {
-                fontSize: "1.0rem",
-                fontFamily: "interMedium",
               },
             }}
             sx={{
@@ -310,8 +301,6 @@ export default function Register() {
               },
               borderRadius: "9px",
               marginBottom: "20px",
-              fontFamily: "interMedium",
-              fontSize: "1rem",
             }}
           />
           {/* *******************EdwardML - Email Field************************** */}
@@ -327,16 +316,8 @@ export default function Register() {
             helperText={errors.email?.message}
             inputProps={{
               style: {
-                fontSize: "1.0rem",
-                fontFamily: "interMedium",
                 paddingTop: "12.5px",
                 paddingBottom: "12.5px",
-              },
-            }}
-            InputLabelProps={{
-              style: {
-                fontSize: "1.0rem",
-                fontFamily: "interMedium",
               },
             }}
             sx={{
@@ -362,16 +343,8 @@ export default function Register() {
             helperText={errors.password?.message}
             inputProps={{
               style: {
-                fontSize: "1.0rem",
-                fontFamily: "interMedium",
                 paddingTop: "12.5px",
                 paddingBottom: "12.5px",
-              },
-            }}
-            InputLabelProps={{
-              style: {
-                fontSize: "1.0rem",
-                fontFamily: "interMedium",
               },
             }}
             sx={{
@@ -382,8 +355,6 @@ export default function Register() {
               },
               borderRadius: "9px",
               marginBottom: "20px",
-              fontFamily: "interMedium",
-              fontSize: "1rem",
             }}
           />
           {/* *******************EdwardML - 'Let's Go!' Button************************** */}
@@ -426,16 +397,14 @@ export default function Register() {
               sx={{
                 color: "error.main",
                 marginTop: "10px",
-                fontFamily: "interExtraBold",
+                fontWeight: 800,
               }}
             >
               *Please resolve errors shown above.
             </Typography>
           )}
           {emailError && (
-            <Typography
-              sx={{ color: "error.main", fontFamily: "interExtraBold" }}
-            >
+            <Typography sx={{ color: "error.main", fontWeight: 800 }}>
               {emailError}
             </Typography>
           )}
@@ -448,15 +417,11 @@ export default function Register() {
             }}
           />
           {/* *******************Already Registered Section************************** */}
-          <div style={{ fontFamily: "interMedium" }}>
+          <div>
             Already registered?{" "}
-            <Link to="/login">
-              <span
-                style={{ fontFamily: "interExtraBold", fontWeight: "bold" }}
-              >
-                Login here!
-              </span>
-            </Link>
+            <Typography component="span" sx={{ fontWeight: 800 }}>
+              <Link to="/login">Login here!</Link>
+            </Typography>
           </div>
         </div>
       </Container>

--- a/src/Components/Reset.js
+++ b/src/Components/Reset.js
@@ -52,8 +52,8 @@ export default function Reset() {
           <DialogTitle
             id="alert-dialog-title"
             sx={{
-              fontFamily: "interExtraBold",
-              fontSize: "1.5rem",
+              fontWeight: 800,
+              //fontSize: "1.5rem",
               textAlign: "center",
             }}
           >
@@ -63,9 +63,7 @@ export default function Reset() {
             <DialogContentText
               id="alert-dialog-description"
               sx={{
-                fontFamily: "interMedium",
                 textAlign: "center",
-                fontSize: "1.1rem",
               }}
             >
               If EdwardML has an account with the email address that was
@@ -120,16 +118,8 @@ export default function Reset() {
             required
             inputProps={{
               style: {
-                fontSize: "1.0rem",
-                fontFamily: "interMedium",
                 paddingTop: "12.5px",
                 paddingBottom: "12.5px",
-              },
-            }}
-            InputLabelProps={{
-              style: {
-                fontSize: "1.0rem",
-                fontFamily: "interMedium",
               },
             }}
             sx={{
@@ -140,8 +130,6 @@ export default function Reset() {
               },
               borderRadius: "9px",
               marginBottom: "20px",
-              fontFamily: "interMedium",
-              fontSize: "1rem",
             }}
           />
           {/* *******************'Send Password Reset' Button************************** */}
@@ -169,14 +157,10 @@ export default function Reset() {
             }}
           />
           {/* *******************Already Registered Section************************** */}
-          <div style={{ fontFamily: "interMedium" }}>
+          <div>
             Need an account?{" "}
             <Link to="/register">
-              <span
-                style={{ fontFamily: "interExtraBold", fontWeight: "bold" }}
-              >
-                Register here!
-              </span>
+              <span style={{ fontWeight: 800 }}>Register here!</span>
             </Link>
           </div>
         </div>

--- a/src/Components/Reset.js
+++ b/src/Components/Reset.js
@@ -53,7 +53,6 @@ export default function Reset() {
             id="alert-dialog-title"
             sx={{
               fontWeight: 800,
-              //fontSize: "1.5rem",
               textAlign: "center",
             }}
           >

--- a/src/Components/Review.js
+++ b/src/Components/Review.js
@@ -57,8 +57,7 @@ export default function Review({
     confirm({
       title: `Delete ${typeSingular}`,
       content: `Deleting a ${typeSingular} is permanent. There is no undo.`,
-      titleProps: { sx: { fontFamily: "interExtraBold" } },
-      contentProps: { sx: { fontFamily: "interMedium" } },
+      titleProps: { sx: { fontWeight: 800 } },
       confirmationText: "Delete",
       cancellationButtonProps: { color: "inherit" },
       cancellationText: "Cancel",
@@ -135,8 +134,7 @@ export default function Review({
             <Typography
               component="span"
               sx={{
-                fontFamily: "interSemiBold",
-                fontSize: "1rem",
+                fontWeight: 600,
               }}
             >
               {reviewerInfo?.name}
@@ -145,7 +143,6 @@ export default function Review({
               <Typography
                 component="span"
                 sx={{
-                  fontFamily: "interMedium",
                   fontSize: "0.9rem",
                   color: { xs: "grey", sm: "inherit" },
                 }}
@@ -191,10 +188,7 @@ export default function Review({
                   mt: 1,
                 }}
               >
-                <Typography
-                  component="span"
-                  sx={{ fontFamily: "interBlack", fontSize: "1rem", mr: 2 }}
-                >
+                <Typography component="span" sx={{ fontWeight: 900, mr: 2 }}>
                   {item.reviewTitle}
                 </Typography>{" "}
                 <ConvertDate item={item} />
@@ -239,8 +233,6 @@ export default function Review({
               <ExpandableText
                 text={item.review}
                 sx={{
-                  fontFamily: "interMedium",
-                  fontSize: "16px",
                   lineHeight: "21px",
                   whiteSpace: "pre-line",
                 }}
@@ -308,9 +300,7 @@ export default function Review({
 function ConvertDate({ item }) {
   const time = format(fromUnixTime(item.time.seconds), "MMMM dd, yyyy");
   return (
-    <Typography
-      sx={{ fontFamily: "interMedium", color: "grey", fontSize: "0.9rem" }}
-    >
+    <Typography sx={{ color: "grey", fontSize: "0.9rem" }}>
       {item?.edited ? "Edited on" : ""} {time.toString()}
     </Typography>
   );

--- a/src/Components/ReviewContainer.js
+++ b/src/Components/ReviewContainer.js
@@ -27,9 +27,6 @@ export default function ReviewContainer({ user, docId, type }) {
   const typeSingular = type === "comments" ? "comment" : "review";
 
   const subheadStyle = {
-    fontFamily: "interBlack",
-    fontSize: "22px",
-    lineHeight: "27px",
     marginTop: "24px",
     marginBottom: "12px",
   };
@@ -59,7 +56,7 @@ export default function ReviewContainer({ user, docId, type }) {
       >
         <Typography
           component="div"
-          variant="h5"
+          variant="h3"
           style={{
             ...subheadStyle,
             display: "flex",
@@ -70,8 +67,6 @@ export default function ReviewContainer({ user, docId, type }) {
           {reviews?.length > 2 && (
             <Typography
               sx={{
-                fontFamily: "interMedium",
-                fontSize: "1.0rem",
                 marginL: "10px",
                 color: "grey",
                 ml: 1,

--- a/src/Components/ReviewForm.js
+++ b/src/Components/ReviewForm.js
@@ -194,8 +194,6 @@ export default function ReviewForm({
           }}
           inputProps={{
             style: {
-              fontSize: "1.0rem",
-              fontFamily: "interMedium",
               paddingTop: "12.5px",
               paddingBottom: "12.5px",
               maxWidth: "none",
@@ -222,8 +220,6 @@ export default function ReviewForm({
           }}
           inputProps={{
             style: {
-              fontSize: "1.0rem",
-              fontFamily: "interMedium",
               paddingTop: "0px",
               paddingBottom: "0px",
               maxWidth: "none",

--- a/src/Components/Sandbox.js
+++ b/src/Components/Sandbox.js
@@ -4,6 +4,7 @@ import Container from "@mui/material/Container";
 import { useEffect, useState } from "react";
 import LikeButtons from "./LikeButtons";
 import { useAnimeHR } from "./APICalls";
+import { Typography } from "@mui/material";
 
 export default function Sandbox() {
   const [anime, setAnime] = useState();
@@ -13,12 +14,44 @@ export default function Sandbox() {
     setAnime(animeHR);
   }, []);
 
+  const headerMargin = { mt: 1.3, mb: 1.3 };
+
   return (
     <div className="App">
       <Container maxwidth="sm">
         <div className="gap" />
 
-        <h1>Dev Sandbox</h1>
+        <Typography variant="h2" sx={{ mb: 5 }}>
+          Dev Sandbox
+        </Typography>
+
+        <Typography variant="h1" sx={headerMargin}>
+          Hero Header (h1)
+        </Typography>
+
+        <Typography variant="h2" sx={headerMargin}>
+          Page Header (h2)
+        </Typography>
+
+        <Typography variant="h3" sx={headerMargin}>
+          Section Header (h3)
+        </Typography>
+
+        <Typography variant="h4" sx={headerMargin}>
+          Light Header (h4)
+        </Typography>
+
+        <Typography variant="h5" sx={headerMargin}>
+          Subheader (h5)
+        </Typography>
+
+        <p>
+          Moments prior to Naruto Uzumaki's birth, a huge demon known as the
+          Kyuubi, the Nine-Tailed Fox, attacked Konohagakure, the Hidden Leaf
+          Village, and wreaked havoc. In order to put an end to the Kyuubi's
+          rampage, the leader of the village, the Fourth Hokage, sacrificed his
+          life and sealed the monstrous beast inside the newborn Naruto.
+        </p>
 
         <h4>Default Buttons</h4>
         {["small", "medium", "large"].map((size) => (

--- a/src/Components/Sandbox.js
+++ b/src/Components/Sandbox.js
@@ -1,10 +1,10 @@
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import Container from "@mui/material/Container";
+import Typography from "@mui/material/Typography";
 import { useEffect, useState } from "react";
 import LikeButtons from "./LikeButtons";
 import { useAnimeHR } from "./APICalls";
-import { Typography } from "@mui/material";
 
 export default function Sandbox() {
   const [anime, setAnime] = useState();
@@ -53,7 +53,9 @@ export default function Sandbox() {
           life and sealed the monstrous beast inside the newborn Naruto.
         </p>
 
-        <h4>Default Buttons</h4>
+        <Typography variant="h3" sx={headerMargin}>
+          Default Buttons
+        </Typography>
         {["small", "medium", "large"].map((size) => (
           <Box key={size} sx={{ mb: 2 }}>
             <Button variant="text" color="inherit" size={size}>
@@ -86,7 +88,9 @@ export default function Sandbox() {
           </Box>
         ))}
 
-        <h4>Like Buttons</h4>
+        <Typography variant="h3" sx={headerMargin}>
+          Like Buttons
+        </Typography>
         {!anime && <div>Loading...</div>}
         {anime &&
           anime.map((a) => (

--- a/src/Components/ScoreBars.js
+++ b/src/Components/ScoreBars.js
@@ -25,8 +25,6 @@ export default function ScoreBars({ scores }) {
           <Tooltip title={score.description}>
             <Typography
               sx={{
-                fontFamily: "interMedium",
-                fontSize: "16px",
                 mb: "4px",
                 width: "104px",
                 flexShrink: 0,

--- a/src/Components/Search.js
+++ b/src/Components/Search.js
@@ -59,7 +59,9 @@ export default function Search() {
   return (
     <div className="jsxWrapper">
       <Container maxWidth="sm">
-        <h4 style={{ textAlign: "center" }}>Search Results:</h4>
+        <Typography variant="h3" style={{ textAlign: "center" }}>
+          Search Results:
+        </Typography>
         <Divider></Divider>
 
         <div className="gap" style={{ marginTop: "30px" }}></div>
@@ -88,8 +90,7 @@ export default function Search() {
                 <ListItemText
                   primary={item.display_name}
                   primaryTypographyProps={{
-                    fontFamily: "interSemiBold",
-                    fontSize: "1rem",
+                    fontWeight: 600,
                   }}
                 />
               </ListItemButton>
@@ -103,9 +104,7 @@ export default function Search() {
               alignItems: "center",
             }}
           >
-            <Typography
-              sx={{ fontFamily: "interSemiBold", fontSize: "1.1rem" }}
-            >
+            <Typography sx={{ fontWeight: 600, fontSize: "1.1rem" }}>
               Your search for "
               <span style={{ color: theme.palette.primary.main }}>
                 {" "}
@@ -140,9 +139,7 @@ export default function Search() {
                 }}
               />
             </Paper>
-            <Typography
-              sx={{ fontFamily: "interSemiBold", fontSize: "1.1rem", mt: 4 }}
-            >
+            <Typography sx={{ fontWeight: 600, fontSize: "1.1rem", mt: 4 }}>
               Please try again!
             </Typography>{" "}
           </div>

--- a/src/Components/ShelfTitle.js
+++ b/src/Components/ShelfTitle.js
@@ -1,4 +1,5 @@
 import Container from "@mui/material/Container";
+import Typography from "@mui/material/Typography";
 import useTheme from "@mui/material/styles/useTheme";
 import GenreChips from "./GenreChips";
 
@@ -16,7 +17,9 @@ export default function ShelfTitle({ selectedGenre, setSelectedGenre, title }) {
       }}
     >
       <Container maxWidth="lg">
-        <h4 style={{ marginBottom: "0.3em" }}>{title}</h4>
+        <Typography variant="h3" sx={{ marginBottom: "0.3em" }}>
+          {title}
+        </Typography>
 
         <GenreChips
           selectedGenre={selectedGenre}

--- a/src/Components/SkipOnboardDialog.js
+++ b/src/Components/SkipOnboardDialog.js
@@ -29,7 +29,6 @@ export default function SkipOnboardDialog() {
           id="alert-dialog-title"
           sx={{
             textAlign: "center",
-            fontFamily: "interMedium",
             fontSize: "1.8rem",
           }}
         >

--- a/src/Components/TitleAutocomplete.js
+++ b/src/Components/TitleAutocomplete.js
@@ -81,8 +81,6 @@ export default function TitleAutocomplete({ search, setShowSearch }) {
                 flexShrink: 0,
                 borderRadius: "8px",
               },
-              fontFamily: "interMedium",
-              fontSize: "1rem",
             }}
             {...props}
           >
@@ -129,8 +127,6 @@ export default function TitleAutocomplete({ search, setShowSearch }) {
                 paddingLeft: "18px",
                 paddingTop: "4px",
                 height: "46px",
-                fontSize: "1rem",
-                fontFamily: "interMedium",
               },
               ".MuiInputLabel-root": {
                 paddingLeft: "18px",

--- a/src/Components/Top8List.js
+++ b/src/Components/Top8List.js
@@ -49,9 +49,8 @@ export default function Top8List() {
         }}
       >
         <Typography
+          variant="h3"
           sx={{
-            fontFamily: "interBlack",
-            fontSize: "1.375rem",
             mt: 1,
             mb: 2.5,
             pl: 2,
@@ -132,10 +131,7 @@ export default function Top8List() {
                             </ListItemAvatar>
                             <Typography
                               sx={{
-                                fontFamily: "interMedium",
-                                fontSize: "1rem",
                                 cursor: "pointer",
-                                lineHeight: "1.5",
                                 maxHeight: "2.625rem",
                                 overflow: "hidden",
                               }}

--- a/src/Components/UrlButtons.js
+++ b/src/Components/UrlButtons.js
@@ -88,11 +88,7 @@ function UrlButton({ title, link, image }) {
       >
         <Box component="img" src={image} alt={title} sx={{ height: 48 }} />
       </IconButton>
-      <Typography
-        sx={{ fontFamily: "interMedium", fontSize: "16px", lineHeight: "21px" }}
-      >
-        {title}
-      </Typography>
+      <Typography>{title}</Typography>
     </Box>
   );
 }

--- a/src/Components/WatchlistTile.js
+++ b/src/Components/WatchlistTile.js
@@ -45,7 +45,7 @@ export default function WatchlistTile({
           <Typography
             variant="h5"
             sx={{
-              fontWeight: 800,
+              fontWeight: 600,
               marginBottom: "6px",
               flexGrow: 1,
               justifyItems: "baseline",

--- a/src/Components/WatchlistTile.js
+++ b/src/Components/WatchlistTile.js
@@ -43,10 +43,9 @@ export default function WatchlistTile({
       >
         <Box sx={{ display: "flex" }}>
           <Typography
-            variant="h6"
+            variant="h5"
             sx={{
-              fontFamily: "interExtraBold",
-              fontSize: "16px",
+              fontWeight: 800,
               marginBottom: "6px",
               flexGrow: 1,
               justifyItems: "baseline",
@@ -55,9 +54,8 @@ export default function WatchlistTile({
             {name}
           </Typography>
           <Typography
+            variant="body2"
             sx={{
-              fontFamily: "interMedium",
-              fontSize: "14px",
               marginLeft: "8px",
             }}
           >
@@ -122,8 +120,6 @@ export default function WatchlistTile({
                 <ListItemText
                   primary={creator}
                   primaryTypographyProps={{
-                    fontFamily: "interMedium",
-                    fontSize: "1rem",
                     overflow: "hidden",
                     textOverflow: "ellipsis",
                   }}

--- a/src/Components/theme.js
+++ b/src/Components/theme.js
@@ -1,6 +1,8 @@
 import createTheme from "@mui/material/styles/createTheme";
 import { alpha } from "@mui/system/colorManipulator";
 
+const mainFontStack = "Inter, Arial-fallback, sans-serif";
+
 export function createAppTheme(darkMode) {
   // A custom theme for this app
   return createTheme({
@@ -45,7 +47,8 @@ export function createAppTheme(darkMode) {
         styleOverrides: {
           root: {
             textTransform: "unset",
-            fontFamily: "interSemiBold",
+            fontFamily: mainFontStack,
+            fontWeight: 600,
           },
           sizeSmall: {
             fontSize: "0.8125rem",
@@ -74,6 +77,12 @@ export function createAppTheme(darkMode) {
           disableElevation: true,
         },
       },
+      MuiLink: {
+        root: {
+          fontFamily: mainFontStack,
+          fontWeight: 600,
+        },
+      },
       MuiChip: {
         styleOverrides: {
           root: {
@@ -92,7 +101,8 @@ export function createAppTheme(darkMode) {
             },
           },
           label: {
-            fontFamily: "interSemiBold, sans-serif",
+            fontFamily: mainFontStack,
+            fontWeight: 600,
           },
         },
       },
@@ -114,7 +124,39 @@ export function createAppTheme(darkMode) {
       },
     },
     typography: {
-      fontFamily: ["Helvetica", "Arial", "sans-serif"],
+      fontFamily: mainFontStack,
+      body1: {
+        letterSpacing: "0.00938em",
+        fontSize: "1rem",
+        lineHeight: 1.5,
+      },
+      h1: {
+        fontFamily: "montserrat, sans-serif",
+        fontSize: "4.0rem",
+      },
+      h2: {
+        fontFamily: mainFontStack,
+        fontSize: "2.5rem",
+        fontWeight: 900,
+      },
+      h3: {
+        fontFamily: mainFontStack,
+        fontSize: "1.375rem",
+        lineHeight: "1.23em",
+        fontWeight: 900,
+      },
+      h4: {
+        fontFamily: mainFontStack,
+        fontSize: "1.25rem",
+        lineHeight: "1.23em",
+        fontWeight: 600,
+      },
+      h5: {
+        fontFamily: mainFontStack,
+        fontSize: "1rem",
+        lineHeight: "1.1875em",
+        fontWeight: 800,
+      },
     },
   });
 }

--- a/src/Components/theme.js
+++ b/src/Components/theme.js
@@ -113,5 +113,8 @@ export function createAppTheme(darkMode) {
         ],
       },
     },
+    typography: {
+      fontFamily: ["Helvetica", "Arial", "sans-serif"],
+    },
   });
 }

--- a/src/Styles/App.css
+++ b/src/Styles/App.css
@@ -1,22 +1,15 @@
 /* GLOBAL FONTS DO NOT DELETE */
-@font-face {
-  font-family: interExtraBold;
-  src: url(./Inter-ExtraBold.woff) format("woff");
-}
+
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@500;600;800;900&display=swap');
 
 @font-face {
-  font-family: interSemiBold;
-  src: url(./Inter-SemiBold.woff) format("woff");
-}
-
-@font-face {
-  font-family: interMedium;
-  src: url(./Inter-Medium.woff) format("woff");
-}
-
-@font-face {
-  font-family: interBlack;
-  src: url(./Inter-Black.woff) format("woff");
+  font-family: Arial-fallback;
+  src: local('Arial');
+  font-size: 16px;
+  line-height: 1.6;
+  font-weight: 500;
+  letter-spacing: 0.5px;
+  word-spacing: 0px;
 }
 
 @font-face {
@@ -157,8 +150,6 @@ h4 {
 }
 
 .shelfTitle {
-  font-family: "interSemiBold", Georgia, "Times New Roman", Times, serif;
-  font-size: 1.25rem;
   margin-top: 2rem;
   margin-bottom: 0.5em;
 }

--- a/src/Styles/App.css
+++ b/src/Styles/App.css
@@ -33,6 +33,7 @@
   font-family: montserratBold;
   src: url(./Montserrat-Bold.woff) format("woff");
 }
+
 /* GLOBAL FONTS DO NOT DELETE */
 
 .App-header {
@@ -150,7 +151,7 @@ css-1cfh48w-MuiGrid-root {
 }
 
 h4 {
-  font-family: interExtraBold, Arial, Helvetica, sans-serif;
+  font-family: interExtraBold;
   font-size: 1.5rem;
   text-align: left;
 }

--- a/src/Styles/index.css
+++ b/src/Styles/index.css
@@ -1,16 +1,8 @@
 body {
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen",
-    "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue",
-    sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   padding-bottom: 50px;
-}
-
-code {
-  font-family: source-code-pro, Menlo, Monaco, Consolas, "Courier New",
-    monospace;
 }
 
 a:-webkit-any-link {


### PR DESCRIPTION
Ok this one was a bit of a pain, but this change sets up all font data to be specified through the theme generated by theme.js. This is much more maintainable, as fonts are no longer hardcoded in individual components. Also, fallback fonts are always applied (previously, if we set `fontFamily: interMedium` on a component, that became the whole font stack for that component, and the fallbacks go back to being system default, probably Times. Yuck.).  So now the "Flash Of Unstyled Text" on page load before the custom fonts load looks much nicer (basically a tweaked Arial is used instead of Inter).

This change touches a _lot_ of files, but 90% of this change is either:
- Deleting lots of `fontFamily: interMedium` since that is now default everywhere, including in material components
- Changing headers from `h3` to `<Typography variant="h3">`
- Replacing some `fontFamily: interExtraBold` type things with `fontWeight: 800`, where we just wanted bold text

This change _should_ be almost entirely a visual no-op. Lmk if you see major changes in appearance and I can fix them.

I moved to loading all font variants under the same font name "Inter" and using font weights to select the bold variations. So, if you need to make some text use SemiBold, just use `fontWeight: 600`, etc. No more need to hardcode font names. Here are the weights mapped to font variants:
- interMedium: default, 500
- interSemiBold: 600
- interExtraBold: 800
- interBlack: 900

When creating headers, use the appropriate semantic header, when possible. There is a meaningful structure to headers `h1` through `h5`, which can be seen in /sandbox, but I will also list them here:

- h1: Hero titles in Montserrat, as seen on the landing page.  Used very rarely.
- h2: Page titles. Heavy weight (Black/900) and large, usually only one of these at the top of every page.
- h3: Section headers. Appear over a subsection of a page. Also heavy (Black/900), not as large. Seen extensively on DetailedView, etc.
- h4: Light headers. For shelf headers under a section header, as seen on Home. Font is _almost_ the same size as h3 but uses a SemiBold weight (600)
- h5: Subheader. Basically body text, but using a heavy (Black/900) weight.

Using only these will also help ensure consistency in fonts, weights, and sizes between pages in the app.

These can be accessed by using `<Typography variant="h3" />` or similar. It bums me out that material doesn't override the base header tags `<h3>`, but oh well. It was a pain to chase down all the headers and convert them to Typography, but we only have to do it once.

A cool thing about this implementation, in addition to better centralizing all font stuff and making sure the default font stack is applied everywhere, is it makes it easy to experiment with large typography changes for the app (want to see what happens if we use a different font for body text? what happens if section headers are less bold? This should be a one or two line change).