### PR TITLE
Search caching & debouncing

### DIFF
--- a/src/Components/APICalls.js
+++ b/src/Components/APICalls.js
@@ -15,6 +15,9 @@ export function useAPISearch(inputValue) {
       let responseJson = await response.json();
       let temp = [];
       responseJson.items.map((item, index) => temp.push(item));
+      // Clears option field if search term is "".
+      if (inputValue.length === 0) return [];
+      // Otherwise return query results
       return temp;
     },
     { staleTime: fiveMinutesMs }

--- a/src/Components/APICalls.js
+++ b/src/Components/APICalls.js
@@ -4,6 +4,23 @@ const fiveMinutesMs = 1000 * 60 * 5;
 
 const apiUrl = `https://api-jet-lfoguxrv7q-uw.a.run.app`;
 
+export function useAPISearch(inputValue) {
+  return useQuery(
+    ["search" + inputValue],
+    async () => {
+      let response = await fetch(`${apiUrl}/anime/search?query=${inputValue}`, {
+        mode: "cors",
+      });
+      await handleErrors(response);
+      let responseJson = await response.json();
+      let temp = [];
+      responseJson.items.map((item, index) => temp.push(item));
+      return temp;
+    },
+    { staleTime: fiveMinutesMs }
+  );
+}
+
 export async function APISearch(inputValue) {
   let response = await fetch(`${apiUrl}/anime/search?query=${inputValue}`, {
     mode: "cors",

--- a/src/Components/APICalls.js
+++ b/src/Components/APICalls.js
@@ -6,7 +6,7 @@ const apiUrl = `https://api-jet-lfoguxrv7q-uw.a.run.app`;
 
 export function useAPISearch(inputValue) {
   return useQuery(
-    ["search" + inputValue],
+    ["search:" + inputValue],
     async () => {
       let response = await fetch(`${apiUrl}/anime/search?query=${inputValue}`, {
         mode: "cors",
@@ -19,17 +19,6 @@ export function useAPISearch(inputValue) {
     },
     { staleTime: fiveMinutesMs }
   );
-}
-
-export async function APISearch(inputValue) {
-  let response = await fetch(`${apiUrl}/anime/search?query=${inputValue}`, {
-    mode: "cors",
-  });
-  await handleErrors(response);
-  let responseJson = await response.json();
-  let temp = [];
-  responseJson.items.map((item, index) => temp.push(item));
-  return temp;
 }
 
 export async function APIGetAnime(animeId) {

--- a/src/Components/APICalls.js
+++ b/src/Components/APICalls.js
@@ -5,23 +5,19 @@ const fiveMinutesMs = 1000 * 60 * 5;
 const apiUrl = `https://api-jet-lfoguxrv7q-uw.a.run.app`;
 
 export function useAPISearch(inputValue) {
-  return useQuery(
-    ["search:" + inputValue],
-    async () => {
+  return useQuery({
+    queryKey: ["search:" + inputValue],
+    queryFn: async () => {
       let response = await fetch(`${apiUrl}/anime/search?query=${inputValue}`, {
         mode: "cors",
       });
       await handleErrors(response);
       let responseJson = await response.json();
-      let temp = [];
-      responseJson.items.map((item, index) => temp.push(item));
-      // Clears option field if search term is "".
-      if (inputValue.length === 0) return [];
-      // Otherwise return query results
-      return temp;
+      return responseJson.items ?? [];
     },
-    { staleTime: fiveMinutesMs }
-  );
+    staleTime: fiveMinutesMs,
+    placeholderData: [],
+  });
 }
 
 export async function APIGetAnime(animeId) {

--- a/src/Components/Search.js
+++ b/src/Components/Search.js
@@ -17,7 +17,7 @@ import { auth } from "./Firebase";
 import { PopulateFromFirestore } from "./Firestore";
 import { LocalUserContext } from "./LocalUserContext";
 import EdAndEinGif from "../Styles/images/ein-ed-compressed.gif";
-import { APISearch } from "./APICalls";
+import { useAPISearch } from "./APICalls";
 import BreathingLogo from "./BreathingLogo";
 import SearchGhost from "./SearchGhost";
 
@@ -30,16 +30,16 @@ export default function Search() {
 
   const [localUser, setLocalUser] = useContext(LocalUserContext);
   let [search, setSearch] = useState("");
-  let [searchResults, setSearchResults] = useState(false);
+
+  // To-Do: Handle loading/error states from API call
+  const {
+    data: searchResults,
+    loading: searchLoading,
+    error: apiError,
+  } = useAPISearch(search);
 
   useEffect(() => {
-    if (location.state?.length > 0) {
-      setSearchResults(false);
-      setSearch(location.state);
-      APISearch(location.state)
-        .then((result) => setSearchResults(result))
-        .catch((error) => console.log(error));
-    }
+    setSearch(location.state);
   }, [location]);
 
   useEffect(() => {

--- a/src/Components/TitleAutocomplete.js
+++ b/src/Components/TitleAutocomplete.js
@@ -27,10 +27,11 @@ export default function TitleAutocomplete({ search, setShowSearch }) {
 
   let focusElement = useRef(null);
 
+  // To-Do: Handle loading/error states from API call
   const {
     data: searchOptions,
-    loading: isLoadingSearch,
-    error: errorSearch,
+    loading: searchLoading,
+    error: apiError,
   } = useAPISearch(inputValue);
 
   function onSubmit(key, input) {
@@ -50,7 +51,7 @@ export default function TitleAutocomplete({ search, setShowSearch }) {
         // Prevents options being set to undefined while APISearch request is being sent
       } else if (searchOptions) setOptions(searchOptions);
     })();
-  }, [inputValue]);
+  }, [inputValue, searchOptions]);
 
   return (
     <div style={{ display: "flex", justifyContent: "center" }}>

--- a/src/Components/TitleAutocomplete.js
+++ b/src/Components/TitleAutocomplete.js
@@ -33,7 +33,7 @@ export default function TitleAutocomplete({ search, setShowSearch }) {
   // To-Do: Handle loading/error states from API call
   const {
     data: searchOptions,
-    loading: searchLoading,
+    isLoading: searchLoading,
     error: apiError,
   } = useAPISearch(searchTerm);
 
@@ -45,12 +45,16 @@ export default function TitleAutocomplete({ search, setShowSearch }) {
     if (key === "Escape") setShowSearch(false);
   }
 
+  // Prevents popper from showing "No Results" during loading state and while there's no search term
+  useEffect(() => {
+    if (!searchLoading && inputValue.length > 0) openPopper();
+    else closePopper();
+  }, [searchOptions]);
+
   const debouncedSearch = useCallback(
     debounce((value) => {
       const normalizedSearchTerm = value?.toLowerCase();
       setSearchTerm(normalizedSearchTerm); // Triggers APISearch call by changing TanStack query key
-      if (value.length !== 0) openPopper();
-      else closePopper();
     }, 450),
     []
   );
@@ -62,7 +66,9 @@ export default function TitleAutocomplete({ search, setShowSearch }) {
 
   // Prevents options being set to undefined while APISearch request is being sent
   useEffect(() => {
-    if (searchOptions) setOptions(searchOptions);
+    if (searchOptions) {
+      setOptions(searchOptions);
+    }
   }, [searchOptions]);
 
   return (

--- a/src/Components/TitleAutocomplete.js
+++ b/src/Components/TitleAutocomplete.js
@@ -6,7 +6,7 @@ import InputAdornment from "@mui/material/InputAdornment";
 import TextField from "@mui/material/TextField";
 import Tooltip from "@mui/material/Tooltip";
 import { useState, useEffect, useRef } from "react";
-import { APISearch } from "./APICalls";
+import { useAPISearch } from "./APICalls";
 import { useNavigate } from "react-router-dom";
 import { useLocation } from "react-router-dom";
 import { MagnifyingGlass } from "phosphor-react";
@@ -27,6 +27,12 @@ export default function TitleAutocomplete({ search, setShowSearch }) {
 
   let focusElement = useRef(null);
 
+  const {
+    data: searchOptions,
+    loading: isLoadingSearch,
+    error: errorSearch,
+  } = useAPISearch(inputValue);
+
   function onSubmit(key, input) {
     if (key === "Enter") {
       navigate("/search", { state: input });
@@ -37,13 +43,15 @@ export default function TitleAutocomplete({ search, setShowSearch }) {
 
   useEffect(() => {
     (async () => {
-      //Clear options when user deletes input field
+      // Clear options when user deletes input field
       if (inputValue && inputValue.length === 0) {
         setLoading(true);
         setOptions([]);
-      } else setOptions(await APISearch(inputValue));
+        // Prevents options being set to undefined while APISearch request is being sent
+      } else if (searchOptions) setOptions(searchOptions);
     })();
   }, [inputValue]);
+
   return (
     <div style={{ display: "flex", justifyContent: "center" }}>
       <Autocomplete

--- a/src/Components/TitleAutocomplete.js
+++ b/src/Components/TitleAutocomplete.js
@@ -49,7 +49,8 @@ export default function TitleAutocomplete({ search, setShowSearch }) {
     debounce((value) => {
       const normalizedSearchTerm = value?.toLowerCase();
       setSearchTerm(normalizedSearchTerm); // Triggers APISearch call by changing TanStack query key
-      openPopper();
+      if (value.length !== 0) openPopper();
+      else closePopper();
     }, 450),
     []
   );
@@ -58,18 +59,6 @@ export default function TitleAutocomplete({ search, setShowSearch }) {
     setInputValue(newInputValue);
     debouncedSearch(newInputValue);
   };
-
-  useEffect(() => {
-    console.log(searchOptions);
-  }, [searchOptions]);
-
-  // Clear options when user deletes input field
-  useEffect(() => {
-    if (inputValue && inputValue.length === 0) {
-      setLoading(true);
-      setOptions([]);
-    }
-  }, [inputValue]);
 
   // Prevents options being set to undefined while APISearch request is being sent
   useEffect(() => {
@@ -90,7 +79,7 @@ export default function TitleAutocomplete({ search, setShowSearch }) {
         onInputChange={handleInput}
         forcePopupIcon={false}
         fullWidth={true}
-        filterSelectedOptions
+        // filterSelectedOptions
         options={options}
         handleHomeEndKeys={true}
         open={open}

--- a/src/Components/TitleAutocomplete.js
+++ b/src/Components/TitleAutocomplete.js
@@ -85,7 +85,7 @@ export default function TitleAutocomplete({ search, setShowSearch }) {
         onInputChange={handleInput}
         forcePopupIcon={false}
         fullWidth={true}
-        // filterSelectedOptions
+        filterSelectedOptions
         options={options}
         handleHomeEndKeys={true}
         open={open}


### PR DESCRIPTION
- Changes our API requests to search into a TanStack query for caching purposes.
- Debounces search requests, currently pauses for 450 ms prior to firing request to API...that feels about right to me, but feel free to tinker with the value.
- Prevents misleading "No Options" result from being shown in popper during loading state.