### PR TITLE
Remove child from Chip in GenreChipsNew

### DIFF
--- a/src/Components/GenreChipsNew.js
+++ b/src/Components/GenreChipsNew.js
@@ -44,9 +44,7 @@ export default function GenreChipsNew({ selectedGenre, setSelectedGenre }) {
           clickable={true}
           label={genre}
           onClick={() => onClick(genre)}
-        >
-          {genre}
-        </Chip>
+        />
       ))}
     </ScrollMenu>
   );


### PR DESCRIPTION
Chip doesn't support having a child element, so react complains in the console.  Removing it since it is unneeded and does nothing.