### PR TITLE
Notifications! 🔔🔔🔔

### DIFF
--- a/src/Components/DropMenu.js
+++ b/src/Components/DropMenu.js
@@ -135,16 +135,14 @@ export default function DropMenu() {
         open={open}
         anchorEl={anchorRef.current}
         role={undefined}
-        placement="bottom-start"
         transition
         style={{ zIndex: "4" }}
       >
-        {({ TransitionProps, placement }) => (
+        {({ TransitionProps }) => (
           <Grow
             {...TransitionProps}
             style={{
-              transformOrigin:
-                placement === "bottom-start" ? "left top" : "left bottom",
+              transformOrigin: "right top",
             }}
           >
             <Paper elevation={6}>

--- a/src/Components/EmojiReactionChip.js
+++ b/src/Components/EmojiReactionChip.js
@@ -42,13 +42,29 @@ export default function EmojiReactionChip({
     docId: docId,
     docType: type,
     time: new Date(),
-    read: false,
+    seen: false, // Remains true until noti popper is opened.
+    read: false, // Remains true until popper is closed (so it can be specially marked)
     listId: listId ?? null,
     listOwnerId: ownerId ?? null,
     commentOwnerId: item?.uid ?? null,
   };
 
   // To-Do: Prevent repeated clicking of a reaction from filling up someone's notification stack.
+
+  // To-Do: Paginate notifications. - DONE
+  //        Get see more button to work - DONE
+  //        Get read/seen working - DONE
+  //        Fix unread count - DONE
+
+  // To-Do: Responsive design for mobile
+  //         Add loading spinner after clicking see more
+  //         Add margin left on mobile
+
+  // To-Do: Get scroll bar AND elevation to show up on Popper - DONE
+
+  // To-Do: Add ghost cards while info needed to display notis is loading
+
+  // To-Do: Get comment notifications working
 
   function reactToReview() {
     let docIdString = docId.toString();
@@ -69,6 +85,7 @@ export default function EmojiReactionChip({
       setSelected(false);
       let newUserReview = { ...temp[index] };
       SaveReviewToFirestore(temp[index].uid, newUserReview, docIdString, type);
+      // if (reaction !== "trash") SaveNotification(notification, item.uid);
     }
   }
 
@@ -87,6 +104,8 @@ export default function EmojiReactionChip({
       setItem(temp);
       setSelected(false);
       SaveListReactionsToFirestore(docId, temp);
+      console.log(notification, ownerId);
+      // if (reaction !== "trash") UpdateNotification(notification, ownerId);
     }
   }
 

--- a/src/Components/EmojiReactionChip.js
+++ b/src/Components/EmojiReactionChip.js
@@ -50,23 +50,6 @@ export default function EmojiReactionChip({
     commentOwnerId: item?.uid ?? null,
   };
 
-  // To-Do: Prevent repeated clicking of a reaction from filling up someone's notification stack. - DONE
-
-  // To-Do: Paginate notifications. - DONE
-  //        Get see more button to work - DONE
-  //        Get read/seen working - DONE
-  //        Fix unread count - DONE
-
-  // To-Do: Responsive design for mobile
-  //         Add loading spinner after clicking see more
-  //         Add margin left on mobile
-
-  // To-Do: Get scroll bar AND elevation to show up on Popper - DONE
-
-  // To-Do: Add ghost cards while info needed to display notis is loading - NOT NEEDED
-
-  // To-Do: Get comment notifications working
-
   function reactToReview() {
     let docIdString = docId.toString();
 
@@ -105,7 +88,6 @@ export default function EmojiReactionChip({
       setItem(temp);
       setSelected(false);
       SaveListReactionsToFirestore(docId, temp);
-      console.log(notification, ownerId);
       if (reaction !== "trash") DeleteNotification(notification, ownerId);
     }
   }

--- a/src/Components/EmojiReactionChip.js
+++ b/src/Components/EmojiReactionChip.js
@@ -5,6 +5,7 @@ import { useEffect, useState } from "react";
 import { useAuthState } from "react-firebase-hooks/auth";
 import { auth } from "./Firebase";
 import {
+  DeleteNotification,
   SaveListReactionsToFirestore,
   SaveNotification,
   SaveReviewToFirestore,
@@ -49,7 +50,7 @@ export default function EmojiReactionChip({
     commentOwnerId: item?.uid ?? null,
   };
 
-  // To-Do: Prevent repeated clicking of a reaction from filling up someone's notification stack.
+  // To-Do: Prevent repeated clicking of a reaction from filling up someone's notification stack. - DONE
 
   // To-Do: Paginate notifications. - DONE
   //        Get see more button to work - DONE
@@ -62,7 +63,7 @@ export default function EmojiReactionChip({
 
   // To-Do: Get scroll bar AND elevation to show up on Popper - DONE
 
-  // To-Do: Add ghost cards while info needed to display notis is loading
+  // To-Do: Add ghost cards while info needed to display notis is loading - NOT NEEDED
 
   // To-Do: Get comment notifications working
 
@@ -85,7 +86,7 @@ export default function EmojiReactionChip({
       setSelected(false);
       let newUserReview = { ...temp[index] };
       SaveReviewToFirestore(temp[index].uid, newUserReview, docIdString, type);
-      // if (reaction !== "trash") SaveNotification(notification, item.uid);
+      if (reaction !== "trash") DeleteNotification(notification, item.uid);
     }
   }
 
@@ -105,7 +106,7 @@ export default function EmojiReactionChip({
       setSelected(false);
       SaveListReactionsToFirestore(docId, temp);
       console.log(notification, ownerId);
-      // if (reaction !== "trash") UpdateNotification(notification, ownerId);
+      if (reaction !== "trash") DeleteNotification(notification, ownerId);
     }
   }
 

--- a/src/Components/EmojiReactionChip.js
+++ b/src/Components/EmojiReactionChip.js
@@ -43,8 +43,8 @@ export default function EmojiReactionChip({
     docId: docId,
     docType: type,
     time: new Date(),
-    seen: false, // Remains true until noti popper is opened.
-    read: false, // Remains true until popper is closed (so it can be specially marked)
+    seen: false, // Remains false until noti popper is opened.
+    read: false, // Remains false until popper is closed (so it can be specially styled)
     listId: listId ?? null,
     listOwnerId: ownerId ?? null,
     commentOwnerId: item?.uid ?? null,
@@ -60,7 +60,7 @@ export default function EmojiReactionChip({
       setSelected(true);
       let newUserReview = { ...temp[index] };
       SaveReviewToFirestore(temp[index].uid, newUserReview, docIdString, type);
-      if (reaction !== "trash") SaveNotification(notification, item.uid);
+      if (reaction !== "trash") SaveNotification(notification, item.uid); // Good vibes only on EdwardML!
     } else if (selected) {
       let temp = [...reviews];
       let indexInArray = temp[index].emojis[reaction].indexOf(user.uid);

--- a/src/Components/Firestore.js
+++ b/src/Components/Firestore.js
@@ -281,9 +281,7 @@ export async function DeleteNotification(notification, IdToUnnotify) {
       where("action", "==", notification.action)
     );
     const docSnap = await getDocs(d);
-    docSnap.forEach((doc) => {
-      deleteDoc(doc.ref);
-    });
+    await Promise.all(docSnap.docs.map((doc) => deleteDoc(doc.ref)));
   } catch (error) {
     console.error("Error deleting notification from Firestore: ", error);
   }

--- a/src/Components/Firestore.js
+++ b/src/Components/Firestore.js
@@ -301,7 +301,7 @@ export async function MarkNotificationsSeenOrRead(notiArray, IdToNotify, verb) {
     try {
       await updateDoc(docRef, { [verb]: true });
     } catch (error) {
-      console.error("Error updating notifcations on Firestore: ", error);
+      console.error("Error updating notifications on Firestore: ", error);
     }
   }
 }

--- a/src/Components/Firestore.js
+++ b/src/Components/Firestore.js
@@ -13,6 +13,8 @@ import {
   endBefore,
   where,
   runTransaction,
+  arrayUnion,
+  onSnapshot,
 } from "firebase/firestore";
 import { db } from "./Firebase";
 
@@ -221,4 +223,18 @@ export async function ClaimHandle(handle, userId) {
     transaction.set(handleDocRef, { uid: userId, handle: handle });
     transaction.update(userDocRef, { handle: handle });
   });
+}
+
+export async function SaveNotification(notification, IdToNotify) {
+  let ref = doc(db, "notifications", IdToNotify);
+  try {
+    // TO DO: Either check if this notification already exists, or add a DeleteNotification if someone "unlikes" or deletes their comment
+    await setDoc(
+      ref,
+      { notificationStack: arrayUnion(notification) },
+      { merge: true }
+    );
+  } catch (error) {
+    console.error("Error writing review data to Firestore", error);
+  }
 }

--- a/src/Components/Firestore.js
+++ b/src/Components/Firestore.js
@@ -266,10 +266,26 @@ export async function SaveNotification(notification, IdToNotify) {
     "usersNotifications"
   );
   try {
-    // TO DO: Either check if this notification already exists, or add a DeleteNotification if someone "unlikes" or deletes their comment
     await addDoc(subcollectionRef, notification);
   } catch (error) {
     console.error("Error writing notifications to Firestore: ", error);
+  }
+}
+
+export async function DeleteNotification(notification, IdToUnnotify) {
+  try {
+    const d = query(
+      collection(db, "notifications", IdToUnnotify, "usersNotifications"),
+      where("interactorId", "==", notification.interactorId),
+      where("docId", "==", notification.docId),
+      where("action", "==", notification.action)
+    );
+    const docSnap = await getDocs(d);
+    docSnap.forEach((doc) => {
+      deleteDoc(doc.ref);
+    });
+  } catch (error) {
+    console.error("Error deleting notification from Firestore: ", error);
   }
 }
 

--- a/src/Components/Firestore.js
+++ b/src/Components/Firestore.js
@@ -16,6 +16,9 @@ import {
   getCountFromServer,
   arrayUnion,
   onSnapshot,
+  addDoc,
+  writeBatch,
+  updateDoc,
 } from "firebase/firestore";
 import { db } from "./Firebase";
 
@@ -256,15 +259,33 @@ export async function ClaimHandle(handle, userId) {
 }
 
 export async function SaveNotification(notification, IdToNotify) {
-  let ref = doc(db, "notifications", IdToNotify);
+  let subcollectionRef = collection(
+    db,
+    "notifications",
+    IdToNotify,
+    "usersNotifications"
+  );
   try {
     // TO DO: Either check if this notification already exists, or add a DeleteNotification if someone "unlikes" or deletes their comment
-    await setDoc(
-      ref,
-      { notificationStack: arrayUnion(notification) },
-      { merge: true }
-    );
+    await addDoc(subcollectionRef, notification);
   } catch (error) {
-    console.error("Error writing review data to Firestore", error);
+    console.error("Error writing notifications to Firestore: ", error);
+  }
+}
+
+export async function MarkNotificationsSeenOrRead(notiArray, IdToNotify, verb) {
+  for (let item of notiArray) {
+    const docRef = doc(
+      db,
+      "notifications",
+      IdToNotify,
+      "usersNotifications",
+      item.firestoreDocId
+    );
+    try {
+      await updateDoc(docRef, { [verb]: true });
+    } catch (error) {
+      console.error("Error updating notifcations on Firestore: ", error);
+    }
   }
 }

--- a/src/Components/Header.js
+++ b/src/Components/Header.js
@@ -53,7 +53,7 @@ function Header() {
             </Grid>
           ) : (
             <>
-              <Grid item md={2.5} sm={4.75} xs={2.5}>
+              <Grid item md={2.5} sm={4} xs={2.5}>
                 <Link to="/home">
                   <EdwardMLLogo />
                 </Link>
@@ -94,7 +94,7 @@ function Header() {
               <Grid
                 item
                 xs={4}
-                sm={1.25}
+                sm={2}
                 md={2.5}
                 textAlign="right"
                 sx={{

--- a/src/Components/Header.js
+++ b/src/Components/Header.js
@@ -64,7 +64,7 @@ function Header() {
                     item
                     md={7}
                     sm={6}
-                    xs={7.5}
+                    xs={5.5}
                     sx={{
                       marginY: 0.75,
                       display: "flex",
@@ -93,7 +93,7 @@ function Header() {
               )}
               <Grid
                 item
-                xs={2}
+                xs={4}
                 sm={1.25}
                 md={2.5}
                 textAlign="right"

--- a/src/Components/Header.js
+++ b/src/Components/Header.js
@@ -8,12 +8,13 @@ import useTheme from "@mui/material/styles/useTheme";
 
 import { useState } from "react";
 import TitleAutocomplete from "./TitleAutocomplete";
-import { MagnifyingGlass, House, User } from "phosphor-react";
+import { MagnifyingGlass, House, User, Bell } from "phosphor-react";
 import DropMenu from "./DropMenu";
 import EdwardMLLogo from "./EdwardMLLogo";
 import HeaderTab from "./HeaderTab";
 import { useAuthState } from "react-firebase-hooks/auth";
 import { auth } from "./Firebase";
+import NotificationDropMenu from "./NotificationDropMenu";
 
 function Header() {
   const [user] = useAuthState(auth);
@@ -96,8 +97,13 @@ function Header() {
                 sm={1.25}
                 md={2.5}
                 textAlign="right"
-                sx={{ display: "flex", justifyContent: "right" }}
+                sx={{
+                  display: "flex",
+                  justifyContent: "right",
+                  alignItems: "center",
+                }}
               >
+                <NotificationDropMenu />
                 <DropMenu />
               </Grid>
             </>

--- a/src/Components/NotificationDropMenu.js
+++ b/src/Components/NotificationDropMenu.js
@@ -70,7 +70,7 @@ export default function NotificationDropMenu() {
   }, [open]);
 
   // Mark all notifications as "seen" when the popper is opened
-  useMemo(() => {
+  useEffect(() => {
     if (open && notifications) {
       let temp = [];
       for (let item of notifications) {
@@ -85,7 +85,7 @@ export default function NotificationDropMenu() {
   }, [open, notifications]);
 
   // Mark all notifications as "read" when the popper is closed
-  useMemo(() => {
+  useEffect(() => {
     if (!open && notifications) {
       let temp = [];
       for (let item of notifications) {
@@ -100,11 +100,11 @@ export default function NotificationDropMenu() {
   }, [open]);
 
   // Makes popper show default # of notifications when re-opened.
-  useMemo(() => {
+  useEffect(() => {
     if (notifications && open === false) setMoreNotiRequests(0);
   }, [open]);
 
-  useMemo(() => {
+  useEffect(() => {
     setLoadingMoreNotis(false);
   }, [notifications]);
 

--- a/src/Components/NotificationDropMenu.js
+++ b/src/Components/NotificationDropMenu.js
@@ -111,8 +111,9 @@ export default function NotificationDropMenu() {
   return (
     <Stack>
       <IconButton
+        color="inherit"
         aria-label="notifications"
-        sx={{ mr: isMobileWidth ? 0 : 2 }}
+        sx={{ mr: 2 }}
         onClick={handleToggle}
         ref={anchorRef}
       >

--- a/src/Components/NotificationDropMenu.js
+++ b/src/Components/NotificationDropMenu.js
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useRef, useState } from "react";
+import React, { useContext, useEffect, useMemo, useRef, useState } from "react";
 import ClickAwayListener from "@mui/material/ClickAwayListener";
 import Grow from "@mui/material/Grow";
 import Paper from "@mui/material/Paper";
@@ -6,32 +6,49 @@ import Popper from "@mui/material/Popper";
 import MenuList from "@mui/material/MenuList";
 import IconButton from "@mui/material/IconButton";
 import Stack from "@mui/material/Stack";
+import useTheme from "@mui/material/styles/useTheme";
 
-import { Bell } from "phosphor-react";
-import { useNavigate } from "react-router-dom";
+import { Bell, CaretDown } from "phosphor-react";
 
-import { Badge } from "@mui/material";
+import Badge from "@mui/material/Badge";
+import useMediaQuery from "@mui/material/useMediaQuery";
+
 import NotificationsContext from "./NotificationsContext";
 import { NotificationListItem } from "./NotificationListItem";
+import { MarkNotificationsSeenOrRead, SaveNotification } from "./Firestore";
+import { useAuthState } from "react-firebase-hooks/auth";
+import { auth } from "./Firebase";
+import ListItemButton from "@mui/material/ListItemButton";
+import ListItemIcon from "@mui/material/ListItemIcon";
+import ListItemText from "@mui/material/ListItemText";
 
 export default function NotificationDropMenu() {
+  const theme = useTheme();
   const [open, setOpen] = useState(false);
   const anchorRef = useRef(null);
+  const [user, loading, error] = useAuthState(auth);
 
-  const [notifications, setNotifications] = useContext(NotificationsContext);
+  const [
+    notifications,
+    setNotifications,
+    totalNotis,
+    unreadNotiCount,
+    moreNotiRequests,
+    setMoreNotiRequests,
+  ] = useContext(NotificationsContext);
 
-  const unreadCount = getUnreadCount(notifications);
+  const isMobileWidth = useMediaQuery(theme.breakpoints.down("sm"));
 
   const handleToggle = () => {
     setOpen((prevOpen) => !prevOpen);
   };
 
-  function handleClose(event) {
+  const handleClose = (event) => {
     if (anchorRef.current && anchorRef.current.contains(event.target)) {
       return;
     }
     setOpen(false);
-  }
+  };
 
   function handleListKeyDown(event) {
     if (event.key === "Tab") {
@@ -50,8 +67,41 @@ export default function NotificationDropMenu() {
     }
     prevOpen.current = open;
   }, [open]);
-  // To-Do: clear notifications count upon view of popper
-  // To-Do: Get vertical scroll bar to show up
+
+  // Mark all notifications as "seen" when the popper is opened
+  useMemo(() => {
+    if (open) {
+      let temp = [];
+      for (let item of notifications) {
+        if (!item.seen) {
+          item.seen = true;
+          temp.push(item);
+        }
+      }
+      if (temp.length === 0) return;
+      MarkNotificationsSeenOrRead(temp, user.uid, "seen");
+    }
+  }, [open, notifications]);
+
+  // Mark all notifications as "read" when the popper is closed
+  useMemo(() => {
+    if (!open && notifications) {
+      let temp = [];
+      for (let item of notifications) {
+        if (!item.read) {
+          item.read = true;
+          temp.push(item);
+        }
+      }
+      if (temp.length === 0) return;
+      MarkNotificationsSeenOrRead(temp, user.uid, "read");
+    }
+  }, [open]);
+
+  // Makes popper show default # of notifications when re-opened.
+  useEffect(() => {
+    if (open === false) setMoreNotiRequests(0);
+  }, [open]);
 
   return (
     <Stack>
@@ -59,16 +109,15 @@ export default function NotificationDropMenu() {
         aria-label="notifications"
         sx={{ mr: 2 }}
         onClick={handleToggle}
-        onKeyDown={handleListKeyDown}
+        ref={anchorRef}
       >
         <Badge
-          ref={anchorRef}
           id="composition-button"
           alt="notifications"
           aria-controls={open ? "composition-menu" : undefined}
           aria-expanded={open ? "true" : undefined}
           aria-haspopup="true"
-          badgeContent={unreadCount}
+          badgeContent={unreadNotiCount}
           color="primary"
         >
           <Bell size={24} />
@@ -78,27 +127,32 @@ export default function NotificationDropMenu() {
         open={open}
         anchorEl={anchorRef.current}
         role={undefined}
-        placement="bottom-start"
         transition
         style={{
           zIndex: "4",
-          maxHeight: "92vh",
-          maxWidth: "500px",
-          overflow: "scroll",
+          maxWidth: "530px",
         }}
       >
-        {({ TransitionProps, placement }) => (
+        {({ TransitionProps }) => (
           <Grow
             {...TransitionProps}
             style={{
-              transformOrigin:
-                placement === "bottom-start" ? "left top" : "left bottom",
+              transformOrigin: isMobileWidth ? "right top" : "center top",
             }}
           >
-            <Paper elevation={6}>
+            <Paper
+              elevation={6}
+              sx={{
+                overflow: "auto",
+                mr: 1,
+                maxHeight: "92vh",
+                overflowY: "auto",
+              }}
+            >
               <ClickAwayListener onClickAway={handleClose}>
                 <MenuList
                   autoFocusItem={open}
+                  variant="menu"
                   id="composition-menu"
                   aria-labelledby="composition-button"
                   onKeyDown={handleListKeyDown}
@@ -107,11 +161,26 @@ export default function NotificationDropMenu() {
                     return (
                       <NotificationListItem
                         item={item}
-                        key={item.time}
+                        key={`${item.time?.seconds} + ${index}`}
                         handleClose={handleClose}
+                        index={index}
                       />
                     );
                   })}
+                  {/* Render SEE MORE button */}
+                  {totalNotis > notifications?.length && (
+                    <ListItemButton
+                      sx={{ display: "flex", justifyContent: "center" }}
+                      onClick={() => {
+                        setMoreNotiRequests(moreNotiRequests + 1);
+                      }}
+                    >
+                      See More
+                      <ListItemIcon sx={{ ml: 2 }}>
+                        <CaretDown size={32} />
+                      </ListItemIcon>
+                    </ListItemButton>
+                  )}
                 </MenuList>
               </ClickAwayListener>
             </Paper>
@@ -122,11 +191,13 @@ export default function NotificationDropMenu() {
   );
 }
 
-function getUnreadCount(input) {
-  if (!input) return 0;
-  let count = 0;
-  for (let item of input) {
-    if (item.read === false) count++;
-  }
-  return count;
-}
+// function getUnreadCount(input) {
+//   if (!input || input.length === 0) {
+//     return 0;
+//   }
+//   let count = 0;
+//   for (let item of input) {
+//     if (item.seen === false) count++;
+//   }
+//   return count;
+// }

--- a/src/Components/NotificationDropMenu.js
+++ b/src/Components/NotificationDropMenu.js
@@ -70,7 +70,7 @@ export default function NotificationDropMenu() {
 
   // Mark all notifications as "seen" when the popper is opened
   useMemo(() => {
-    if (open) {
+    if (open && notifications) {
       let temp = [];
       for (let item of notifications) {
         if (!item.seen) {
@@ -157,7 +157,7 @@ export default function NotificationDropMenu() {
                   aria-labelledby="composition-button"
                   onKeyDown={handleListKeyDown}
                 >
-                  {notifications.map((item, index) => {
+                  {notifications?.map((item, index) => {
                     return (
                       <NotificationListItem
                         item={item}
@@ -190,14 +190,3 @@ export default function NotificationDropMenu() {
     </Stack>
   );
 }
-
-// function getUnreadCount(input) {
-//   if (!input || input.length === 0) {
-//     return 0;
-//   }
-//   let count = 0;
-//   for (let item of input) {
-//     if (item.seen === false) count++;
-//   }
-//   return count;
-// }

--- a/src/Components/NotificationDropMenu.js
+++ b/src/Components/NotificationDropMenu.js
@@ -30,8 +30,8 @@ export default function NotificationDropMenu() {
   const [
     notifications,
     setNotifications,
-    totalNotis,
-    unreadNotiCount,
+    showMore,
+    hideBadge,
     moreNotiRequests,
     setMoreNotiRequests,
   ] = useContext(NotificationsContext);
@@ -101,7 +101,7 @@ export default function NotificationDropMenu() {
 
   // Makes popper show default # of notifications when re-opened.
   useMemo(() => {
-    if (open === false) setMoreNotiRequests(0);
+    if (notifications && open === false) setMoreNotiRequests(0);
   }, [open]);
 
   useMemo(() => {
@@ -122,8 +122,16 @@ export default function NotificationDropMenu() {
           aria-controls={open ? "composition-menu" : undefined}
           aria-expanded={open ? "true" : undefined}
           aria-haspopup="true"
-          badgeContent={unreadNotiCount}
+          invisible={hideBadge}
           color="primary"
+          variant="dot"
+          sx={{
+            "& .MuiBadge-dot": {
+              borderRadius: "6px",
+              width: "12px",
+              height: "12px",
+            },
+          }}
         >
           <Bell size={24} />
         </Badge>
@@ -172,7 +180,7 @@ export default function NotificationDropMenu() {
                     );
                   })}
                   {/* Render SEE MORE button */}
-                  {totalNotis > notifications?.length && (
+                  {showMore && (
                     <ListItemButton
                       sx={{ display: "flex", justifyContent: "center" }}
                       onClick={() => {

--- a/src/Components/NotificationDropMenu.js
+++ b/src/Components/NotificationDropMenu.js
@@ -1,0 +1,132 @@
+import React, { useContext, useEffect, useRef, useState } from "react";
+import ClickAwayListener from "@mui/material/ClickAwayListener";
+import Grow from "@mui/material/Grow";
+import Paper from "@mui/material/Paper";
+import Popper from "@mui/material/Popper";
+import MenuList from "@mui/material/MenuList";
+import IconButton from "@mui/material/IconButton";
+import Stack from "@mui/material/Stack";
+
+import { Bell } from "phosphor-react";
+import { useNavigate } from "react-router-dom";
+
+import { Badge } from "@mui/material";
+import NotificationsContext from "./NotificationsContext";
+import { NotificationListItem } from "./NotificationListItem";
+
+export default function NotificationDropMenu() {
+  const [open, setOpen] = useState(false);
+  const anchorRef = useRef(null);
+
+  const [notifications, setNotifications] = useContext(NotificationsContext);
+
+  const unreadCount = getUnreadCount(notifications);
+
+  const handleToggle = () => {
+    setOpen((prevOpen) => !prevOpen);
+  };
+
+  function handleClose(event) {
+    if (anchorRef.current && anchorRef.current.contains(event.target)) {
+      return;
+    }
+    setOpen(false);
+  }
+
+  function handleListKeyDown(event) {
+    if (event.key === "Tab") {
+      event.preventDefault();
+      setOpen(false);
+    } else if (event.key === "Escape") {
+      setOpen(false);
+    }
+  }
+
+  // return focus to the button when we transitioned from !open -> open
+  const prevOpen = useRef(open);
+  useEffect(() => {
+    if (prevOpen.current === true && open === false) {
+      anchorRef.current.focus();
+    }
+    prevOpen.current = open;
+  }, [open]);
+  // To-Do: clear notifications count upon view of popper
+  // To-Do: Get vertical scroll bar to show up
+
+  return (
+    <Stack>
+      <IconButton
+        aria-label="notifications"
+        sx={{ mr: 2 }}
+        onClick={handleToggle}
+        onKeyDown={handleListKeyDown}
+      >
+        <Badge
+          ref={anchorRef}
+          id="composition-button"
+          alt="notifications"
+          aria-controls={open ? "composition-menu" : undefined}
+          aria-expanded={open ? "true" : undefined}
+          aria-haspopup="true"
+          badgeContent={unreadCount}
+          color="primary"
+        >
+          <Bell size={24} />
+        </Badge>
+      </IconButton>
+      <Popper
+        open={open}
+        anchorEl={anchorRef.current}
+        role={undefined}
+        placement="bottom-start"
+        transition
+        style={{
+          zIndex: "4",
+          maxHeight: "92vh",
+          maxWidth: "500px",
+          overflow: "scroll",
+        }}
+      >
+        {({ TransitionProps, placement }) => (
+          <Grow
+            {...TransitionProps}
+            style={{
+              transformOrigin:
+                placement === "bottom-start" ? "left top" : "left bottom",
+            }}
+          >
+            <Paper elevation={6}>
+              <ClickAwayListener onClickAway={handleClose}>
+                <MenuList
+                  autoFocusItem={open}
+                  id="composition-menu"
+                  aria-labelledby="composition-button"
+                  onKeyDown={handleListKeyDown}
+                >
+                  {notifications.map((item, index) => {
+                    return (
+                      <NotificationListItem
+                        item={item}
+                        key={item.time}
+                        handleClose={handleClose}
+                      />
+                    );
+                  })}
+                </MenuList>
+              </ClickAwayListener>
+            </Paper>
+          </Grow>
+        )}
+      </Popper>
+    </Stack>
+  );
+}
+
+function getUnreadCount(input) {
+  if (!input) return 0;
+  let count = 0;
+  for (let item of input) {
+    if (item.read === false) count++;
+  }
+  return count;
+}

--- a/src/Components/NotificationDropMenu.js
+++ b/src/Components/NotificationDropMenu.js
@@ -7,26 +7,25 @@ import MenuList from "@mui/material/MenuList";
 import IconButton from "@mui/material/IconButton";
 import Stack from "@mui/material/Stack";
 import useTheme from "@mui/material/styles/useTheme";
-
-import { Bell, CaretDown } from "phosphor-react";
-
+import ListItemButton from "@mui/material/ListItemButton";
+import CircularProgress from "@mui/material/CircularProgress";
 import Badge from "@mui/material/Badge";
 import useMediaQuery from "@mui/material/useMediaQuery";
 
+import { Bell, CaretDown } from "phosphor-react";
+
 import NotificationsContext from "./NotificationsContext";
 import { NotificationListItem } from "./NotificationListItem";
-import { MarkNotificationsSeenOrRead, SaveNotification } from "./Firestore";
+import { MarkNotificationsSeenOrRead } from "./Firestore";
 import { useAuthState } from "react-firebase-hooks/auth";
 import { auth } from "./Firebase";
-import ListItemButton from "@mui/material/ListItemButton";
-import ListItemIcon from "@mui/material/ListItemIcon";
-import ListItemText from "@mui/material/ListItemText";
 
 export default function NotificationDropMenu() {
   const theme = useTheme();
   const [open, setOpen] = useState(false);
   const anchorRef = useRef(null);
   const [user, loading, error] = useAuthState(auth);
+  const [loadingMoreNotis, setLoadingMoreNotis] = useState(false);
 
   const [
     notifications,
@@ -37,7 +36,9 @@ export default function NotificationDropMenu() {
     setMoreNotiRequests,
   ] = useContext(NotificationsContext);
 
-  const isMobileWidth = useMediaQuery(theme.breakpoints.down("sm"));
+  const isMobileWidth = useMediaQuery(
+    theme.breakpoints.down("sevenHundredFifty")
+  );
 
   const handleToggle = () => {
     setOpen((prevOpen) => !prevOpen);
@@ -99,15 +100,19 @@ export default function NotificationDropMenu() {
   }, [open]);
 
   // Makes popper show default # of notifications when re-opened.
-  useEffect(() => {
+  useMemo(() => {
     if (open === false) setMoreNotiRequests(0);
   }, [open]);
+
+  useMemo(() => {
+    setLoadingMoreNotis(false);
+  }, [notifications]);
 
   return (
     <Stack>
       <IconButton
         aria-label="notifications"
-        sx={{ mr: 2 }}
+        sx={{ mr: isMobileWidth ? 0 : 2 }}
         onClick={handleToggle}
         ref={anchorRef}
       >
@@ -126,11 +131,10 @@ export default function NotificationDropMenu() {
       <Popper
         open={open}
         anchorEl={anchorRef.current}
-        role={undefined}
         transition
         style={{
           zIndex: "4",
-          maxWidth: "530px",
+          maxWidth: isMobileWidth ? "95vw" : "530px",
         }}
       >
         {({ TransitionProps }) => (
@@ -173,12 +177,15 @@ export default function NotificationDropMenu() {
                       sx={{ display: "flex", justifyContent: "center" }}
                       onClick={() => {
                         setMoreNotiRequests(moreNotiRequests + 1);
+                        setLoadingMoreNotis(true);
                       }}
                     >
-                      See More
-                      <ListItemIcon sx={{ ml: 2 }}>
-                        <CaretDown size={32} />
-                      </ListItemIcon>
+                      {!loadingMoreNotis ? "See More" : ""}
+                      {!loadingMoreNotis ? (
+                        <CaretDown size={32} style={{ marginLeft: "10px" }} />
+                      ) : (
+                        <CircularProgress />
+                      )}
                     </ListItemButton>
                   )}
                 </MenuList>

--- a/src/Components/NotificationListItem.js
+++ b/src/Components/NotificationListItem.js
@@ -2,7 +2,7 @@ import ListItemAvatar from "@mui/material/ListItemAvatar";
 import ListItemText from "@mui/material/ListItemText";
 import Avatar from "@mui/material/Avatar";
 import MenuItem from "@mui/material/MenuItem";
-import { Fragment, useContext, useMemo, useState } from "react";
+import { Fragment, useContext, useEffect, useMemo, useState } from "react";
 import useTheme from "@mui/material/styles/useTheme";
 import { getAvatarSrc } from "./Avatars";
 import { APIGetAnime, useProfile } from "../Components/APICalls";
@@ -14,19 +14,15 @@ import useAnime from "../Hooks/useAnime";
 import { LocalUserContext } from "./LocalUserContext";
 import { Asterisk, AsteriskSimple, Circle } from "phosphor-react";
 import useMediaQuery from "@mui/material/useMediaQuery";
+
 //
 // @param {Object} item - The notification object.
-// @param {string} item.action - The type of reaction.
-// @param {string} item.docId - The document ID that was reacted to.
-// @param {boolean} item.read - Has the notification been seen.
-// @param {object} item.time - The time the notification was created.
-// @param {string} item.uid - The uid of the notification creator.
-//
 
 export function NotificationListItem({ item, handleClose, index }) {
   const theme = useTheme();
   const navigate = useNavigate();
   const isMobileWidth = useMediaQuery(theme.breakpoints.down("sm"));
+  const [showGhosts, setShowGhosts] = useState(false);
 
   const { data: interactorData } = useProfile(item.interactorId);
 
@@ -86,16 +82,13 @@ export function NotificationListItem({ item, handleClose, index }) {
           <ListCommentText item={item} interactorData={interactorData} />
         )}
         {notificationType === "emojiOnComment" && (
-          <EmojiOnCommentText item={item} interactorData={interactorData} />
+          <EmojiOnCommentText item={item} />
         )}
         {notificationType === "emojiOnReview" && (
-          <EmojiOnReviewText item={item} interactorData={interactorData} />
+          <EmojiOnReviewText item={item} />
         )}
-        {notificationType === "emojiOnList" && (
-          <EmojiOnListText item={item} interactorData={interactorData} />
-        )}
+        {notificationType === "emojiOnList" && <EmojiOnListText item={item} />}
       </Box>
-
       <Box sx={{ textAlign: "center", flexShrink: 0, ml: 2 }}>
         <Typography>{time}</Typography>
       </Box>
@@ -108,6 +101,7 @@ export function NotificationListItem({ item, handleClose, index }) {
 function ListCommentText({ item }) {
   const [localUser, setLocalUser] = useContext(LocalUserContext);
   const contentName = getContentName(item.listId, localUser?.lists);
+
   return (
     <Fragment>
       <Typography
@@ -120,10 +114,11 @@ function ListCommentText({ item }) {
   );
 }
 
-function EmojiOnCommentText({ item, interactorData }) {
+function EmojiOnCommentText({ item, setLoading }) {
   const verbed = getInteractionType(item.action);
   const { data: listOwnerData } = useProfile(item.listOwnerId);
   const contentName = getContentName(item.listId, listOwnerData?.lists);
+
   if (!listOwnerData) return;
   return (
     <Fragment>
@@ -140,7 +135,8 @@ function EmojiOnCommentText({ item, interactorData }) {
 function EmojiOnReviewText({ item }) {
   const verbed = getInteractionType(item.action);
   const [anime, animeLoading, animeError] = useAnime(item.docId.toString());
-  if (animeError) console.error(animeError);
+
+  if (!anime) return;
   return (
     <Fragment>
       <Typography sx={{ display: "inline" }}>

--- a/src/Components/NotificationListItem.js
+++ b/src/Components/NotificationListItem.js
@@ -74,7 +74,7 @@ export function NotificationListItem({ item, handleClose, index }) {
           }}
         />
       </ListItemAvatar>
-      <Box>
+      <Box sx={{ flexGrow: 1 }}>
         <Typography sx={{ fontWeight: "800", display: "inline" }}>
           {`@${interactorData?.handle} `}
         </Typography>

--- a/src/Components/NotificationListItem.js
+++ b/src/Components/NotificationListItem.js
@@ -1,0 +1,176 @@
+import ListItemAvatar from "@mui/material/ListItemAvatar";
+import ListItemText from "@mui/material/ListItemText";
+import Avatar from "@mui/material/Avatar";
+import MenuItem from "@mui/material/MenuItem";
+import { Fragment, useContext, useMemo, useState } from "react";
+import useTheme from "@mui/material/styles/useTheme";
+import { getAvatarSrc } from "./Avatars";
+import { APIGetAnime, useProfile } from "../Components/APICalls";
+import Box from "@mui/material/Box";
+import Typography from "@mui/material/Typography";
+import { formatDistanceToNowStrict, fromUnixTime } from "date-fns";
+import { useNavigate } from "react-router-dom";
+import useAnime from "../Hooks/useAnime";
+import { LocalUserContext } from "./LocalUserContext";
+
+//
+// @param {Object} item - The notification object.
+// @param {string} item.action - The type of reaction.
+// @param {string} item.docId - The document ID that was reacted to.
+// @param {boolean} item.read - Has the notification been seen.
+// @param {object} item.time - The time the notification was created.
+// @param {string} item.uid - The uid of the notification creator.
+//
+
+export function NotificationListItem({ item, handleClose }) {
+  const theme = useTheme();
+  const navigate = useNavigate();
+
+  const { data: interactorData } = useProfile(item.interactorId);
+
+  const avatarSrc = useMemo(
+    () => getAvatarSrc(interactorData?.avatar),
+    [interactorData?.avatar]
+  );
+
+  // Determine what type of notification this is, in order to select text output
+  let notificationType;
+  if (!item.docType) notificationType = "listComment";
+  if (item.docType === "comments") notificationType = "emojiOnComment";
+  if (item.docType === "reviews") notificationType = "emojiOnReview";
+  if (item.docType === "list") notificationType = "emojiOnList";
+
+  const time = getTimeElapsed(item.time);
+  return (
+    <MenuItem
+      sx={{ whiteSpace: "normal", mt: 1, mb: 1 }}
+      onClick={(e) => {
+        handleClose(e);
+        if (notificationType === "emojiOnReview")
+          navigate(`/anime/${item.docId}`);
+        else navigate(`/profile/${item.listOwnerId}/list/${item.listId}`);
+      }}
+    >
+      <ListItemAvatar>
+        <Avatar
+          alt={interactorData?.name ?? "Guest"}
+          src={avatarSrc ?? "purposefully bad link"}
+          sx={{
+            bgcolor: theme.palette.primary.main,
+            fontWeight: 600,
+            width: "48px",
+            height: "48px",
+          }}
+        />
+      </ListItemAvatar>
+      <Box>
+        <Typography sx={{ fontWeight: "800", display: "inline" }}>
+          {`@${interactorData?.handle} `}
+        </Typography>
+        {notificationType === "listComment" && (
+          <ListCommentText item={item} interactorData={interactorData} />
+        )}
+        {notificationType === "emojiOnComment" && (
+          <EmojiOnCommentText item={item} interactorData={interactorData} />
+        )}
+        {notificationType === "emojiOnReview" && (
+          <EmojiOnReviewText item={item} interactorData={interactorData} />
+        )}
+        {notificationType === "emojiOnList" && (
+          <EmojiOnListText item={item} interactorData={interactorData} />
+        )}
+      </Box>
+
+      <Box sx={{ textAlign: "center", flexShrink: 0, ml: 2 }}>
+        <Typography>{time}</Typography>
+      </Box>
+    </MenuItem>
+  );
+}
+
+// Components for each notification's text (separate components required due to
+// the hooks needed NOT being used in all the components)
+function ListCommentText({ item }) {
+  const [localUser, setLocalUser] = useContext(LocalUserContext);
+  const contentName = getContentName(item.listId, localUser?.lists);
+  return (
+    <Fragment>
+      <Typography
+        sx={{ display: "inline" }}
+      >{`commented on your list `}</Typography>
+      <Typography sx={{ fontWeight: "800", display: "inline" }}>
+        {contentName}
+      </Typography>
+    </Fragment>
+  );
+}
+
+function EmojiOnCommentText({ item, interactorData }) {
+  const verbed = getInteractionType(item.action);
+  const { data: listOwnerData } = useProfile(item.listOwnerId);
+  const contentName = getContentName(item.listId, listOwnerData?.lists);
+  if (!listOwnerData) return;
+  return (
+    <Fragment>
+      <Typography component="div" sx={{ display: "inline" }}>
+        {`${verbed} your comment on @${listOwnerData.handle}'s list `}{" "}
+      </Typography>
+      <Typography sx={{ fontWeight: "800", display: "inline" }}>
+        {contentName}
+      </Typography>
+    </Fragment>
+  );
+}
+
+function EmojiOnReviewText({ item }) {
+  const verbed = getInteractionType(item.action);
+  const [anime, animeLoading, animeError] = useAnime(item.docId.toString());
+  if (animeError) console.error(animeError);
+  return (
+    <Fragment>
+      <Typography sx={{ display: "inline" }}>
+        {`${verbed} your review of `}
+      </Typography>
+      <Typography sx={{ fontWeight: "800", display: "inline" }}>
+        {anime?.display_name}
+      </Typography>
+    </Fragment>
+  );
+}
+
+function EmojiOnListText({ item }) {
+  const [localUser, setLocalUser] = useContext(LocalUserContext);
+  const contentName = getContentName(item.listId, localUser?.lists);
+  const verbed = getInteractionType(item.action);
+
+  return (
+    <Fragment>
+      <Typography
+        sx={{ display: "inline" }}
+      >{`${verbed} your list `}</Typography>
+      <Typography sx={{ fontWeight: "800", display: "inline" }}>
+        {contentName}
+      </Typography>
+    </Fragment>
+  );
+}
+
+// Support functions
+function getInteractionType(input) {
+  if (input === "applause") return "applauded";
+  if (input === "heart") return "loved";
+}
+
+function getContentName(listId, listOwnersLists) {
+  if (!listOwnersLists) return;
+  if (listId === "likes") return "Likes";
+  if (listId === "dislikes") return "Dislikes";
+  for (let item of listOwnersLists) {
+    if (listId === item?.id) return item?.name;
+  }
+}
+
+function getTimeElapsed(input) {
+  const inputDate = fromUnixTime(input.seconds);
+  return formatDistanceToNowStrict(inputDate);
+}

--- a/src/Components/NotificationsContext.js
+++ b/src/Components/NotificationsContext.js
@@ -1,0 +1,5 @@
+import { createContext } from "react";
+
+const NotificationsContext = createContext();
+
+export default NotificationsContext;

--- a/src/Components/NotificationsProvider.js
+++ b/src/Components/NotificationsProvider.js
@@ -1,25 +1,104 @@
 import { useEffect, useMemo, useState } from "react";
 import NotificationsContext from "./NotificationsContext";
-import { doc, onSnapshot } from "firebase/firestore";
+import {
+  collection,
+  doc,
+  getCountFromServer,
+  limit,
+  onSnapshot,
+  orderBy,
+  query,
+  where,
+} from "firebase/firestore";
 import { auth, db } from "./Firebase";
 import { useAuthState } from "react-firebase-hooks/auth";
 
 export default function NotificationsProvider(props) {
   const [user, loading, error] = useAuthState(auth);
   const [notifications, setNotifications] = useState();
+  const [totalNotis, setTotalNotis] = useState();
+  const [unreadNotiCount, setUnreadNotiCount] = useState();
+  const [moreNotiRequests, setMoreNotiRequests] = useState(0);
 
   // Read initial state from Firestore, or else use blank array.
   // It calls Firestore one time, after user has been authed.
-
   useMemo(() => {
     if (!user) return;
-    onSnapshot(doc(db, "notifications", user?.uid), (doc) => {
-      setNotifications(doc.data()?.notificationStack ?? []);
+    // Get notifications
+    const notisRef = collection(
+      db,
+      "notifications",
+      user?.uid,
+      "usersNotifications"
+    );
+    const q = query(
+      notisRef,
+      orderBy("time", "desc"),
+      limit(5 + moreNotiRequests * 5)
+    );
+    onSnapshot(q, (querySnapshot) => {
+      const notis = [];
+      querySnapshot.forEach((doc) => {
+        notis.push({ ...doc.data(), firestoreDocId: doc.id });
+      });
+      setNotifications(notis ?? []);
     });
-  }, [user]);
+  }, [user, moreNotiRequests]);
+
+  // The count() firestore fn can't be used with real-time listeners...so this is my work-around.
+  useMemo(() => {
+    if (!user) return;
+    GetTotalNotiCount().then((result) => {
+      setTotalNotis(result);
+    });
+    GetUnreadNotiCount().then((result) => {
+      setUnreadNotiCount(result);
+    });
+  }, [notifications]);
+
+  async function GetTotalNotiCount() {
+    const notisRef = collection(
+      db,
+      "notifications",
+      user?.uid,
+      "usersNotifications"
+    );
+    const qCollection = query(notisRef);
+    try {
+      const countSnapshot = await getCountFromServer(qCollection);
+      return countSnapshot.data().count;
+    } catch (error) {
+      console.error("Error getting notification count: ", error);
+    }
+  }
+
+  async function GetUnreadNotiCount() {
+    const notisRef = collection(
+      db,
+      "notifications",
+      user?.uid,
+      "usersNotifications"
+    );
+    const qCollection = query(notisRef, where("seen", "==", false));
+    try {
+      const countSnapshot = await getCountFromServer(qCollection);
+      return countSnapshot.data().count;
+    } catch (error) {
+      console.error("Error getting notification count: ", error);
+    }
+  }
 
   return (
-    <NotificationsContext.Provider value={[notifications, setNotifications]}>
+    <NotificationsContext.Provider
+      value={[
+        notifications,
+        setNotifications,
+        totalNotis,
+        unreadNotiCount,
+        moreNotiRequests,
+        setMoreNotiRequests,
+      ]}
+    >
       {props.children}
     </NotificationsContext.Provider>
   );

--- a/src/Components/NotificationsProvider.js
+++ b/src/Components/NotificationsProvider.js
@@ -1,0 +1,26 @@
+import { useEffect, useMemo, useState } from "react";
+import NotificationsContext from "./NotificationsContext";
+import { doc, onSnapshot } from "firebase/firestore";
+import { auth, db } from "./Firebase";
+import { useAuthState } from "react-firebase-hooks/auth";
+
+export default function NotificationsProvider(props) {
+  const [user, loading, error] = useAuthState(auth);
+  const [notifications, setNotifications] = useState();
+
+  // Read initial state from Firestore, or else use blank array.
+  // It calls Firestore one time, after user has been authed.
+
+  useMemo(() => {
+    if (!user) return;
+    onSnapshot(doc(db, "notifications", user?.uid), (doc) => {
+      setNotifications(doc.data()?.notificationStack ?? []);
+    });
+  }, [user]);
+
+  return (
+    <NotificationsContext.Provider value={[notifications, setNotifications]}>
+      {props.children}
+    </NotificationsContext.Provider>
+  );
+}

--- a/src/Components/NotificationsProvider.js
+++ b/src/Components/NotificationsProvider.js
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 import NotificationsContext from "./NotificationsContext";
 import {
   collection,
@@ -23,7 +23,7 @@ export default function NotificationsProvider(props) {
 
   // Read initial state from Firestore, or else use blank array.
   // It calls Firestore one time, after user has been authed.
-  useMemo(() => {
+  useEffect(() => {
     if (!user) return;
     // Get notifications
     const notisRef = collection(
@@ -37,7 +37,7 @@ export default function NotificationsProvider(props) {
       orderBy("time", "desc"),
       limit(5 + moreNotiRequests * 5)
     );
-    onSnapshot(q, (querySnapshot) => {
+    const unsub = onSnapshot(q, (querySnapshot) => {
       const notis = [];
       querySnapshot.forEach((doc) => {
         notis.push({ ...doc.data(), firestoreDocId: doc.id });
@@ -52,10 +52,12 @@ export default function NotificationsProvider(props) {
         setShowMore(false);
       }
     });
+
+    return unsub;
   }, [user, moreNotiRequests]);
 
   // The count() firestore fn can't be used with real-time listeners...so this is my work-around.
-  useMemo(() => {
+  useEffect(() => {
     if (!user || !notifications) return;
     GetUnseenNotiCount().then((result) => {
       setHideBadge(result);

--- a/src/Components/ProfileListPage.js
+++ b/src/Components/ProfileListPage.js
@@ -70,7 +70,7 @@ export default function ProfileListPage() {
   let privateList = false;
 
   useEffect(() => {
-    GetListReactions(`${userId}+${listId}`, setListRxns);
+    GetListReactions(`${userId}${listId}`, setListRxns);
   }, [listId]);
 
   const sevenHundredFifty = useMediaQuery(

--- a/src/Components/ProfileListPage.js
+++ b/src/Components/ProfileListPage.js
@@ -217,6 +217,7 @@ export default function ProfileListPage() {
             emoji={<HandsClapping size={24} />}
             reaction="applause"
             type="list"
+            ownerId={userId}
           ></EmojiReactionChip>
           <EmojiReactionChip
             docId={`${userId}+${listId}`}
@@ -225,6 +226,7 @@ export default function ProfileListPage() {
             emoji={<Heart size={24} />}
             reaction="heart"
             type="list"
+            ownerId={userId}
           ></EmojiReactionChip>
           <EmojiReactionChip
             docId={`${userId}+${listId}`}
@@ -233,6 +235,7 @@ export default function ProfileListPage() {
             emoji={<Trash size={24} />}
             reaction="trash"
             type="list"
+            ownerId={userId}
           ></EmojiReactionChip>
         </Grid>
         <Grid
@@ -312,6 +315,8 @@ export default function ProfileListPage() {
         user={user}
         docId={`${userId}+${listId}`}
         type={"comments"}
+        listOwnerId={userId}
+        listId={listId}
       />
     </Box>
   );

--- a/src/Components/Review.js
+++ b/src/Components/Review.js
@@ -21,6 +21,7 @@ import EmojiReactionChip from "./EmojiReactionChip";
 import ExpandableText from "./ExpandableText";
 import { auth } from "./Firebase";
 import {
+  DeleteNotification,
   DeleteReviewFromFirestore,
   PopulateReviewsFromFirestore,
   SaveReviewToFirestore,
@@ -37,12 +38,12 @@ export default function Review({
   setReviews,
   setShowReviewForm,
   type,
+  listOwnerId,
 }) {
   const [localUser, setLocalUser] = useContext(LocalUserContext);
   const [user] = useAuthState(auth);
   const theme = useTheme();
   const confirm = useConfirm();
-  let reviewerAvatar = undefined;
 
   const { data: reviewerInfo } = useProfile(item.uid);
 
@@ -74,6 +75,16 @@ export default function Review({
       // Delete review from Firestore documents listing
       let docIdString = docId.toString();
       DeleteReviewFromFirestore(user, docIdString, type);
+
+      // Delete notification from firestore
+      if (type === "comments") {
+        const notiInfo = {
+          interactorId: user.uid,
+          docId: docId,
+          action: "comment",
+        };
+        DeleteNotification(notiInfo, listOwnerId);
+      }
     });
   }
 

--- a/src/Components/ReviewContainer.js
+++ b/src/Components/ReviewContainer.js
@@ -13,7 +13,13 @@ import ReviewFilterDropMenu from "./ReviewFilterDropMenu";
 import ReviewForm from "./ReviewForm";
 import Review from "./Review";
 
-export default function ReviewContainer({ user, docId, type }) {
+export default function ReviewContainer({
+  user,
+  docId,
+  type,
+  listOwnerId,
+  listId,
+}) {
   const location = useLocation();
 
   const [reviews, setReviews] = useState(null);
@@ -128,13 +134,15 @@ export default function ReviewContainer({ user, docId, type }) {
           setLastVisible={setLastVisible}
           setSeeMore={setSeeMore}
           type={type}
+          listOwnerId={listOwnerId}
+          listId={listId}
         />
       )}
 
       {reviews?.map((item, index) => {
         return (
           <Review
-            key={item.uid}
+            key={`${item.uid}+${item.time.seconds}`}
             item={item}
             index={index}
             docId={docId}

--- a/src/Components/ReviewContainer.js
+++ b/src/Components/ReviewContainer.js
@@ -156,6 +156,7 @@ export default function ReviewContainer({
             setReviews={setReviews}
             setShowReviewForm={setShowReviewForm}
             type={type}
+            listOwnerId={listOwnerId}
           />
         );
       })}

--- a/src/Components/ReviewForm.js
+++ b/src/Components/ReviewForm.js
@@ -16,6 +16,7 @@ import { Star } from "phosphor-react";
 import {
   GetPaginatedReviewsFromFirestore,
   PopulateReviewsFromFirestore,
+  SaveNotification,
   SaveReviewToFirestore,
   SaveToFirestore,
   setLastVisible,
@@ -31,6 +32,8 @@ export default function ReviewForm({
   setLastVisible,
   setSeeMore,
   type,
+  listOwnerId,
+  listId,
 }) {
   const [localUser, setLocalUser] = useContext(LocalUserContext);
   const [user] = useAuthState(auth);
@@ -83,6 +86,17 @@ export default function ReviewForm({
   const cancelReview = () => {
     setShowReviewForm(false);
   };
+  const notification = {
+    interactorId: user.uid, // Person writing the review
+    action: listOwnerId ? "comment" : "review",
+    docId: docId,
+    docType: null,
+    time: new Date(),
+    read: false,
+    listId: listId ?? null,
+    listOwnerId: listOwnerId ?? null,
+    commentOwnerId: null,
+  };
 
   const saveReview = () => {
     handleSubmit();
@@ -104,6 +118,8 @@ export default function ReviewForm({
       }
       const userID = user.uid.toString();
       SaveReviewToFirestore(userID, userReview, docIdString, type);
+      SaveNotification(notification, listOwnerId);
+
       GetPaginatedReviewsFromFirestore(
         docId,
         reviews,

--- a/src/Components/ReviewForm.js
+++ b/src/Components/ReviewForm.js
@@ -93,8 +93,8 @@ export default function ReviewForm({
     docId: docId,
     docType: null,
     time: new Date(),
-    seen: false, // Remains true until noti popper is opened.
-    read: false, // Remains true until popper is closed (so it can be specially marked)
+    seen: false, // Remains false until noti popper is opened.
+    read: false, // Remains galse until popper is closed (so it can be specially styled)
     listId: listId ?? null,
     listOwnerId: listOwnerId ?? null,
     commentOwnerId: null,

--- a/src/Components/ReviewForm.js
+++ b/src/Components/ReviewForm.js
@@ -39,7 +39,7 @@ export default function ReviewForm({
   const [localUser, setLocalUser] = useContext(LocalUserContext);
   const [user] = useAuthState(auth);
   const theme = useTheme();
-  console.log(localUser);
+
   let [reviewTitle, setReviewTitle] = useState("");
   let [review, setReview] = useState("");
   let [rating, setRating] = useState(null);
@@ -126,7 +126,9 @@ export default function ReviewForm({
         type,
         reviewCount
       );
-      SaveNotification(notification, listOwnerId);
+
+      // Only provide notification when a comment is created NOT when edited
+      if (!edited) SaveNotification(notification, listOwnerId);
 
       await GetPaginatedReviewsFromFirestore(
         docId,

--- a/src/Components/ReviewForm.js
+++ b/src/Components/ReviewForm.js
@@ -93,7 +93,8 @@ export default function ReviewForm({
     docId: docId,
     docType: null,
     time: new Date(),
-    read: false,
+    seen: false, // Remains true until noti popper is opened.
+    read: false, // Remains true until popper is closed (so it can be specially marked)
     listId: listId ?? null,
     listOwnerId: listOwnerId ?? null,
     commentOwnerId: null,

--- a/src/Components/RouteSwitch.js
+++ b/src/Components/RouteSwitch.js
@@ -20,6 +20,7 @@ import AppSettingsProvider from "./AppSettingsProvider";
 import AppThemeProvider from "./AppThemeProvider";
 import YoutubeModalProvider from "./YoutubeModalProvider";
 import { SnackbarProvider } from "notistack";
+import NotificationsProvider from "./NotificationsProvider";
 
 const queryClient = new QueryClient();
 
@@ -30,36 +31,41 @@ const RouteSwitch = () => {
         <BrowserRouter>
           <LocalUserProvider>
             <QueryClientProvider client={queryClient}>
-              <YoutubeModalProvider>
-                <ConfirmProvider>
-                  <SnackbarProvider maxSnack={3}>
-                    <Routes>
-                      <Route element={<RoutingHelper />}>
-                        <Route path="/reset" element={<Reset />} />
-                        <Route
-                          path="/profile/:userId/list/:listId"
-                          element={<Profile />}
-                        />
-                        <Route path="/profile/:userId" element={<Profile />} />
-                        <Route path="/search" element={<Search />} />
-                        <Route
-                          path="/anime/:animeId"
-                          element={<DetailedViewPage />}
-                        />
-                        <Route path="/home" element={<Home />} />
-                        <Route path="/sandbox" element={<Sandbox />} />
-                        <Route path="/login" element={<Login />} />
-                        <Route path="/logout" element={<Logout />} />
-                        <Route path="/onboarding" element={<Onboarding />} />
-                        <Route path="/register" element={<Register />} />
-                        <Route path="*" element={<NotFound404 />} />
-                        <Route path="/" element={<LandingPage />} />
-                      </Route>
-                    </Routes>
-                    <ReactQueryDevtools initialIsOpen={false} />
-                  </SnackbarProvider>
-                </ConfirmProvider>
-              </YoutubeModalProvider>
+              <NotificationsProvider>
+                <YoutubeModalProvider>
+                  <ConfirmProvider>
+                    <SnackbarProvider maxSnack={3}>
+                      <Routes>
+                        <Route element={<RoutingHelper />}>
+                          <Route path="/reset" element={<Reset />} />
+                          <Route
+                            path="/profile/:userId/list/:listId"
+                            element={<Profile />}
+                          />
+                          <Route
+                            path="/profile/:userId"
+                            element={<Profile />}
+                          />
+                          <Route path="/search" element={<Search />} />
+                          <Route
+                            path="/anime/:animeId"
+                            element={<DetailedViewPage />}
+                          />
+                          <Route path="/home" element={<Home />} />
+                          <Route path="/sandbox" element={<Sandbox />} />
+                          <Route path="/login" element={<Login />} />
+                          <Route path="/logout" element={<Logout />} />
+                          <Route path="/onboarding" element={<Onboarding />} />
+                          <Route path="/register" element={<Register />} />
+                          <Route path="*" element={<NotFound404 />} />
+                          <Route path="/" element={<LandingPage />} />
+                        </Route>
+                      </Routes>
+                      <ReactQueryDevtools initialIsOpen={false} />
+                    </SnackbarProvider>
+                  </ConfirmProvider>
+                </YoutubeModalProvider>
+              </NotificationsProvider>
             </QueryClientProvider>
           </LocalUserProvider>
         </BrowserRouter>


### PR DESCRIPTION
**SUMMARY:**
This feature adds notifications using a real-time listener. The below activities generate a notification:
1. React to a list 
2. React to a comment (comment author is notified, list owner is NOT notified)
3. React to a review 
4. Comment on a list 

Other mechanics:
- Notifications are deleted when either un-reacted to or a comment gets deleted.
- Editing comments does not generate a notification.

**NOTE:**
This feature feels relatively heavy on firebase reads/writes.  I did my best to limit them, but please let me know if you find places for further savings. Below is an outline of where this feature stands (not considering the 'see more' option for simplicity/brevity)

On page load:
- 5 reads to populate notifications (1 of which determines if we show the 'see more' button).
- 1 read to determine whether to show notification 'badge'

On opening notification popper:
- 4 writes (marking all notis as 'read', so `<Badge/>` will disappear)
- 1 read to determine whether to show notification `<Badge/>`

On closing notification popper:
- 4 writes (marking all notis as 'seen', so special styling for new notifications disappears)
- 1 read to determine whether to show notification 'badge'

**OTHER:**
1. The firebase `.count()` function can't be used with real-time listeners, so I'm only showing a `<Badge/>` when there are new notifications and NOT a count of the unseen notifications.
2. The header gets rather crowded on mobile...I don't love it, so definitely open to other solutions!!!