### PR TITLE
Bug Fix: Fallback for anime images

### DIFF
--- a/src/Components/ProfileListItem.js
+++ b/src/Components/ProfileListItem.js
@@ -56,10 +56,20 @@ export default function ProfileListItem({
       >
         <ListItemAvatar>
           <Box
-            component="img"
             alt={item.display_name}
             src={item.image_large ?? item.image_small}
-            sx={{ height: "56px" }}
+            sx={{
+              height: "56px",
+              aspectRatio: "0.7",
+              background: `url(${item?.image_large})`,
+              backgroundPosition: "center",
+              backgroundSize: "cover",
+              borderRadius: "8px",
+              overflow: "clip",
+              backgroundColor: theme.palette.custom.missingAnimeCover,
+              mr: 2,
+              my: 0.3,
+            }}
           ></Box>{" "}
         </ListItemAvatar>
         <ListItemText primary={item.display_name} />

--- a/src/Components/TitleAutocompleteOption.js
+++ b/src/Components/TitleAutocompleteOption.js
@@ -3,8 +3,10 @@ import Avatar from "@mui/material/Avatar";
 import { useMemo } from "react";
 import { getAvatarSrc } from "./Avatars";
 import ListItemText from "@mui/material/ListItemText";
+import { useTheme } from "@mui/material";
 
 export default function TitleAutocompleteOption({ props, options }) {
+  const theme = useTheme();
   const avatarSrc = useMemo(
     () => getAvatarSrc(options?.avatar),
     [options?.avatar]
@@ -24,10 +26,19 @@ export default function TitleAutocompleteOption({ props, options }) {
       {...props}
     >
       {options.id && (
-        <img
-          width="35"
-          src={options.image_large || options.image_small || avatarSrc}
-          alt=""
+        <Box
+          alt={options.display_name}
+          sx={{
+            width: "35px",
+            aspectRatio: "0.7",
+            background: `url(${options?.image_large})` ?? avatarSrc,
+            backgroundPosition: "center",
+            backgroundSize: "cover",
+            borderRadius: "8px",
+            overflow: "clip",
+            backgroundColor: theme.palette.custom.missingAnimeCover,
+            mr: 2,
+          }}
         />
       )}
       {options.uid && (

--- a/src/Components/TitleAutocompleteOption.js
+++ b/src/Components/TitleAutocompleteOption.js
@@ -31,7 +31,8 @@ export default function TitleAutocompleteOption({ props, options }) {
           sx={{
             width: "35px",
             aspectRatio: "0.7",
-            background: `url(${options?.image_large})` ?? avatarSrc,
+            background:
+              `url(${options?.image_large})` ?? `url(${options?.image_small})`,
             backgroundPosition: "center",
             backgroundSize: "cover",
             borderRadius: "8px",

--- a/src/Components/WatchlistTile.js
+++ b/src/Components/WatchlistTile.js
@@ -26,7 +26,7 @@ export default function WatchlistTile({
   const gradient = `linear-gradient(270deg, ${bgColor} 0%, rgba(245, 245, 245, 0) 67.39%)`;
 
   const avatarSrc = useMemo(() => getAvatarSrc(creatorAvatar), [creatorAvatar]);
-
+  console.log(items);
   return (
     <Link to={`/profile/${userId}/list/${listId}`}>
       <Box
@@ -78,6 +78,7 @@ export default function WatchlistTile({
                   backgroundSize: "cover",
                   borderRadius: "8px",
                   overflow: "clip",
+                  backgroundColor: theme.palette.custom.missingAnimeCover,
                 }}
               />
             </Grid>

--- a/src/Components/WatchlistTile.js
+++ b/src/Components/WatchlistTile.js
@@ -26,7 +26,7 @@ export default function WatchlistTile({
   const gradient = `linear-gradient(270deg, ${bgColor} 0%, rgba(245, 245, 245, 0) 67.39%)`;
 
   const avatarSrc = useMemo(() => getAvatarSrc(creatorAvatar), [creatorAvatar]);
-  console.log(items);
+
   return (
     <Link to={`/profile/${userId}/list/${listId}`}>
       <Box

--- a/src/Components/theme.js
+++ b/src/Components/theme.js
@@ -31,6 +31,7 @@ export function createAppTheme(darkMode) {
         top8Bg: darkMode
           ? "linear-gradient(#171717, #4a3636)"
           : "linear-gradient(#f5f5f5, #f5eaea)",
+        missingAnimeCover: darkMode ? "#2c2c2c" : "#cccccc",
       },
     },
     breakpoints: {


### PR DESCRIPTION
Bug: When the url for an anime image is broken (as is the case for Bleach Thousand Year Blood War) its tile does not show up in a few spots.

Fix: Makes all places that show the image for an anime also have a gray background color.  This allows anime with broken image links to still have a visible tile (albeit with a gray background...but we can dress this up later!)