### PR TITLE
Removes itemId from Chip in GenreChipsNew

### DIFF
--- a/src/Components/GenreChipsNew.js
+++ b/src/Components/GenreChipsNew.js
@@ -34,7 +34,6 @@ export default function GenreChipsNew({ selectedGenre, setSelectedGenre }) {
       {genres.map((genre) => (
         <Chip
           key={genre}
-          itemId={genre}
           sx={{
             borderRadius: "16px",
             mr: 1,


### PR DESCRIPTION
- React flags this as an invalid DOM property and suggests 'itemID' instead. However, I don't think this parameter is needed so I deleted it, but feel free to add it back in if I missed something.