### PR TITLE
Display privacy setting

### DIFF
--- a/src/Components/ProfileListDropMenu.js
+++ b/src/Components/ProfileListDropMenu.js
@@ -125,7 +125,6 @@ export default function ProfileListDropMenu({
                         variant: "success",
                         style: {
                           fontSize: "0.9rem",
-                          // background: theme.palette.primary.main,
                         },
                         anchorOrigin: {
                           vertical: "top",
@@ -182,7 +181,6 @@ export default function ProfileListDropMenu({
                             variant: "success",
                             style: {
                               fontSize: "0.9rem",
-                              // background: theme.palette.primary.main,
                             },
                             anchorOrigin: {
                               vertical: "top",

--- a/src/Components/ProfileListDropMenu.js
+++ b/src/Components/ProfileListDropMenu.js
@@ -22,6 +22,7 @@ export default function ProfileListDropMenu({
   deletableList,
   userId,
   listId,
+  privateList,
 }) {
   const [open, setOpen] = useState(false);
   const anchorRef = useRef(null);
@@ -119,11 +120,12 @@ export default function ProfileListDropMenu({
                     onClick={() => {
                       navigator.clipboard.writeText(window.location.href);
                       setOpen(false);
+
                       enqueueSnackbar("Link copied to clipboard", {
                         variant: "success",
                         style: {
                           fontSize: "0.9rem",
-                          background: theme.palette.primary.main,
+                          // background: theme.palette.primary.main,
                         },
                         anchorOrigin: {
                           vertical: "top",
@@ -137,6 +139,25 @@ export default function ProfileListDropMenu({
                           </Fragment>
                         ),
                       });
+                      if (privateList) {
+                        enqueueSnackbar("Only you can view this PRIVATE list", {
+                          variant: "warning",
+                          style: {
+                            fontSize: "0.9rem",
+                          },
+                          anchorOrigin: {
+                            vertical: "top",
+                            horizontal: "center",
+                          },
+                          action: (key) => (
+                            <Fragment>
+                              <IconButton onClick={() => closeSnackbar(key)}>
+                                <X color="white" size={20} />
+                              </IconButton>
+                            </Fragment>
+                          ),
+                        });
+                      }
                     }}
                   >
                     <ListItemIcon>
@@ -161,7 +182,7 @@ export default function ProfileListDropMenu({
                             variant: "success",
                             style: {
                               fontSize: "0.9rem",
-                              background: theme.palette.primary.main,
+                              // background: theme.palette.primary.main,
                             },
                             anchorOrigin: {
                               vertical: "top",

--- a/src/Components/ProfileListPage.js
+++ b/src/Components/ProfileListPage.js
@@ -248,6 +248,7 @@ export default function ProfileListPage() {
             deletableList={deletableList}
             userId={userId}
             listId={listId}
+            privateList={privateList}
           />
         </Grid>
 

--- a/src/Components/ProfileListPage.js
+++ b/src/Components/ProfileListPage.js
@@ -1,11 +1,17 @@
 import Box from "@mui/material/Box";
-import IconButton from "@mui/material/IconButton";
 import List from "@mui/material/List";
 import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
 
 import { useConfirm } from "material-ui-confirm";
-import { CaretLeft, HandsClapping, Heart, Trash, X } from "phosphor-react";
+import {
+  GlobeHemisphereWest,
+  HandsClapping,
+  Heart,
+  LockSimple,
+  Trash,
+  X,
+} from "phosphor-react";
 import { useContext, useEffect, useState } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
 import { slugifyListName } from "../Util/ListUtil";
@@ -61,6 +67,7 @@ export default function ProfileListPage() {
   let deletableList = false;
   let listHasDesc = false;
   let showSuggestions = false;
+  let privateList = false;
 
   useEffect(() => {
     GetListReactions(`${userId}+${listId}`, setListRxns);
@@ -95,6 +102,7 @@ export default function ProfileListPage() {
     name = list.name;
     typeName = "Watchlist";
     desc = list.desc;
+    privateList = list.privateList;
     updateFn = (newItems) =>
       updateList(index, { ...list, anime: newItems, desc: desc });
     deleteFn = () => deleteList(index);
@@ -180,9 +188,12 @@ export default function ProfileListPage() {
             styling={headStyle}
             onSave={onListTitleSave}
           />
-          <Typography variant="body1" sx={subtitleStyle}>
-            {getSubtitleText(typeName, items)}
-          </Typography>
+          <div style={{ display: "flex" }}>
+            <Typography variant="body1" sx={subtitleStyle}>
+              {getSubtitleText(typeName, items)}
+            </Typography>
+            {isOwnProfile && <GetPrivacySymbol privateList={privateList} />}
+          </div>
         </Grid>
         <Grid
           item
@@ -328,4 +339,19 @@ function getItemsText(items) {
   }
 
   return `${items.length} items`;
+}
+
+function GetPrivacySymbol({ privateList }) {
+  return (
+    <Tooltip title={privateList ? "Private list" : "Public list"}>
+      <div style={{ display: "flex", alignItems: "center" }}>
+        <Typography sx={{ ml: "0.25em", mr: "0.25em" }}> • </Typography>
+        {privateList ? (
+          <LockSimple size={20} />
+        ) : (
+          <GlobeHemisphereWest size={20} />
+        )}
+      </div>
+    </Tooltip>
+  );
 }

--- a/src/Components/ProfileListPage.js
+++ b/src/Components/ProfileListPage.js
@@ -192,7 +192,7 @@ export default function ProfileListPage() {
             <Typography variant="body1" sx={subtitleStyle}>
               {getSubtitleText(typeName, items)}
             </Typography>
-            {isOwnProfile && <GetPrivacySymbol privateList={privateList} />}
+            {isOwnProfile && <PrivacySymbol privateList={privateList} />}
           </div>
         </Grid>
         <Grid
@@ -342,17 +342,17 @@ function getItemsText(items) {
   return `${items.length} items`;
 }
 
-function GetPrivacySymbol({ privateList }) {
+function PrivacySymbol({ privateList }) {
   return (
-    <Tooltip title={privateList ? "Private list" : "Public list"}>
-      <div style={{ display: "flex", alignItems: "center" }}>
-        <Typography sx={{ ml: "0.25em", mr: "0.25em" }}> • </Typography>
+    <div style={{ display: "flex", alignItems: "center" }}>
+      <Typography sx={{ ml: "0.25em", mr: "0.25em" }}> • </Typography>
+      <Tooltip title={privateList ? "Private list" : "Public list"}>
         {privateList ? (
           <LockSimple size={20} />
         ) : (
           <GlobeHemisphereWest size={20} />
         )}
-      </div>
-    </Tooltip>
+      </Tooltip>
+    </div>
   );
 }

--- a/src/Components/ProfileUserBanner.js
+++ b/src/Components/ProfileUserBanner.js
@@ -39,7 +39,12 @@ export default function ProfileUserBanner() {
           <Tooltip title="Change your avatar">
             <ListItemButton
               onClick={handleAvatarToggle}
-              sx={{ maxWidth: "96px", p: 1, borderRadius: "16px" }}
+              sx={{
+                maxWidth: "96px",
+                p: 1,
+                borderRadius: "16px",
+                flexShrink: 0,
+              }}
             >
               <Avatar
                 sx={{ width: "80px", height: "80px" }}
@@ -68,12 +73,12 @@ export default function ProfileUserBanner() {
           </Tooltip>
         ) : (
           <Avatar
-            sx={{ width: "80px", height: "80px", mr: 1 }}
+            sx={{ width: "80px", height: "80px", mr: 1, flexShrink: 0 }}
             alt={profile?.name}
             src={avatarSrc}
           />
         )}
-        <Box sx={{ ml: 2, display: "flex", flex: "1" }}>
+        <Box sx={{ ml: 2, display: "flex", flexDirection: "column" }}>
           <ClickAndEdit
             data={profile?.name}
             label={"Edit display name"}

--- a/src/Components/WatchlistTile.js
+++ b/src/Components/WatchlistTile.js
@@ -41,7 +41,7 @@ export default function WatchlistTile({
           },
         }}
       >
-        <Box sx={{ display: "flex" }}>
+        <Box sx={{ display: "flex", justifyContent: "stretch" }}>
           <Typography
             variant="h5"
             sx={{
@@ -57,6 +57,7 @@ export default function WatchlistTile({
             variant="body2"
             sx={{
               marginLeft: "8px",
+              flexShrink: 0,
             }}
           >
             {items?.length ?? "0"} {items?.length === 1 ? "item" : "items"}


### PR DESCRIPTION
- Shows a globe icon for public lists and a lock icon for private lists on list pages the user owns.
  Note - currently a lists privacy setting is permanent.  This could certainly be changed at a later date if desired.
- Adds an orange reminder snackbar when user copy the link for a private list.
- Changes successful snackbar color to green to provide a more familiar UX.
- Tweaked styling of main profile pages to accommodate long display/handle names.