### PR TITLE
Show 'For You' during localUser loading state

### DIFF
--- a/src/Components/Home.js
+++ b/src/Components/Home.js
@@ -106,22 +106,6 @@ export default function Home() {
       )}
       <Container maxWidth="lg">
         <div className="gap" />
-        {localUser && localUser?.likes.length > 0 ? (
-          <>
-            <Typography
-              variant="h2"
-              style={{
-                marginBlockStart: 0,
-                marginBlockEnd: "0.5rem",
-              }}
-            >
-              For You
-            </Typography>
-            <AnimeGrid items={recommendation} large />
-          </>
-        ) : (
-          ""
-        )}
         {localUser.uid && localUser?.likes.length === 0 ? (
           <Typography
             variant="h2"
@@ -136,7 +120,18 @@ export default function Home() {
             recommendations!
           </Typography>
         ) : (
-          ""
+          <>
+            <Typography
+              variant="h2"
+              style={{
+                marginBlockStart: 0,
+                marginBlockEnd: "0.5rem",
+              }}
+            >
+              For You
+            </Typography>
+            <AnimeGrid items={recommendation} large />
+          </>
         )}
         <div className="gap" />
       </Container>


### PR DESCRIPTION
Change /home to show the 'For You' ghost cards while localUser is loading, regardless of whether the user has liked shows required to generate the 'For You' content.

Great catch on this one Steve - this really smooths out the page load feel.  😎