### PR TITLE
Implement scrolling shelf for touchscreens

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "react-dom": "^18.2.0",
         "react-firebase-hooks": "^5.1.1",
         "react-hook-form": "^7.42.1",
+        "react-horizontal-scrolling-menu": "^4.0.4",
         "react-router-dom": "^6.4.5",
         "react-scripts": "5.0.1",
         "react-swipeable": "^7.0.0",
@@ -7073,6 +7074,11 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "node_modules/compute-scroll-into-view": {
+      "version": "1.0.20",
+      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-1.0.20.tgz",
+      "integrity": "sha512-UCB0ioiyj8CRjtrvaceBLqqhZCVP+1B8+NWQhmdsm0VXOJtobBCf1dBQmebCCo34qZmUwZfIH2MZLqNHazrfjg=="
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -15869,6 +15875,17 @@
         "react": "^16.8.0 || ^17 || ^18"
       }
     },
+    "node_modules/react-horizontal-scrolling-menu": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/react-horizontal-scrolling-menu/-/react-horizontal-scrolling-menu-4.0.4.tgz",
+      "integrity": "sha512-SzNC3q1GbmdfGJ/Uq8VAJ0G3yqPe/4KAWOSNYqXzuLpKWhdpk8hUMqHatFr4Z+SReYoK4XvA9qjYsA6Qe5e1Qw==",
+      "dependencies": {
+        "smooth-scroll-into-view-if-needed": "~1.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
     "node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
@@ -16558,6 +16575,14 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/scroll-into-view-if-needed": {
+      "version": "2.2.31",
+      "resolved": "https://registry.npmjs.org/scroll-into-view-if-needed/-/scroll-into-view-if-needed-2.2.31.tgz",
+      "integrity": "sha512-dGCXy99wZQivjmjIqihaBQNjryrz5rueJY7eHfTdyWEiR4ttYpsajb14rn9s5d4DY4EcY6+4+U/maARBXJedkA==",
+      "dependencies": {
+        "compute-scroll-into-view": "^1.0.20"
+      }
+    },
     "node_modules/select-hose": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
@@ -16790,6 +16815,14 @@
       "integrity": "sha512-5ByW6qXqPeG0Tmlkh24JhdXhvQsbaJSjVr3GgGxUV0BSskZKKBZZfFWxezap8+fh1vxBN9GVbqI1V6nqAFxlBg==",
       "bin": {
         "slug": "cli.js"
+      }
+    },
+    "node_modules/smooth-scroll-into-view-if-needed": {
+      "version": "1.1.33",
+      "resolved": "https://registry.npmjs.org/smooth-scroll-into-view-if-needed/-/smooth-scroll-into-view-if-needed-1.1.33.tgz",
+      "integrity": "sha512-crS8NfAaoPrtVYOCMSAnO2vHRgUp22NiiDgEQ7YiaAy5xe2jmR19Jm+QdL8+97gO8ENd7PUyQIAQojJyIiyRHw==",
+      "dependencies": {
+        "scroll-into-view-if-needed": "^2.2.28"
       }
     },
     "node_modules/sockjs": {
@@ -23896,6 +23929,11 @@
         }
       }
     },
+    "compute-scroll-into-view": {
+      "version": "1.0.20",
+      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-1.0.20.tgz",
+      "integrity": "sha512-UCB0ioiyj8CRjtrvaceBLqqhZCVP+1B8+NWQhmdsm0VXOJtobBCf1dBQmebCCo34qZmUwZfIH2MZLqNHazrfjg=="
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -30078,6 +30116,14 @@
       "integrity": "sha512-2UIGqwMZksd5HS55crTT1ATLTr0rAI4jS7yVuqTaoRVDhY2Qc4IyjskCmpnmdYqUNOYFy04vW253tb2JRVh+IQ==",
       "requires": {}
     },
+    "react-horizontal-scrolling-menu": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/react-horizontal-scrolling-menu/-/react-horizontal-scrolling-menu-4.0.4.tgz",
+      "integrity": "sha512-SzNC3q1GbmdfGJ/Uq8VAJ0G3yqPe/4KAWOSNYqXzuLpKWhdpk8hUMqHatFr4Z+SReYoK4XvA9qjYsA6Qe5e1Qw==",
+      "requires": {
+        "smooth-scroll-into-view-if-needed": "~1.1"
+      }
+    },
     "react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
@@ -30548,6 +30594,14 @@
         "ajv-keywords": "^3.5.2"
       }
     },
+    "scroll-into-view-if-needed": {
+      "version": "2.2.31",
+      "resolved": "https://registry.npmjs.org/scroll-into-view-if-needed/-/scroll-into-view-if-needed-2.2.31.tgz",
+      "integrity": "sha512-dGCXy99wZQivjmjIqihaBQNjryrz5rueJY7eHfTdyWEiR4ttYpsajb14rn9s5d4DY4EcY6+4+U/maARBXJedkA==",
+      "requires": {
+        "compute-scroll-into-view": "^1.0.20"
+      }
+    },
     "select-hose": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
