### PR TITLE
Fix review bugs

### DIFF
--- a/src/Components/Firestore.js
+++ b/src/Components/Firestore.js
@@ -193,18 +193,9 @@ export async function GetReviewCount(docId, type, setReviewCount) {
   try {
     let collectionRef = collection(db, collectionName, docIdString, "reviews");
     let q = query(collectionRef);
-    // Get count of docs - NOT WORKING CORRECTLY FOR COMMENTS
     const countSnapshot = await getCountFromServer(q);
     let numOfReviews = countSnapshot.data().count;
     setReviewCount(numOfReviews);
-    console.log(numOfReviews);
-    // Get docs - works fine and proves the docs ARE there!!
-    let docSnapshot = await getDocs(q);
-    let docs = [];
-    docSnapshot.forEach((x) => {
-      docs.push(x.data());
-    });
-    console.log(docs);
   } catch (error) {
     console.error("Error getting review count from Firebase Database: ", error);
   }

--- a/src/Components/ProfileListPage.js
+++ b/src/Components/ProfileListPage.js
@@ -211,7 +211,7 @@ export default function ProfileListPage() {
           }}
         >
           <EmojiReactionChip
-            docId={`${userId}+${listId}`}
+            docId={`${userId}${listId}`}
             item={listRxns}
             setItem={setListRxns}
             emoji={<HandsClapping size={24} />}
