### PR TITLE
Fixes bugs/nits

### DIFF
--- a/src/Components/ClickAndEdit.js
+++ b/src/Components/ClickAndEdit.js
@@ -6,6 +6,7 @@ import useTheme from "@mui/material/styles/useTheme";
 import Tooltip from "@mui/material/Tooltip";
 import Box from "@mui/material/Box";
 import useMediaQuery from "@mui/material/useMediaQuery";
+import { useLocation } from "react-router-dom";
 
 export default function ClickAndEdit({
   data,
@@ -17,8 +18,9 @@ export default function ClickAndEdit({
 }) {
   placeholder = placeholder ?? "Enter some text...";
 
+  const location = useLocation();
   const theme = useTheme();
-
+  console.log(location);
   const [editDesc, setEditDesc] = useState(false);
   const [editedDesc, setEditedDesc] = useState(data);
 
@@ -37,10 +39,14 @@ export default function ClickAndEdit({
     if (e?.key === "Enter") e.preventDefault();
   }
 
+  useEffect(() => {
+    setEditDesc(false);
+  }, [location]);
+
   return (
     <div style={{ display: "flex", flex: "1" }}>
       {!editDesc ? (
-        <Box sx={{ display: "flex" }}>
+        <Box sx={{ display: "flex", flex: "1" }}>
           <Tooltip
             title={canEdit ? label : ""}
             placement="bottom"

--- a/src/Components/ClickAndEdit.js
+++ b/src/Components/ClickAndEdit.js
@@ -20,7 +20,7 @@ export default function ClickAndEdit({
 
   const location = useLocation();
   const theme = useTheme();
-  console.log(location);
+
   const [editDesc, setEditDesc] = useState(false);
   const [editedDesc, setEditedDesc] = useState(data);
 

--- a/src/Components/DropMenu.js
+++ b/src/Components/DropMenu.js
@@ -111,7 +111,7 @@ export default function DropMenu() {
       <Avatar
         ref={anchorRef}
         id="composition-button"
-        alt={user?.displayName ?? "Guest"}
+        alt={localUser?.name ?? "Guest"}
         src={avatarSrc ?? "purposefully bad link"}
         aria-controls={open ? "composition-menu" : undefined}
         aria-expanded={open ? "true" : undefined}
@@ -163,7 +163,7 @@ export default function DropMenu() {
                   >
                     <ListItemAvatar>
                       <Avatar
-                        alt={user?.displayName ?? "Guest"}
+                        alt={localUser?.name ?? "Guest"}
                         src={avatarSrc ?? "purposefully bad link"}
                         sx={{
                           bgcolor: theme.palette.primary.main,
@@ -176,9 +176,7 @@ export default function DropMenu() {
                       sx={{
                         color: user ? "primary" : theme.palette.text.primary,
                       }}
-                      primary={
-                        user?.displayName ? `${user?.displayName}` : "Guest"
-                      }
+                      primary={localUser?.name ? `${localUser?.name}` : "Guest"}
                       primaryTypographyProps={{ fontWeight: 600 }}
                     />
                   </ListItemButton>

--- a/src/Components/ProfileUserBanner.js
+++ b/src/Components/ProfileUserBanner.js
@@ -72,7 +72,7 @@ export default function ProfileUserBanner() {
             src={avatarSrc}
           />
         )}
-        <Box sx={{ ml: 2 }}>
+        <Box sx={{ ml: 2, display: "flex", flex: "1" }}>
           <ClickAndEdit
             data={profile?.name}
             label={"Edit display name"}


### PR DESCRIPTION
- Shows correct display name in `DropMenu.js`
- Fix display name in `ProfileUserBanner` to spread across entire page when opened for editing.
- Fix bug where if a `ClickAndEdit` component is open on your profile for editing, then after navigating to another user's profile would cause the wrong display name to show.