@@ -30742,6 +30796,14 @@
       "version": "8.2.2",
       "resolved": "https://registry.npmjs.org/slug/-/slug-8.2.2.tgz",
       "integrity": "sha512-5ByW6qXqPeG0Tmlkh24JhdXhvQsbaJSjVr3GgGxUV0BSskZKKBZZfFWxezap8+fh1vxBN9GVbqI1V6nqAFxlBg=="
+    },
+    "smooth-scroll-into-view-if-needed": {
+      "version": "1.1.33",
+      "resolved": "https://registry.npmjs.org/smooth-scroll-into-view-if-needed/-/smooth-scroll-into-view-if-needed-1.1.33.tgz",
+      "integrity": "sha512-crS8NfAaoPrtVYOCMSAnO2vHRgUp22NiiDgEQ7YiaAy5xe2jmR19Jm+QdL8+97gO8ENd7PUyQIAQojJyIiyRHw==",
+      "requires": {
+        "scroll-into-view-if-needed": "^2.2.28"
+      }
     },
     "sockjs": {
       "version": "0.3.24",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "react-dom": "^18.2.0",
     "react-firebase-hooks": "^5.1.1",
     "react-hook-form": "^7.42.1",
+    "react-horizontal-scrolling-menu": "^4.0.4",
     "react-router-dom": "^6.4.5",
     "react-scripts": "5.0.1",
     "react-swipeable": "^7.0.0",

--- a/src/Components/AnimeCard.js
+++ b/src/Components/AnimeCard.js
@@ -1,29 +1,16 @@
 import Box from "@mui/material/Box";
 import Paper from "@mui/material/Paper";
 import Typography from "@mui/material/Typography";
+import useMediaQuery from "@mui/material/useMediaQuery";
 import useTheme from "@mui/material/styles/useTheme";
 
-import { useState } from "react";
 import { Link } from "react-router-dom";
 import LikeButtons from "./LikeButtons";
 
-export default function AnimeCard({ anime, large, onChangeSelected }) {
-  const [selected, setSelected] = useState(false);
+export default function AnimeCard({ anime, large }) {
   const theme = useTheme();
 
-  const onMouseOver = () => {
-    setSelected(true);
-    if (onChangeSelected) {
-      onChangeSelected(true);
-    }
-  };
-
-  const onMouseOut = () => {
-    setSelected(false);
-    if (onChangeSelected) {
-      onChangeSelected(false);
-    }
-  };
+  const canHover = useMediaQuery("(hover: hover)");
 
   return (
     <Link
@@ -32,7 +19,6 @@ export default function AnimeCard({ anime, large, onChangeSelected }) {
       aria-label={anime.display_name}
     >
       <Paper
-        elevation={selected ? 12 : 0}
         sx={{
           width: "100%",
           height: "100%",
@@ -42,52 +28,65 @@ export default function AnimeCard({ anime, large, onChangeSelected }) {
           backgroundSize: "cover",
           borderRadius: "8px",
           overflow: "clip",
-          transition: "transform 0.25s ease-in-out",
-          transform: selected ? "scale3d(1.15, 1.15, 1)" : "scale3d(1, 1, 1)",
-          zIndex: selected ? 2 : 0,
+          transition: "transform 0.175s ease-in-out",
+          transform: "scale3d(1, 1, 1)",
+          zIndex: 0,
+          ":hover": canHover
+            ? {
+                transform: "scale3d(1.08, 1.08, 1)",
+                zIndex: 2,
+                boxShadow: theme.shadows[12],
+              }
+            : {},
+          "& div": {
+            visibility: "hidden",
+          },
+          "&:hover div": {
+            visibility: "visible",
+          },
         }}
-        onMouseOver={onMouseOver}
-        onMouseOut={onMouseOut}
       >
-        <Box
-          sx={{
-            height: "100%",
-            display: "flex",
-            flexDirection: "column",
-            visibility: selected ? "visible" : "hidden",
-            color: "#fff",
-            cursor: "pointer",
-            justifyContent: "flex-end",
-          }}
-        >
+        {canHover && (
           <Box
+            component={"div"}
             sx={{
-              width: "100%",
-              background:
-                "linear-gradient(180deg, rgba(0, 0, 0, 0) 0%," +
-                "rgba(0, 0, 0, 0.79) 40.00%," +
-                "rgba(0, 0, 0, 0.94) 100%)",
-              boxSizing: "border-box",
-              padding: 2,
+              height: "100%",
+              display: "flex",
+              flexDirection: "column",
               color: "#fff",
+              cursor: "pointer",
+              justifyContent: "flex-end",
             }}
           >
-            <Typography
+            <Box
               sx={{
+                width: "100%",
+                background:
+                  "linear-gradient(180deg, rgba(0, 0, 0, 0) 0%," +
+                  "rgba(0, 0, 0, 0.79) 40.00%," +
+                  "rgba(0, 0, 0, 0.94) 100%)",
+                boxSizing: "border-box",
+                padding: 2,
                 color: "#fff",
-                textAlign: "center",
-                fontWeight: 600,
-                fontSize: large ? "1.2rem" : "unset",
-                mb: 1,
               }}
             >
-              {anime.display_name}
-            </Typography>
-            <Box sx={{ display: "flex", justifyContent: "center" }}>
-              <LikeButtons anime={anime} selected={true} />
+              <Typography
+                sx={{
+                  color: "#fff",
+                  textAlign: "center",
+                  fontWeight: 600,
+                  fontSize: large ? "1.2rem" : "unset",
+                  mb: 1,
+                }}
+              >
+                {anime.display_name}
+              </Typography>
+              <Box sx={{ display: "flex", justifyContent: "center" }}>
+                <LikeButtons anime={anime} selected={true} />
+              </Box>
             </Box>
           </Box>
-        </Box>
+        )}
       </Paper>
     </Link>
   );

--- a/src/Components/AnimeShelf.js
+++ b/src/Components/AnimeShelf.js
@@ -1,151 +1,18 @@
-import Box from "@mui/material/Box";
-import Grid from "@mui/material/Grid";
-import IconButton from "@mui/material/IconButton";
-import Skeleton from "@mui/material/Skeleton";
-import Paper from "@mui/material/Paper";
 import useMediaQuery from "@mui/material/useMediaQuery";
-import useTheme from "@mui/material/styles/useTheme";
-
-import { CaretLeft, CaretRight } from "phosphor-react";
-import { useState } from "react";
-import { useSwipeable } from "react-swipeable";
-import AnimeCard from "./AnimeCard";
+import AnimeShelfNew from "./AnimeShelfNew";
+import AnimeShelfClassic from "./AnimeShelfClassic";
 
 export default function AnimeShelf({ items }) {
-  items = items ?? [];
+  const cannotHover = useMediaQuery("(hover: none)");
+  const coarsePointer = useMediaQuery("(pointer: coarse)");
 
-  const [selected, setSelected] = useState();
-  const [startIndex, setStartIndex] = useState(0);
-  const theme = useTheme();
+  const isTouchscreen = cannotHover && coarsePointer;
 
-  const sm = useMediaQuery(theme.breakpoints.up("sm"));
-  const sevenHundredFifty = useMediaQuery(
-    theme.breakpoints.up("sevenHundredFifty")
-  );
-  const md = useMediaQuery(theme.breakpoints.up("md"));
-  const lg = useMediaQuery(theme.breakpoints.up("lg"));
-
-  const itemsPerPage = lg ? 6 : md ? 5 : sevenHundredFifty ? 4 : sm ? 3 : 2;
-
-  const columns = 12;
-  const breakpoints = { xs: 12 / itemsPerPage };
-
-  const currentItems = items.slice(startIndex, startIndex + itemsPerPage);
-
-  const hasPrevious = startIndex > 0;
-  const hasNext = startIndex < items.length - itemsPerPage;
-
-  const ghosts = new Array(itemsPerPage).fill(0);
-  const showGhosts = !items.length;
-
-  const onChangeSelected = (index, value) => {
-    if (value) {
-      setSelected(index);
-    } else if (!value && selected === index) {
-      setSelected(undefined);
-    }
-  };
-
-  const onClickNext = (e) => {
-    setStartIndex(
-      Math.min(startIndex + itemsPerPage, items.length - itemsPerPage)
-    );
-    e.preventDefault();
-  };
-
-  const onClickPrevious = (e) => {
-    setStartIndex(Math.max(startIndex - itemsPerPage, 0));
-    e.preventDefault();
-  };
-
-  const handlers = useSwipeable({
-    onSwiped: (eventData) => console.log("user swiped!", eventData),
-    onSwipedLeft: (eventData) =>
-      setStartIndex(
-        Math.min(startIndex + itemsPerPage, items.length - itemsPerPage)
-      ),
-    onSwipedRight: (eventData) =>
-      setStartIndex(Math.max(startIndex - itemsPerPage, 0)),
-  });
-
-  return (
-    <Box
-      {...handlers}
-      sx={{
-        display: "flex",
-        flexDirection: "column",
-        textAlign: "start",
-        mb: 1,
-        position: "relative",
-      }}
-    >
-      <Box
-        sx={{
-          paddingLeft: { xs: hasPrevious ? "24px" : 0, lg: 0 },
-          paddingRight: { xs: hasNext ? "24px" : 0, lg: 0 },
-        }}
-      >
-        <Grid container spacing={2} columns={columns}>
-          {showGhosts &&
-            ghosts.map((_, index) => (
-              <Grid
-                item
-                key={index}
-                {...breakpoints}
-                sx={{ aspectRatio: "0.7" }}
-              >
-                <Skeleton
-                  variant="rounded"
-                  sx={{ height: "100%", borderRadius: "8px" }}
-                />
-              </Grid>
-            ))}
-          {!showGhosts &&
-            currentItems.map((anime, index) => (
-              <Grid
-                item
-                key={index}
-                {...breakpoints}
-                sx={{ aspectRatio: "0.7", zIndex: selected === index ? 1 : 0 }}
-              >
-                <AnimeCard
-                  anime={anime}
-                  onChangeSelected={(v) => onChangeSelected(index, v)}
-                />
-              </Grid>
-            ))}
-        </Grid>
-      </Box>
-      <Paper
-        elevation={4}
-        sx={{
-          position: "absolute",
-          visibility: hasPrevious ? "visible" : "hidden",
-          left: { xs: 0, lg: "-24px" },
-          top: "calc(50% - 24px)",
-          zIndex: 1,
-          borderRadius: "24px",
-        }}
-      >
-        <IconButton onClick={onClickPrevious} color="inherit">
-          <CaretLeft size={24} />
-        </IconButton>
-      </Paper>
-      <Paper
-        elevation={4}
-        sx={{
-          position: "absolute",
-          visibility: hasNext ? "visible" : "hidden",
-          right: { xs: 0, lg: "-24px" },
-          top: "calc(50% - 24px)",
-          zIndex: 1,
-          borderRadius: "24px",
-        }}
-      >
-        <IconButton onClick={onClickNext} color="inherit">
-          <CaretRight size={24} />
-        </IconButton>
-      </Paper>
-    </Box>
-  );
+  // Hovering doesn't work so well with the new shelf yet.  Only serve it for
+  // touchscreens.
+  if (isTouchscreen) {
+    return <AnimeShelfNew items={items} />;
+  } else {
+    return <AnimeShelfClassic items={items} />;
+  }
 }

--- a/src/Components/AnimeShelfClassic.js
+++ b/src/Components/AnimeShelfClassic.js
@@ -1,0 +1,151 @@
+import Box from "@mui/material/Box";
+import Grid from "@mui/material/Grid";
+import IconButton from "@mui/material/IconButton";
+import Skeleton from "@mui/material/Skeleton";
+import Paper from "@mui/material/Paper";
+import useMediaQuery from "@mui/material/useMediaQuery";
+import useTheme from "@mui/material/styles/useTheme";
+
+import { CaretLeft, CaretRight } from "phosphor-react";
+import { useState } from "react";
+import { useSwipeable } from "react-swipeable";
+import AnimeCard from "./AnimeCard";
+
+export default function AnimeShelfClassic({ items }) {
+  items = items ?? [];
+
+  const [selected, setSelected] = useState();
+  const [startIndex, setStartIndex] = useState(0);
+  const theme = useTheme();
+
+  const sm = useMediaQuery(theme.breakpoints.up("sm"));
+  const sevenHundredFifty = useMediaQuery(
+    theme.breakpoints.up("sevenHundredFifty")
+  );
+  const md = useMediaQuery(theme.breakpoints.up("md"));
+  const lg = useMediaQuery(theme.breakpoints.up("lg"));
+
+  const itemsPerPage = lg ? 6 : md ? 5 : sevenHundredFifty ? 4 : sm ? 3 : 2;
+
+  const columns = 12;
+  const breakpoints = { xs: 12 / itemsPerPage };
+
+  const currentItems = items.slice(startIndex, startIndex + itemsPerPage);
+
+  const hasPrevious = startIndex > 0;
+  const hasNext = startIndex < items.length - itemsPerPage;
+
+  const ghosts = new Array(itemsPerPage).fill(0);
+  const showGhosts = !items.length;
+
+  const onChangeSelected = (index, value) => {
+    if (value) {
+      setSelected(index);
+    } else if (!value && selected === index) {
+      setSelected(undefined);
+    }
+  };
+
+  const onClickNext = (e) => {
+    setStartIndex(
+      Math.min(startIndex + itemsPerPage, items.length - itemsPerPage)
+    );
+    e.preventDefault();
+  };
+
+  const onClickPrevious = (e) => {
+    setStartIndex(Math.max(startIndex - itemsPerPage, 0));
+    e.preventDefault();
+  };
+
+  const handlers = useSwipeable({
+    onSwiped: (eventData) => console.log("user swiped!", eventData),
+    onSwipedLeft: (eventData) =>
+      setStartIndex(
+        Math.min(startIndex + itemsPerPage, items.length - itemsPerPage)
+      ),
+    onSwipedRight: (eventData) =>
+      setStartIndex(Math.max(startIndex - itemsPerPage, 0)),
+  });
+
+  return (
+    <Box
+      {...handlers}
+      sx={{
+        display: "flex",
+        flexDirection: "column",
+        textAlign: "start",
+        mb: 1,
+        position: "relative",
+      }}
+    >
+      <Box
+        sx={{
+          paddingLeft: { xs: hasPrevious ? "24px" : 0, lg: 0 },
+          paddingRight: { xs: hasNext ? "24px" : 0, lg: 0 },
+        }}
+      >
+        <Grid container spacing={2} columns={columns}>
+          {showGhosts &&
+            ghosts.map((_, index) => (
+              <Grid
+                item
+                key={index}
+                {...breakpoints}
+                sx={{ aspectRatio: "0.7" }}
+              >
+                <Skeleton
+                  variant="rounded"
+                  sx={{ height: "100%", borderRadius: "8px" }}
+                />
+              </Grid>
+            ))}
+          {!showGhosts &&
+            currentItems.map((anime, index) => (
+              <Grid
+                item
+                key={index}
+                {...breakpoints}
+                sx={{ aspectRatio: "0.7", zIndex: selected === index ? 1 : 0 }}
+              >
+                <AnimeCard
+                  anime={anime}
+                  onChangeSelected={(v) => onChangeSelected(index, v)}
+                />
+              </Grid>
+            ))}
+        </Grid>
+      </Box>
+      <Paper
+        elevation={4}
+        sx={{
+          position: "absolute",
+          visibility: hasPrevious ? "visible" : "hidden",
+          left: { xs: 0, lg: "-24px" },
+          top: "calc(50% - 24px)",
+          zIndex: 1,
+          borderRadius: "24px",
+        }}
+      >
+        <IconButton onClick={onClickPrevious} color="inherit">
+          <CaretLeft size={24} />
+        </IconButton>
+      </Paper>
+      <Paper
+        elevation={4}
+        sx={{
+          position: "absolute",
+          visibility: hasNext ? "visible" : "hidden",
+          right: { xs: 0, lg: "-24px" },
+          top: "calc(50% - 24px)",
+          zIndex: 1,
+          borderRadius: "24px",
+        }}
+      >
+        <IconButton onClick={onClickNext} color="inherit">
+          <CaretRight size={24} />
+        </IconButton>
+      </Paper>
+    </Box>
+  );
+}

--- a/src/Components/AnimeShelfNew.js
+++ b/src/Components/AnimeShelfNew.js
@@ -1,0 +1,40 @@
+import Box from "@mui/material/Box";
+import Skeleton from "@mui/material/Skeleton";
+import { ScrollMenu } from "react-horizontal-scrolling-menu";
+
+import AnimeCard from "./AnimeCard";
+
+import "react-horizontal-scrolling-menu/dist/styles.css";
+import "../Styles/ScrollShelf.css";
+
+export default function AnimeShelfNew({ items }) {
+  // If no items, create a 'ghost' list of nulls.
+  items = items ?? new Array(6).fill(null);
+
+  return (
+    <ScrollMenu
+      wrapperClassName={"scrollWrapper"}
+      scrollContainerClassName={"scrollContainer"}
+    >
+      {items.map((item, index) => (
+        <Box
+          key={index}
+          sx={{
+            width: { xs: "164px", sm: "178px" },
+            aspectRatio: "0.7",
+            mr: 2,
+          }}
+        >
+          {item ? (
+            <AnimeCard anime={item} />
+          ) : (
+            <Skeleton
+              variant="rounded"
+              sx={{ height: "100%", borderRadius: "8px" }}
+            />
+          )}
+        </Box>
+      ))}
+    </ScrollMenu>
+  );
+}

--- a/src/Components/ChipShelf.js
+++ b/src/Components/ChipShelf.js
@@ -1,0 +1,52 @@
+import Box from "@mui/material/Box";
+import Chip from "@mui/material/Chip";
+import { ScrollMenu } from "react-horizontal-scrolling-menu";
+
+import "react-horizontal-scrolling-menu/dist/styles.css";
+import "../Styles/ScrollShelf.css";
+
+const genres = [
+  "Action",
+  "Award Winning",
+  "Comedy",
+  "Ecchi",
+  "Gourmet",
+  "Horror",
+  "Romance",
+  "Sci-Fi",
+  "Sports",
+];
+
+export default function ChipShelf({ selectedGenre, setSelectedGenre }) {
+  const onClick = (genre) => {
+    if (selectedGenre === genre) {
+      setSelectedGenre("");
+    } else {
+      setSelectedGenre(genre);
+    }
+  };
+
+  return (
+    <Box sx={{ mx: { xs: -2, sm: -3, lg: 0 } }}>
+      <ScrollMenu scrollContainerClassName={"scrollContainer"}>
+        {genres.map((genre) => (
+          <Chip
+            key={genre}
+            itemId={genre}
+            sx={{
+              borderRadius: "16px",
+              mr: 1,
+              my: 1,
+            }}
+            variant={genre === selectedGenre ? "filled" : "outlined"}
+            clickable={true}
+            label={genre}
+            onClick={() => onClick(genre)}
+          >
+            {genre}
+          </Chip>
+        ))}
+      </ScrollMenu>
+    </Box>
+  );
+}

--- a/src/Components/ChipShelf.js
+++ b/src/Components/ChipShelf.js
@@ -27,26 +27,27 @@ export default function ChipShelf({ selectedGenre, setSelectedGenre }) {
   };
 
   return (
-    <Box sx={{ mx: { xs: -2, sm: -3, lg: 0 } }}>
-      <ScrollMenu scrollContainerClassName={"scrollContainer"}>
-        {genres.map((genre) => (
-          <Chip
-            key={genre}
-            itemId={genre}
-            sx={{
-              borderRadius: "16px",
-              mr: 1,
-              my: 1,
-            }}
-            variant={genre === selectedGenre ? "filled" : "outlined"}
-            clickable={true}
-            label={genre}
-            onClick={() => onClick(genre)}
-          >
-            {genre}
-          </Chip>
-        ))}
-      </ScrollMenu>
-    </Box>
+    <ScrollMenu
+      wrapperClassName={"scrollWrapper"}
+      scrollContainerClassName={"scrollContainer"}
+    >
+      {genres.map((genre) => (
+        <Chip
+          key={genre}
+          itemId={genre}
+          sx={{
+            borderRadius: "16px",
+            mr: 1,
+            my: 1,
+          }}
+          variant={genre === selectedGenre ? "filled" : "outlined"}
+          clickable={true}
+          label={genre}
+          onClick={() => onClick(genre)}
+        >
+          {genre}
+        </Chip>
+      ))}
+    </ScrollMenu>
   );
 }

--- a/src/Components/GenreChips.js
+++ b/src/Components/GenreChips.js
@@ -1,137 +1,26 @@
-import Stack from "@mui/material/Stack";
-import IconButton from "@mui/material/IconButton";
-import Chip from "@mui/material/Chip";
-import Paper from "@mui/material/Paper";
 import useMediaQuery from "@mui/material/useMediaQuery";
-import useTheme from "@mui/material/styles/useTheme";
-import { CaretLeft, CaretRight } from "phosphor-react";
-import { useState } from "react";
+import GenreChipsClassic from "./GenreChipsClassic";
+import ChipShelf from "./ChipShelf";
 
 export default function GenreChips({ selectedGenre, setSelectedGenre }) {
-  let genres = [
-    "Action",
-    "Award Winning",
-    "Comedy",
-    "Ecchi",
-    "Gourmet",
-    "Horror",
-    "Romance",
-    "Sci-Fi",
-    "Sports",
+  const cannotHover = useMediaQuery("(hover: none)");
+  const coarsePointer = useMediaQuery("(pointer: coarse)");
 
-    // "Adventure",
-    // "Drama",
-    // "Fantasy",
-    // "Mystery",
-    // "Supernatural",
-    // "Slice of Life",
-    // "Suspense",
-    // "Boys Love",
-    // "Girls Love",
-    // "Avant Garde",
-  ];
+  const isTouchscreen = cannotHover && coarsePointer;
 
-  const [startIndex, setStartIndex] = useState(0);
-
-  const theme = useTheme();
-
-  const fourHundred = useMediaQuery(theme.breakpoints.up("fourHundred"));
-
-  const fiveHundred = useMediaQuery(theme.breakpoints.up("fiveHundred"));
-
-  const sm = useMediaQuery(theme.breakpoints.up("sm"));
-  const sevenHundredFifty = useMediaQuery(
-    theme.breakpoints.up("sevenHundredFifty")
-  );
-  const md = useMediaQuery(theme.breakpoints.up("md"));
-  const lg = useMediaQuery(theme.breakpoints.up("lg"));
-
-  const itemsPerPage = lg
-    ? 9
-    : md
-    ? 9
-    : sevenHundredFifty
-    ? 7
-    : sm
-    ? 5
-    : fiveHundred
-    ? 4
-    : fourHundred
-    ? 3
-    : 2;
-
-  const currentItems = genres.slice(startIndex, startIndex + itemsPerPage);
-
-  const hasPrevious = startIndex > 0;
-  const hasNext = startIndex < genres.length - itemsPerPage;
-
-  const onClickNext = (e) => {
-    setStartIndex(
-      Math.min(startIndex + itemsPerPage, genres.length - itemsPerPage)
+  if (isTouchscreen) {
+    return (
+      <ChipShelf
+        selectedGenre={selectedGenre}
+        setSelectedGenre={setSelectedGenre}
+      />
     );
-    e.preventDefault();
-  };
-
-  const onClickPrevious = (e) => {
-    setStartIndex(Math.max(startIndex - itemsPerPage, 0));
-    e.preventDefault();
-  };
-
-  function handleClick(item) {
-    if (item !== selectedGenre) {
-      setSelectedGenre(item);
-    } else {
-      setSelectedGenre("");
-    }
+  } else {
+    return (
+      <GenreChipsClassic
+        selectedGenre={selectedGenre}
+        setSelectedGenre={setSelectedGenre}
+      />
+    );
   }
-
-  return (
-    <Stack
-      direction="row"
-      spacing={1}
-      sx={{ alignItems: "center", marginTop: "0px", marginBottom: "21px" }}
-    >
-      <Paper
-        elevation={4}
-        sx={{
-          visibility: hasPrevious ? "visible" : "hidden",
-          marginLeft: hasPrevious ? "0px" : "-48px",
-          top: "calc(68% - 24px)",
-          borderRadius: "24px",
-          zIndex: 1,
-        }}
-      >
-        <IconButton onClick={onClickPrevious} color="inherit">
-          <CaretLeft size={24} />
-        </IconButton>
-      </Paper>
-      {currentItems?.map((item) => (
-        <Chip
-          sx={{
-            borderRadius: "16px",
-          }}
-          variant={selectedGenre === item ? "filled" : "outlined"}
-          clickable={true}
-          key={item}
-          label={item}
-          onClick={() => {
-            handleClick(item);
-          }}
-        />
-      ))}
-      <Paper
-        elevation={4}
-        sx={{
-          visibility: hasNext ? "visible" : "hidden",
-          top: "calc(68% - 24px)",
-          borderRadius: "24px",
-          zIndex: 1,
-        }}
-      >
-        <IconButton onClick={onClickNext} color="inherit">
-          <CaretRight size={24} />
-        </IconButton>
-      </Paper>
-    </Stack>
-  );
 }

--- a/src/Components/GenreChips.js
+++ b/src/Components/GenreChips.js
@@ -1,6 +1,6 @@
 import useMediaQuery from "@mui/material/useMediaQuery";
 import GenreChipsClassic from "./GenreChipsClassic";
-import ChipShelf from "./ChipShelf";
+import GenreChipsNew from "./GenreChipsNew";
 
 export default function GenreChips({ selectedGenre, setSelectedGenre }) {
   const cannotHover = useMediaQuery("(hover: none)");
@@ -10,7 +10,7 @@ export default function GenreChips({ selectedGenre, setSelectedGenre }) {
 
   if (isTouchscreen) {
     return (
-      <ChipShelf
+      <GenreChipsNew
         selectedGenre={selectedGenre}
         setSelectedGenre={setSelectedGenre}
       />

--- a/src/Components/GenreChipsClassic.js
+++ b/src/Components/GenreChipsClassic.js
@@ -1,0 +1,137 @@
+import Stack from "@mui/material/Stack";
+import IconButton from "@mui/material/IconButton";
+import Chip from "@mui/material/Chip";
+import Paper from "@mui/material/Paper";
+import useMediaQuery from "@mui/material/useMediaQuery";
+import useTheme from "@mui/material/styles/useTheme";
+import { CaretLeft, CaretRight } from "phosphor-react";
+import { useState } from "react";
+
+export default function GenreChips({ selectedGenre, setSelectedGenre }) {
+  let genres = [
+    "Action",
+    "Award Winning",
+    "Comedy",
+    "Ecchi",
+    "Gourmet",
+    "Horror",
+    "Romance",
+    "Sci-Fi",
+    "Sports",
+
+    // "Adventure",
+    // "Drama",
+    // "Fantasy",
+    // "Mystery",
+    // "Supernatural",
+    // "Slice of Life",
+    // "Suspense",
+    // "Boys Love",
+    // "Girls Love",
+    // "Avant Garde",
+  ];
+
+  const [startIndex, setStartIndex] = useState(0);
+
+  const theme = useTheme();
+
+  const fourHundred = useMediaQuery(theme.breakpoints.up("fourHundred"));
+
+  const fiveHundred = useMediaQuery(theme.breakpoints.up("fiveHundred"));
+
+  const sm = useMediaQuery(theme.breakpoints.up("sm"));
+  const sevenHundredFifty = useMediaQuery(
+    theme.breakpoints.up("sevenHundredFifty")
+  );
+  const md = useMediaQuery(theme.breakpoints.up("md"));
+  const lg = useMediaQuery(theme.breakpoints.up("lg"));
+
+  const itemsPerPage = lg
+    ? 9
+    : md
+    ? 9
+    : sevenHundredFifty
+    ? 7
+    : sm
+    ? 5
+    : fiveHundred
+    ? 4
+    : fourHundred
+    ? 3
+    : 2;
+
+  const currentItems = genres.slice(startIndex, startIndex + itemsPerPage);
+
+  const hasPrevious = startIndex > 0;
+  const hasNext = startIndex < genres.length - itemsPerPage;
+
+  const onClickNext = (e) => {
+    setStartIndex(
+      Math.min(startIndex + itemsPerPage, genres.length - itemsPerPage)
+    );
+    e.preventDefault();
+  };
+
+  const onClickPrevious = (e) => {
+    setStartIndex(Math.max(startIndex - itemsPerPage, 0));
+    e.preventDefault();
+  };
+
+  function handleClick(item) {
+    if (item !== selectedGenre) {
+      setSelectedGenre(item);
+    } else {
+      setSelectedGenre("");
+    }
+  }
+
+  return (
+    <Stack
+      direction="row"
+      spacing={1}
+      sx={{ alignItems: "center", marginTop: "0px", marginBottom: "21px" }}
+    >
+      <Paper
+        elevation={4}
+        sx={{
+          visibility: hasPrevious ? "visible" : "hidden",
+          marginLeft: hasPrevious ? "0px" : "-48px",
+          top: "calc(68% - 24px)",
+          borderRadius: "24px",
+          zIndex: 1,
+        }}
+      >
+        <IconButton onClick={onClickPrevious} color="inherit">
+          <CaretLeft size={24} />
+        </IconButton>
+      </Paper>
+      {currentItems?.map((item) => (
+        <Chip
+          sx={{
+            borderRadius: "16px",
+          }}
+          variant={selectedGenre === item ? "filled" : "outlined"}
+          clickable={true}
+          key={item}
+          label={item}
+          onClick={() => {
+            handleClick(item);
+          }}
+        />
+      ))}
+      <Paper
+        elevation={4}
+        sx={{
+          visibility: hasNext ? "visible" : "hidden",
+          top: "calc(68% - 24px)",
+          borderRadius: "24px",
+          zIndex: 1,
+        }}
+      >
+        <IconButton onClick={onClickNext} color="inherit">
+          <CaretRight size={24} />
+        </IconButton>
+      </Paper>
+    </Stack>
+  );
+}

--- a/src/Components/GenreChipsNew.js
+++ b/src/Components/GenreChipsNew.js
@@ -17,7 +17,7 @@ const genres = [
   "Sports",
 ];
 
-export default function ChipShelf({ selectedGenre, setSelectedGenre }) {
+export default function GenreChipsNew({ selectedGenre, setSelectedGenre }) {
   const onClick = (genre) => {
     if (selectedGenre === genre) {
       setSelectedGenre("");

--- a/src/Components/ShelfTitle.js
+++ b/src/Components/ShelfTitle.js
@@ -13,7 +13,7 @@ export default function ShelfTitle({ selectedGenre, setSelectedGenre, title }) {
         top: "68px",
         backgroundColor: theme.palette.background.default,
         zIndex: "3",
-        width: "100vw",
+        // width: "100vw",
       }}
     >
       <Container maxWidth="lg">

--- a/src/Components/ShelfTitle.js
+++ b/src/Components/ShelfTitle.js
@@ -13,7 +13,6 @@ export default function ShelfTitle({ selectedGenre, setSelectedGenre, title }) {
         top: "68px",
         backgroundColor: theme.palette.background.default,
         zIndex: "3",
-        // width: "100vw",
       }}
     >
       <Container maxWidth="lg">

--- a/src/Components/ShelfTitle.js
+++ b/src/Components/ShelfTitle.js
@@ -17,7 +17,7 @@ export default function ShelfTitle({ selectedGenre, setSelectedGenre, title }) {
       }}
     >
       <Container maxWidth="lg">
-        <Typography variant="h3" sx={{ marginBottom: "0.3em" }}>
+        <Typography variant="h3" sx={{ marginBottom: "0.125em" }}>
           {title}
         </Typography>
 
@@ -26,8 +26,6 @@ export default function ShelfTitle({ selectedGenre, setSelectedGenre, title }) {
           setSelectedGenre={setSelectedGenre}
         />
       </Container>
-
-      <div style={{ marginTop: "-15px", height: "1px" }}></div>
     </div>
   );
 }

--- a/src/Styles/ScrollShelf.css
+++ b/src/Styles/ScrollShelf.css
@@ -1,0 +1,38 @@
+.scrollWrapper {
+  margin-left: -16px;
+  margin-right: -16px;
+}
+
+.scrollContainer {
+  -ms-overflow-style: none;  /* IE and Edge */
+  scrollbar-width: none;  /* Firefox */
+  padding-left: 16px;
+}
+
+.scrollContainer::-webkit-scrollbar {
+  display: none;
+}
+
+@media screen and (min-width: 600px)
+{
+  .scrollWrapper {
+    margin-left: -24px;
+    margin-right: -24px;
+  }
+  
+  .scrollContainer {
+    padding-left: 24px;
+  }
+}
+
+@media screen and (min-width: 1200px)
+{
+  .scrollWrapper {
+    margin-left: 0;
+    margin-right: 0;
+  }
+  
+  .scrollContainer {
+    padding-left: 0;
+  }
+}


### PR DESCRIPTION
With support on desktop to follow shortly.  Right now, I have converted `GenreChips` and `AnimeShelf` to decide between implementations based on some media queries (which I read about [here](https://www.smashingmagazine.com/2022/03/guide-hover-pointer-media-queries/)).  Since I do this based on device capability and not screen width, this should enable the scrolly shelves for tablets as well.

In general, the scrolling shelves work pretty well.  Improvements I would still like to have:
 - have AnimeCards adapt their width so there is always a slight peek of a card to indicate that it can scroll.  Right now, on an iPhone 14, it looks really good, but I imagine on some other screen widths it may not seem obvious you can scroll bc you will see two cards only.
 - desktop support, which can happen when I figure out how to get the pagination buttons to work and the card hover effect to look good and not clip.