### PR TITLE
Restyle popper components

### DIFF
--- a/src/Components/AddButton.js
+++ b/src/Components/AddButton.js
@@ -22,7 +22,7 @@ export default function AddButton({ anime, list }) {
       onClick={onClick}
       disabled={disabled}
       color={buttonColor}
-      sx={{}}
+      sx={{ flexShrink: 0 }}
     >
       {buttonText}
     </Button>

--- a/src/Components/AddButtonForTop8.js
+++ b/src/Components/AddButtonForTop8.js
@@ -26,7 +26,7 @@ export default function AddButtonForTop8({ anime, list }) {
       onClick={onClick}
       disabled={disabled}
       color={buttonColor}
-      sx={{}}
+      sx={{ flexShrink: 0 }}
     >
       {buttonText}
     </Button>

--- a/src/Components/AddToListDropMenu.js
+++ b/src/Components/AddToListDropMenu.js
@@ -6,7 +6,7 @@ import Popper from "@mui/material/Popper";
 import MenuItem from "@mui/material/MenuItem";
 import MenuList from "@mui/material/MenuList";
 import { GlobeHemisphereWest, LockSimple, Plus } from "phosphor-react";
-import { useNavigate } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import { auth } from "./Firebase";
 import { LocalUserContext } from "./LocalUserContext";
 import { useAuthState } from "react-firebase-hooks/auth";
@@ -28,6 +28,7 @@ import AddButtonForTop8 from "./AddButtonForTop8";
 import { useContext, useEffect, useRef, useState } from "react";
 import { PrivacySwitch } from "./PrivacySwitch";
 import useMediaQuery from "@mui/material/useMediaQuery";
+import { Typography } from "@mui/material";
 
 export default function AddToListDropMenu({ anime, variant, selected }) {
   const navigate = useNavigate();
@@ -168,18 +169,11 @@ export default function AddToListDropMenu({ anime, variant, selected }) {
         open={open}
         anchorEl={anchorRef.current}
         role={undefined}
-        placement="bottom"
         transition
         sx={{ zIndex: "4", maxWidth: smallScreen ? "98vw" : "600px" }}
       >
         {({ TransitionProps, placement }) => (
-          <Grow
-            {...TransitionProps}
-            style={{
-              transformOrigin:
-                placement === "bottom-start" ? "left top" : "left bottom",
-            }}
-          >
+          <Grow {...TransitionProps} style={{ transformOrigin: "center-top" }}>
             <Paper elevation={6} onClick={(e) => e.stopPropagation()}>
               <ClickAwayListener onClickAway={handleClose}>
                 <MenuList
@@ -218,7 +212,14 @@ export default function AddToListDropMenu({ anime, variant, selected }) {
                         <AddButtonForTop8 anime={anime} list={localUser.top8} />
                       }
                     >
-                      <ListItemText primary="My Top 8" sx={{ mr: 4 }} />
+                      <Typography
+                        sx={{
+                          mr: 8,
+                          ":hover": { color: theme.palette.primary.main },
+                        }}
+                      >
+                        <Link to={`/profile/${user.uid}`}>My Top 8</Link>
+                      </Typography>
                     </ListItem>
                   ) : (
                     ""
@@ -238,15 +239,19 @@ export default function AddToListDropMenu({ anime, variant, selected }) {
                               <AddButton anime={anime} list={item.name} />
                             }
                           >
-                            <ListItemText
-                              primary={item.name}
-                              primaryTypographyProps={{
+                            <Typography
+                              sx={{
                                 mr: 8,
+                                ":hover": { color: theme.palette.primary.main },
                                 whiteSpace: "nowrap",
                                 overflow: "hidden",
                                 textOverflow: "ellipsis",
                               }}
-                            />
+                            >
+                              <Link to={`/profile/${user.uid}/list/${item.id}`}>
+                                {item.name}{" "}
+                              </Link>
+                            </Typography>
                           </ListItem>
                         );
                       })
@@ -352,7 +357,7 @@ export default function AddToListDropMenu({ anime, variant, selected }) {
                   )}
 
                   {/*******************View my Lists Button*******************/}
-                  <div style={{ display: "flex", justifyContent: "center" }}>
+                  {/* <div style={{ display: "flex", justifyContent: "center" }}>
                     <Button
                       color="inherit"
                       variant="text"
@@ -366,7 +371,7 @@ export default function AddToListDropMenu({ anime, variant, selected }) {
                     >
                       View my Lists
                     </Button>
-                  </div>
+                  </div> */}
                 </MenuList>
               </ClickAwayListener>
             </Paper>

--- a/src/Components/AddToListDropMenu.js
+++ b/src/Components/AddToListDropMenu.js
@@ -27,6 +27,7 @@ import { yupResolver } from "@hookform/resolvers/yup";
 import AddButtonForTop8 from "./AddButtonForTop8";
 import { useContext, useEffect, useRef, useState } from "react";
 import { PrivacySwitch } from "./PrivacySwitch";
+import useMediaQuery from "@mui/material/useMediaQuery";
 
 export default function AddToListDropMenu({ anime, variant, selected }) {
   const navigate = useNavigate();
@@ -44,6 +45,8 @@ export default function AddToListDropMenu({ anime, variant, selected }) {
   let [privateList, setPrivateList] = useState(false);
 
   let listNames = localUser?.lists?.map((x) => x.name);
+
+  const smallScreen = useMediaQuery(theme.breakpoints.down("sm"));
 
   // Define Yup schema
   const validationSchema = Yup.object().shape({
@@ -167,7 +170,7 @@ export default function AddToListDropMenu({ anime, variant, selected }) {
         role={undefined}
         placement="bottom"
         transition
-        style={{ zIndex: "4", maxWidth: "600px" }}
+        sx={{ zIndex: "4", maxWidth: smallScreen ? "98vw" : "600px" }}
       >
         {({ TransitionProps, placement }) => (
           <Grow
@@ -235,7 +238,15 @@ export default function AddToListDropMenu({ anime, variant, selected }) {
                               <AddButton anime={anime} list={item.name} />
                             }
                           >
-                            <ListItemText primary={item.name} sx={{ mr: 4 }} />
+                            <ListItemText
+                              primary={item.name}
+                              primaryTypographyProps={{
+                                mr: 8,
+                                whiteSpace: "nowrap",
+                                overflow: "hidden",
+                                textOverflow: "ellipsis",
+                              }}
+                            />
                           </ListItem>
                         );
                       })

--- a/src/Components/AddToListDropMenu.js
+++ b/src/Components/AddToListDropMenu.js
@@ -355,23 +355,6 @@ export default function AddToListDropMenu({ anime, variant, selected }) {
                       </div>{" "}
                     </div>
                   )}
-
-                  {/*******************View my Lists Button*******************/}
-                  {/* <div style={{ display: "flex", justifyContent: "center" }}>
-                    <Button
-                      color="inherit"
-                      variant="text"
-                      onClick={(e) => {
-                        navigate(`/profile/${user?.uid}`);
-                      }}
-                      sx={{
-                        fontSize: "0.8rem",
-                        mt: 1,
-                      }}
-                    >
-                      View my Lists
-                    </Button>
-                  </div> */}
                 </MenuList>
               </ClickAwayListener>
             </Paper>

--- a/src/Components/AddToListDropMenu.js
+++ b/src/Components/AddToListDropMenu.js
@@ -167,7 +167,7 @@ export default function AddToListDropMenu({ anime, variant, selected }) {
         role={undefined}
         placement="bottom"
         transition
-        style={{ zIndex: "4" }}
+        style={{ zIndex: "4", maxWidth: "600px" }}
       >
         {({ TransitionProps, placement }) => (
           <Grow
@@ -215,7 +215,7 @@ export default function AddToListDropMenu({ anime, variant, selected }) {
                         <AddButtonForTop8 anime={anime} list={localUser.top8} />
                       }
                     >
-                      MY TOP 8
+                      <ListItemText primary="My Top 8" sx={{ mr: 4 }} />
                     </ListItem>
                   ) : (
                     ""
@@ -235,7 +235,7 @@ export default function AddToListDropMenu({ anime, variant, selected }) {
                               <AddButton anime={anime} list={item.name} />
                             }
                           >
-                            {item.name}
+                            <ListItemText primary={item.name} sx={{ mr: 4 }} />
                           </ListItem>
                         );
                       })

--- a/src/Components/DropMenu.js
+++ b/src/Components/DropMenu.js
@@ -137,7 +137,7 @@ export default function DropMenu() {
         role={undefined}
         placement="bottom-start"
         transition
-        style={{ zIndex: "4" }}
+        style={{ zIndex: "4", maxWidth: "320px" }}
       >
         {({ TransitionProps, placement }) => (
           <Grow
@@ -179,12 +179,25 @@ export default function DropMenu() {
                         color: user ? "primary" : theme.palette.text.primary,
                       }}
                       primary={localUser?.name ? `${localUser?.name}` : "Guest"}
-                      primaryTypographyProps={{ fontWeight: 600 }}
+                      primaryTypographyProps={{
+                        variant: "h3",
+                        color: theme.palette.text.main,
+                        whiteSpace: "nowrap",
+                        overflow: "hidden",
+                        textOverflow: "ellipsis",
+                      }}
+                      secondary={`@${localUser?.handle}`}
+                      secondaryTypographyProps={{
+                        variant: "body1",
+                        color: theme.palette.text.main,
+                        whiteSpace: "nowrap",
+                        overflow: "hidden",
+                        textOverflow: "ellipsis",
+                      }}
                     />
                   </ListItemButton>
                   <MenuItem
-                    divider
-                    sx={{ paddingTop: "10px", paddingBottom: "10px" }}
+                    sx={{ paddingTop: "10px" }}
                     onClick={(e) => {
                       toggleDarkMode(e);
                     }}
@@ -195,7 +208,6 @@ export default function DropMenu() {
                     {darkMode ? "Dark Mode" : "Light Mode"}
                   </MenuItem>
                   <MenuItem
-                    sx={{ marginTop: "10px" }}
                     onClick={(e) => {
                       sendToProfile(e);
                     }}
@@ -225,6 +237,7 @@ export default function DropMenu() {
                       }}
                     >
                       <ListItemIcon>
+                        {" "}
                         <SignOut size={24} />
                       </ListItemIcon>
                       Logout
@@ -237,6 +250,7 @@ export default function DropMenu() {
                     >
                       {" "}
                       <ListItemIcon>
+                        {" "}
                         <SignOut size={24} />
                       </ListItemIcon>
                       Login

--- a/src/Components/DropMenu.js
+++ b/src/Components/DropMenu.js
@@ -237,7 +237,6 @@ export default function DropMenu() {
                       }}
                     >
                       <ListItemIcon>
-                        {" "}
                         <SignOut size={24} />
                       </ListItemIcon>
                       Logout
@@ -250,7 +249,6 @@ export default function DropMenu() {
                     >
                       {" "}
                       <ListItemIcon>
-                        {" "}
                         <SignOut size={24} />
                       </ListItemIcon>
                       Login


### PR DESCRIPTION
This PR makes the below styling changes to our poppers:
1. Truncates very long list/handle/display names to prevent the layout from breaking.
2. Gives poppers a maxWidth so all contents are visible on mobile.
3. Makes each list name 'clickable' in `AddToListDropMenu` to navigate directly to each list.
