### PR TITLE
Implement fallback font overrides for less layout shift

### DIFF
--- a/src/Components/theme.js
+++ b/src/Components/theme.js
@@ -1,7 +1,7 @@
 import createTheme from "@mui/material/styles/createTheme";
 import { alpha } from "@mui/system/colorManipulator";
 
-const mainFontStack = "Inter, Arial-fallback, sans-serif";
+const mainFontStack = "Inter, Arial-fallback, Roboto-fallback, sans-serif";
 
 export function createAppTheme(darkMode) {
   // A custom theme for this app

--- a/src/Styles/App.css
+++ b/src/Styles/App.css
@@ -5,11 +5,14 @@
 @font-face {
   font-family: Arial-fallback;
   src: local('Arial');
-  font-size: 16px;
-  line-height: 1.6;
-  font-weight: 500;
-  letter-spacing: 0.5px;
-  word-spacing: 0px;
+  size-adjust: 107.35%;
+}
+
+@font-face {
+  font-family: Roboto-fallback;
+  src: local("Roboto");
+  size-adjust: 108.5%;
+  line-gap-override: 95%;
 }
 
 @font-face {


### PR DESCRIPTION
Which I learned about at https://developer.chrome.com/blog/font-fallbacks.  Inter is a bit bigger than Arial, so I adjusted Arial to be larger for less layout shift once Inter loads.  What I was doing before with actual text css properties was wrong.

Before: https://drive.google.com/file/d/1RK10nygHeuNcCt2O4qOfuelKCcH7AssS/view?usp=sharing
After: https://drive.google.com/file/d/1PkwJqAiXQqW_EhFhj0AVkrKuzwEYA_lE/view?usp=sharing

I also added a Roboto fallback since Android doesn't have Arial installed by default.