### PR TITLE
Add react-query for /anime/id/similar, use staleTime for /analyze

### DIFF
--- a/src/Hooks/useAnimeAnalysis.js
+++ b/src/Hooks/useAnimeAnalysis.js
@@ -3,6 +3,8 @@ import { useContext, useMemo } from "react";
 import { APIGetAnimeAnalysis } from "../Components/APICalls";
 import { LocalUserContext } from "../Components/LocalUserContext";
 
+const fiveMinutesMs = 1000 * 60 * 5;
+
 /**
  * A hook that provides anime analysis for the given `animeId`.
  * @param {string} animeId The anime id to get analysis for.
@@ -31,7 +33,7 @@ export default function useAnimeAnalysis(animeId) {
     () => {
       return APIGetAnimeAnalysis(animeId, history);
     },
-    { keepPreviousData: true }
+    { keepPreviousData: true, staleTime: fiveMinutesMs }
   );
 
   return [data, isLoading, error, isFetching];

--- a/src/Hooks/useSimilarAnime.js
+++ b/src/Hooks/useSimilarAnime.js
@@ -1,5 +1,7 @@
-import { useEffect, useState } from "react";
 import { APIGetSimilarAnime } from "../Components/APICalls";
+import { useQuery } from "@tanstack/react-query";
+
+const fiveMinutesMs = 1000 * 60 * 5;
 
 /**
  * A hook that provides similar anime data for the given `animeId`.
@@ -10,33 +12,11 @@ import { APIGetSimilarAnime } from "../Components/APICalls";
  * a list of Anime objects, or `undefined`.
  */
 export default function useSimilarAnime(animeId, amount) {
-  const [fetched, setFetched] = useState();
-  const [error, setError] = useState();
+  const result = useQuery(
+    ["anime", animeId, "similar", amount],
+    () => APIGetSimilarAnime(animeId, amount),
+    { staleTime: fiveMinutesMs }
+  );
 
-  const requestKey = `${animeId}/${amount}`;
-
-  const result = fetched?.requestKey === requestKey ? fetched.data : undefined;
-
-  useEffect(() => {
-    // Don't load if we have the right data already.
-    if (result) {
-      return;
-    }
-    // Otherwise, fetch similar anime from API.
-    setFetched(undefined);
-    setError(undefined);
-    APIGetSimilarAnime(animeId, amount)
-      .then((data) => {
-        if (data) {
-          setFetched({ requestKey, data });
-        } else {
-          throw new Error("Bad similar anime data returned by API.");
-        }
-      })
-      .catch((err) => setError(err));
-  }, [animeId, amount, result]);
-
-  const loading = !result && !error;
-
-  return [result, loading, error];
+  return [result.data, result.isLoading, result.error];
 }


### PR DESCRIPTION
Two improvements.

1. `useSimilarAnime` now uses react-query.
2. `useAnimeAnalysis` now has a stale time, which cuts down on extra unneeded requests, especially when navigating away from a DetailedView page.