### PR TITLE
Create new useAuthActions hook, use for Login and Register

### DIFF
--- a/src/Components/OnboardingButton.js
+++ b/src/Components/OnboardingButton.js
@@ -41,9 +41,6 @@ export default function OnboardingButton({ disabled }) {
             sx={{
               minWidth: "211px",
             }}
-            onClick={(e) => {
-              SaveToFirestore(user, localUser);
-            }}
           >
             Let's Go!
           </Button>

--- a/src/Components/RoutingHelper.js
+++ b/src/Components/RoutingHelper.js
@@ -1,16 +1,14 @@
-import { useContext, useEffect, useLayoutEffect } from "react";
+import { useEffect, useLayoutEffect } from "react";
 import { useAuthState } from "react-firebase-hooks/auth";
 import { matchPath, Outlet, useLocation } from "react-router-dom";
 import Header from "./Header";
-import { auth, logInAnon } from "./Firebase";
+import { auth } from "./Firebase";
 import BreathingLogo from "./BreathingLogo";
-import { LocalUserContext } from "./LocalUserContext";
-import HandleDialog from "./HandleDialog";
-import { PopulateFromFirestore } from "./Firestore";
+import useAuthActions from "../Hooks/useAuthActions";
 
 export const RoutingHelper = () => {
   const [user, loading, error] = useAuthState(auth);
-  const [localUser, setLocalUser] = useContext(LocalUserContext);
+  const authActions = useAuthActions();
 
   const location = useLocation();
 
@@ -49,7 +47,7 @@ export const RoutingHelper = () => {
 
   useEffect(() => {
     if (!loading && !user && headerMatch) {
-      logInAnon();
+      authActions.registerAnonymously();
     }
   }, [loading, user, headerMatch]);
 

--- a/src/Hooks/useAuthActions.js
+++ b/src/Hooks/useAuthActions.js
@@ -1,0 +1,149 @@
+import { auth, db } from "../Components/Firebase";
+import {
+  EmailAuthProvider,
+  GoogleAuthProvider,
+  TwitterAuthProvider,
+  createUserWithEmailAndPassword,
+  linkWithCredential,
+  linkWithPopup,
+  signInAnonymously,
+  signInWithEmailAndPassword,
+  signInWithPopup,
+} from "firebase/auth";
+import { useContext } from "react";
+import { LocalUserContext } from "../Components/LocalUserContext";
+import {
+  PopulateFromFirestore,
+  SaveToFirestore,
+} from "../Components/Firestore";
+import { doc, setDoc } from "firebase/firestore";
+
+export default function useAuthActions() {
+  const [localUser, setLocalUser] = useContext(LocalUserContext);
+
+  // A general function handling a successful authentication.
+  async function onSuccessImpl(
+    userCredential,
+    authProvider,
+    displayNameOverride,
+    isRegistration
+  ) {
+    const user = userCredential.user;
+
+    // Always write auth info to /users.
+    await setDoc(
+      doc(db, "users", user.uid),
+      {
+        uid: user.uid,
+        authProvider: authProvider,
+        email: user.email,
+      },
+      { merge: true }
+    );
+
+    // If this is registration, write onboarding LocalUser to /users.
+    if (isRegistration) {
+      // Set initial display name first.
+      const newLocalUser = { ...localUser };
+      newLocalUser.name = displayNameOverride ?? user.displayName;
+      setLocalUser(newLocalUser);
+      await SaveToFirestore(user, newLocalUser);
+    } else {
+      // Otherwise, for existing users, load the user's LocalUser data.
+      await PopulateFromFirestore(user, localUser, setLocalUser);
+    }
+  }
+
+  async function onLoginSuccess(userCredential, authProvider) {
+    return onSuccessImpl(
+      userCredential,
+      authProvider,
+      /*displayNameOverride=*/ undefined,
+      /*isRegistration=*/ false
+    );
+  }
+
+  async function onRegistrationSuccess(
+    userCredential,
+    authProvider,
+    displayNameOverride = undefined
+  ) {
+    return onSuccessImpl(
+      userCredential,
+      authProvider,
+      displayNameOverride,
+      /*isRegistration=*/ true
+    );
+  }
+
+  return {
+    loginWithGoogle: async () => {
+      const provider = new GoogleAuthProvider();
+      const userCredential = await signInWithPopup(auth, provider);
+      await onLoginSuccess(userCredential, "google");
+    },
+    linkWithGoogle: async () => {
+      const provider = new GoogleAuthProvider();
+      const userCredential = await linkWithPopup(auth, provider);
+      await onRegistrationSuccess(userCredential, "google");
+    },
+    registerWithGoogle: async () => {
+      const provider = new GoogleAuthProvider();
+      const userCredential = await signInWithPopup(auth, provider);
+      await onRegistrationSuccess(userCredential, "google");
+    },
+    loginWithTwitter: async () => {
+      const provider = new TwitterAuthProvider();
+      const userCredential = await signInWithPopup(auth, provider);
+      await onLoginSuccess(userCredential, "twitter");
+    },
+    linkWithTwitter: async () => {
+      const provider = new TwitterAuthProvider();
+      const userCredential = await linkWithPopup(auth, provider);
+      await onRegistrationSuccess(userCredential, "twitter");
+    },
+    registerWithTwitter: async () => {
+      const provider = new TwitterAuthProvider();
+      const userCredential = await signInWithPopup(auth, provider);
+      await onRegistrationSuccess(userCredential, "twitter");
+    },
+    loginWithEmail: async (email, password) => {
+      const userCredential = await signInWithEmailAndPassword(
+        auth,
+        email,
+        password
+      );
+      await onLoginSuccess(userCredential, "email/password via firebase");
+    },
+    linkWithEmail: async (email, password) => {
+      const credential = EmailAuthProvider.credential(email, password);
+      const userCredential = await linkWithCredential(
+        auth.currentUser,
+        credential
+      );
+      await onRegistrationSuccess(
+        userCredential,
+        "email/password via firebase"
+      );
+    },
+    registerWithEmail: async (email, password) => {
+      const userCredential = await createUserWithEmailAndPassword(
+        auth,
+        email,
+        password
+      );
+      await onRegistrationSuccess(
+        userCredential,
+        "email/password via firebase"
+      );
+    },
+    registerAnonymously: async () => {
+      const userCredential = await signInAnonymously(auth);
+      await onRegistrationSuccess(
+        userCredential,
+        "anonymous",
+        /*displayNameOverride=*/ "Guest"
+      );
+    },
+  };
+}

--- a/src/Hooks/useAuthActions.js
+++ b/src/Hooks/useAuthActions.js
@@ -48,10 +48,10 @@ export default function useAuthActions() {
       newLocalUser.name = displayNameOverride ?? user.displayName;
       setLocalUser(newLocalUser);
       await SaveToFirestore(user, newLocalUser);
-    } else {
-      // Otherwise, for existing users, load the user's LocalUser data.
-      await PopulateFromFirestore(user, localUser, setLocalUser);
     }
+
+    // FInally, in all cases, load the user's LocalUser from /users.
+    await PopulateFromFirestore(user, localUser, setLocalUser);
   }
 
   async function onLoginSuccess(userCredential, authProvider) {

--- a/src/Hooks/useAuthActions.js
+++ b/src/Hooks/useAuthActions.js
@@ -33,7 +33,7 @@ export default function useAuthActions() {
     const userDocRef = doc(db, "users", user.uid);
 
     const existingUserDoc = await getDoc(userDocRef);
-    const userDocAlreadyExists = existingUserDoc.exists;
+    const userDocAlreadyExists = existingUserDoc.exists();
 
     // Always write auth info to /users.
     await setDoc(


### PR DESCRIPTION
This change fixes the name-stomping bug, and attempts to reduce complexity of the login/registration code flow.  I do this by making a new hook that will hold all app business logic for logging in and registering, with an effort to minimize code re-use and to be easy to reason about.

The hook will login, register, or link using the appropriate `firebase/auth` method, then:

For all successful authentications (login/register/link):
 - Writes uid, authProvider, and email to `/users`

Then, for registrations/links:
 - Copies the firebase User displayName to localUser.name, and
 - Writes existing onboarding LocalUser to `/users` 

Finally, for all successful authentications:
 - Loads LocalUser from `/users`

The login and user data logic will be separate from the UI logic (showing loading indicators, error text, etc), which will reside in the Login and Register components themselves.  This will make both the hook and components more decoupled and easily testable.  (Tests to come in a follow-up).

The `Login` and `Register` components will then have a single submit handler function which simply calls the right authAction function, waits until it is done, then interprets and displays any errors, or else navigates the user to /home.

I have manually tested it with registering, linking, and logging in and things *seem* to be working nicely.  As a follow-up, I'd like to add some automated tests that mock out the firebase auth and firestore methods, so that we can run them and assure ourselves every login/registration method is fully functional, without creating tons of accounts while doing so.

I'd also like to add a loading indicator to the Login page, and a more universal indicator to Register that will appear when registering with Google/Twitter.