### PR TITLE
Lighthouse improvements

### DIFF
--- a/src/Components/EdwardMLLogo.js
+++ b/src/Components/EdwardMLLogo.js
@@ -7,7 +7,11 @@ export default function EdwardMLLogo() {
 
   return (
     <div className="logo" style={{ height: "68px" }}>
-      <img src={logo} alt="" style={{ width: "35px" }} />
+      <img
+        src={logo}
+        alt=""
+        style={{ width: "35px", aspectRatio: "35/63.19" }}
+      />
       <Box component="div" sx={{ display: { xs: "none", sm: "flex" } }}>
         <h2
           className="appName"

--- a/src/Components/LandingPageHeader.js
+++ b/src/Components/LandingPageHeader.js
@@ -30,7 +30,11 @@ export default function LandingPageHeader() {
         <Grid item md={9} sm={9} xs={9}>
           <div className="logo" style={{ height: "68px" }}>
             <Link to="/" style={{ display: "flex" }}>
-              <img src={logo} alt="" style={{ width: "35px" }} />
+              <img
+                src={logo}
+                alt=""
+                style={{ width: "35px", aspectRatio: "35/63.19" }}
+              />
               <Box
                 component="div"
                 sx={{ display: { xs: "none", fiveHundred: "flex" } }}

--- a/src/Styles/App.css
+++ b/src/Styles/App.css
@@ -1,10 +1,10 @@
 /* GLOBAL FONTS DO NOT DELETE */
 
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@500;600;800;900&display=swap');
+@import url("https://fonts.googleapis.com/css2?family=Inter:wght@500;600;800;900&display=swap");
 
 @font-face {
   font-family: Arial-fallback;
-  src: local('Arial');
+  src: local("Arial");
   font-size: 16px;
   line-height: 1.6;
   font-weight: 500;
@@ -15,16 +15,19 @@
 @font-face {
   font-family: montserrat;
   src: url(./Montserrat-Black.woff) format("woff");
+  font-display: swap;
 }
 
 @font-face {
   font-family: montserratExtraBold;
   src: url(./Montserrat-ExtraBold.woff) format("woff");
+  font-display: swap;
 }
 
 @font-face {
   font-family: montserratBold;
   src: url(./Montserrat-Bold.woff) format("woff");
+  font-display: swap;
 }
 
 /* GLOBAL FONTS DO NOT DELETE */


### PR DESCRIPTION
A couple of improvements based on Lighthouse feedback.
- Gives edward logo a fixed ratio to prevent re-paints
- Allows montserrat font to use a fallback font...(I realize we don't have a fallback font specified for montserrat at the moment - we can discuss more at our next mtg!)