@@ -219,7 +219,7 @@ export default function ProfileListPage() {
             type="list"
           ></EmojiReactionChip>
           <EmojiReactionChip
-            docId={`${userId}+${listId}`}
+            docId={`${userId}${listId}`}
             item={listRxns}
             setItem={setListRxns}
             emoji={<Heart size={24} />}
@@ -227,7 +227,7 @@ export default function ProfileListPage() {
             type="list"
           ></EmojiReactionChip>
           <EmojiReactionChip
-            docId={`${userId}+${listId}`}
+            docId={`${userId}${listId}`}
             item={listRxns}
             setItem={setListRxns}
             emoji={<Trash size={24} />}
@@ -310,7 +310,7 @@ export default function ProfileListPage() {
       {/* Comments */}
       <ReviewContainer
         user={user}
-        docId={`${userId}+${listId}`}
+        docId={`${userId}${listId}`}
         type={"comments"}
       />
     </Box>

--- a/src/Components/Review.js
+++ b/src/Components/Review.js
@@ -301,7 +301,7 @@ function ConvertDate({ item }) {
   const time = format(fromUnixTime(item.time.seconds), "MMMM dd, yyyy");
   return (
     <Typography sx={{ color: "grey", fontSize: "0.9rem" }}>
-      {item?.edited ? "Edited on" : ""} {time.toString()}
+      {item.edited.edited ? "Edited on" : ""} {time.toString()}
     </Typography>
   );
 }

--- a/src/Components/ReviewContainer.js
+++ b/src/Components/ReviewContainer.js
@@ -71,8 +71,7 @@ export default function ReviewContainer({ user, docId, type }) {
           }}
         >
           {type === "comments" ? "Comments" : "Reviews"}
-          {/* CHANGE BACK ONCE DONE DEBUGGING!!!!!!!!!!!!!!!! */}
-          {reviews?.length >= 0 && (
+          {reviews?.length > 2 && (
             <Typography
               sx={{
                 marginL: "10px",
@@ -115,15 +114,13 @@ export default function ReviewContainer({ user, docId, type }) {
             </Tooltip>
           )}
         </Typography>
-        {reviews?.length > 1 ? (
+        {reviews?.length > 1 && (
           <div style={{ ...subheadStyle }}>
             <ReviewFilterDropMenu
               setLastVisible={setLastVisible}
               setSortOption={setSortOption}
             />
           </div>
-        ) : (
-          ""
         )}
       </div>
 

--- a/src/Components/ReviewContainer.js
+++ b/src/Components/ReviewContainer.js
@@ -6,15 +6,17 @@ import Button from "@mui/material/Button";
 import IconButton from "@mui/material/IconButton";
 
 import { CaretDown, Minus, Plus } from "phosphor-react";
-import { GetPaginatedReviewsFromFirestore } from "./Firestore";
-import { useEffect, useState } from "react";
+import { GetPaginatedReviewsFromFirestore, GetReviewCount } from "./Firestore";
+import { useContext, useEffect, useState } from "react";
 import { useLocation } from "react-router-dom";
 import ReviewFilterDropMenu from "./ReviewFilterDropMenu";
 import ReviewForm from "./ReviewForm";
 import Review from "./Review";
+import { LocalUserContext } from "./LocalUserContext";
 
 export default function ReviewContainer({ user, docId, type }) {
   const location = useLocation();
+  const [localUser, setLocalUser] = useContext(LocalUserContext);
 
   const [reviews, setReviews] = useState(null);
 
@@ -23,6 +25,7 @@ export default function ReviewContainer({ user, docId, type }) {
   const [lastVisible, setLastVisible] = useState(null);
   const [seeMore, setSeeMore] = useState(true);
   const [sortOption, setSortOption] = useState(["time", "desc"]);
+  const [reviewCount, setReviewCount] = useState(undefined);
 
   const typeSingular = type === "comments" ? "comment" : "review";
 
@@ -45,6 +48,10 @@ export default function ReviewContainer({ user, docId, type }) {
     );
   }, [location.pathname, docId, sortOption]);
 
+  useEffect(() => {
+    GetReviewCount(docId, type, setReviewCount);
+  }, [localUser.reviews, localUser.comments]);
+
   return (
     <Grid item xs={12}>
       <div
@@ -64,7 +71,8 @@ export default function ReviewContainer({ user, docId, type }) {
           }}
         >
           {type === "comments" ? "Comments" : "Reviews"}
-          {reviews?.length > 2 && (
+          {/* CHANGE BACK ONCE DONE DEBUGGING!!!!!!!!!!!!!!!! */}
+          {reviews?.length >= 0 && (
             <Typography
               sx={{
                 marginL: "10px",
@@ -72,7 +80,7 @@ export default function ReviewContainer({ user, docId, type }) {
                 ml: 1,
               }}
             >
-              ({reviews?.length} total)
+              ({reviewCount} total)
             </Typography>
           )}
           {!showReviewForm ? (
@@ -128,6 +136,7 @@ export default function ReviewContainer({ user, docId, type }) {
           setLastVisible={setLastVisible}
           setSeeMore={setSeeMore}
           type={type}
+          reviewCount={reviewCount}
         />
       )}
 

--- a/src/Components/ReviewForm.js
+++ b/src/Components/ReviewForm.js
@@ -41,7 +41,7 @@ export default function ReviewForm({
   let [rating, setRating] = useState(null);
   let [existingReview, setExistingReview] = useState(false);
 
-  let edited = false;
+  let [edited, setEdited] = useState(false);
 
   const typeSingular = type === "comments" ? "comment" : "review";
 
@@ -121,8 +121,8 @@ export default function ReviewForm({
 
   useEffect(() => {
     populateForm();
-    if (localUser[type].includes(docId)) edited = true;
-  }, []);
+    if (localUser[type].includes(docId)) setEdited(true);
+  }, [localUser]);
 
   return (
     <Paper

--- a/src/Components/ReviewForm.js
+++ b/src/Components/ReviewForm.js
@@ -31,6 +31,7 @@ export default function ReviewForm({
   setLastVisible,
   setSeeMore,
   type,
+  reviewCount,
 }) {
   const [localUser, setLocalUser] = useContext(LocalUserContext);
   const [user] = useAuthState(auth);
@@ -84,7 +85,7 @@ export default function ReviewForm({
     setShowReviewForm(false);
   };
 
-  const saveReview = () => {
+  const saveReview = async () => {
     handleSubmit();
     let docIdString = docId.toString();
     if (!errors.reviewTitle && !errors.review) {
@@ -103,8 +104,14 @@ export default function ReviewForm({
         SaveToFirestore(user, localUser);
       }
       const userID = user.uid.toString();
-      SaveReviewToFirestore(userID, userReview, docIdString, type);
-      GetPaginatedReviewsFromFirestore(
+      await SaveReviewToFirestore(
+        userID,
+        userReview,
+        docIdString,
+        type,
+        reviewCount
+      );
+      await GetPaginatedReviewsFromFirestore(
         docId,
         reviews,
         setReviews,

--- a/src/Components/ReviewForm.js
+++ b/src/Components/ReviewForm.js
@@ -36,7 +36,7 @@ export default function ReviewForm({
   const [localUser, setLocalUser] = useContext(LocalUserContext);
   const [user] = useAuthState(auth);
   const theme = useTheme();
-
+  console.log(localUser);
   let [reviewTitle, setReviewTitle] = useState("");
   let [review, setReview] = useState("");
   let [rating, setRating] = useState(null);


### PR DESCRIPTION
- Fixes the 'edited' text on reviews/comments to only show on content that was actually edited.
- Displays new reviews/comments immediately on the page after submittal.
- Fixes the total count of reviews/comments that got bungled when we switched over to paginated reviews.

**NOTE:** The 3rd commit contains the following bug:
- The total # of comments always returns as (0), while the same code used for retrieving the # of reviews returns the correct number.

Also, FYI I left in an unnecessary `getDocs()` request in `GetReviewCount` to show the collection ref being used is correct.