### PR TITLE
Add dynamic <head> tags

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-firebase-hooks": "^5.1.1",
+        "react-helmet": "^6.1.0",
         "react-hook-form": "^7.42.1",
         "react-horizontal-scrolling-menu": "^4.0.4",
         "react-router-dom": "^6.4.5",
@@ -15851,6 +15852,11 @@
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.11.tgz",
       "integrity": "sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg=="
     },
+    "node_modules/react-fast-compare": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
+      "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ=="
+    },
     "node_modules/react-firebase-hooks": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/react-firebase-hooks/-/react-firebase-hooks-5.1.1.tgz",
@@ -15858,6 +15864,20 @@
       "peerDependencies": {
         "firebase": ">= 9.0.0",
         "react": ">= 16.8.0"
+      }
+    },
+    "node_modules/react-helmet": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/react-helmet/-/react-helmet-6.1.0.tgz",
+      "integrity": "sha512-4uMzEY9nlDlgxr61NL3XbKRy1hEkXmKNXhjbAIOVw5vcFrsdYbH2FEwcNyWvWinl103nXgzYNlns9ca+8kFiWw==",
+      "dependencies": {
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.7.2",
+        "react-fast-compare": "^3.1.1",
+        "react-side-effect": "^2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.3.0"
       }
     },
     "node_modules/react-hook-form": {
@@ -15999,6 +16019,14 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-side-effect": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/react-side-effect/-/react-side-effect-2.1.2.tgz",
+      "integrity": "sha512-PVjOcvVOyIILrYoyGEpDN3vmYNLdy1CajSFNt4TDsVQC5KpTijDvWVoR+/7Rz2xT978D8/ZtFceXxzsPwZEDvw==",
+      "peerDependencies": {
+        "react": "^16.3.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/react-swipeable": {
@@ -30104,11 +30132,27 @@
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.11.tgz",
       "integrity": "sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg=="
     },
+    "react-fast-compare": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
+      "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ=="
+    },
     "react-firebase-hooks": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/react-firebase-hooks/-/react-firebase-hooks-5.1.1.tgz",
       "integrity": "sha512-y2UpWs82xs+39q5Rc/wq316ca52QsC0n8m801V+yM4IC4hbfOL4yQPVSh7w+ydstdvjN9F+lvs1WrO2VYxpmdA==",
       "requires": {}
+    },
+    "react-helmet": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/react-helmet/-/react-helmet-6.1.0.tgz",
+      "integrity": "sha512-4uMzEY9nlDlgxr61NL3XbKRy1hEkXmKNXhjbAIOVw5vcFrsdYbH2FEwcNyWvWinl103nXgzYNlns9ca+8kFiWw==",
+      "requires": {
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.7.2",
+        "react-fast-compare": "^3.1.1",
+        "react-side-effect": "^2.1.0"
+      }
     },
     "react-hook-form": {
       "version": "7.42.1",
@@ -30205,6 +30249,12 @@
         "webpack-manifest-plugin": "^4.0.2",
         "workbox-webpack-plugin": "^6.4.1"
       }
+    },
+    "react-side-effect": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/react-side-effect/-/react-side-effect-2.1.2.tgz",
+      "integrity": "sha512-PVjOcvVOyIILrYoyGEpDN3vmYNLdy1CajSFNt4TDsVQC5KpTijDvWVoR+/7Rz2xT978D8/ZtFceXxzsPwZEDvw==",
+      "requires": {}
     },
     "react-swipeable": {
       "version": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-firebase-hooks": "^5.1.1",
+    "react-helmet": "^6.1.0",
     "react-hook-form": "^7.42.1",
     "react-horizontal-scrolling-menu": "^4.0.4",
     "react-router-dom": "^6.4.5",

--- a/public/index.html
+++ b/public/index.html
@@ -4,7 +4,6 @@
     <meta charset="utf-8" />
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="theme-color" content="#000000" />
     <meta
       name="EdwardML"
       content="EdwardML uses its giant computer brain to help you decide which anime

--- a/src/Components/AppThemeProvider.js
+++ b/src/Components/AppThemeProvider.js
@@ -2,6 +2,8 @@ import CssBaseline from "@mui/material/CssBaseline";
 import ThemeProvider from "@mui/material/styles/ThemeProvider";
 
 import { useContext, useMemo } from "react";
+import { Helmet } from "react-helmet";
+
 import AppSettingsContext from "./AppSettingsContext";
 import { createAppTheme } from "./theme";
 
@@ -15,6 +17,12 @@ export default function AppThemeProvider(props) {
 
   return (
     <ThemeProvider theme={currentTheme}>
+      <Helmet>
+        <meta
+          name="theme-color"
+          content={currentTheme.palette.background.default}
+        />
+      </Helmet>
       <CssBaseline />
       {props.children}
     </ThemeProvider>

--- a/src/Components/DetailedView.js
+++ b/src/Components/DetailedView.js
@@ -26,6 +26,7 @@ import SimilarContent from "./SimilarContent";
 import UrlButtons from "./UrlButtons";
 import ReviewContainer from "./ReviewContainer";
 import HandleDialog from "./HandleDialog";
+import HtmlPageTitle from "./HtmlPageTitle";
 
 export default function DetailedView() {
   const navigate = useNavigate();
@@ -83,6 +84,7 @@ export default function DetailedView() {
 
   return (
     <Container maxWidth="lg" key={anime.id}>
+      <HtmlPageTitle title={anime?.display_name} />
       {/* Below ensure the following: localUser has been loaded, user is not 
       on a guest account, and they do NOT have a handle.*/}
       {localUser.uid && !user.isAnonymous && !localUser.handle && (

--- a/src/Components/Home.js
+++ b/src/Components/Home.js
@@ -23,6 +23,7 @@ import { LocalUserContext } from "./LocalUserContext";
 import HandleDialog from "./HandleDialog";
 import { PopulateFromFirestore } from "./Firestore";
 import useGenreFilter from "../Hooks/useGenreFilter";
+import HtmlPageTitle from "./HtmlPageTitle";
 
 export default function Home() {
   let [animeRandom, setAnimeRandom] = useState(null); //randomized
@@ -99,6 +100,7 @@ export default function Home() {
 
   return (
     <div>
+      <HtmlPageTitle title={"Home"} />
       {/* Below ensure the following: localUser has been loaded, user is not 
       on a guest account, and they do NOT have a handle.*/}
       {localUser.uid && !user.isAnonymous && !localUser.handle && (

--- a/src/Components/HtmlPageTitle.js
+++ b/src/Components/HtmlPageTitle.js
@@ -1,0 +1,18 @@
+import { useMemo } from "react";
+import { Helmet } from "react-helmet";
+
+export default function HtmlPageTitle({ title }) {
+  const titleString = useMemo(() => {
+    if (title) {
+      return `${title} - EdwardML`;
+    } else {
+      return "EdwardML";
+    }
+  }, [title]);
+
+  return (
+    <Helmet>
+      <title>{titleString}</title>
+    </Helmet>
+  );
+}

--- a/src/Components/Login.js
+++ b/src/Components/Login.js
@@ -15,6 +15,7 @@ import TwitterIcon from "@mui/icons-material/Twitter";
 import google from "../Styles/images/google.svg";
 import EdwardMLLogo from "./EdwardMLLogo";
 import useAuthActions from "../Hooks/useAuthActions";
+import HtmlPageTitle from "./HtmlPageTitle";
 
 export default function Login() {
   const authActions = useAuthActions();
@@ -71,6 +72,7 @@ export default function Login() {
 
   return (
     <div className="login">
+      <HtmlPageTitle title={"Login"} />
       <Container maxWidth="lg">
         <div className="welcomeBanner">
           <Link to="/">

--- a/src/Components/Onboarding.js
+++ b/src/Components/Onboarding.js
@@ -26,6 +26,7 @@ import Ponyo from "../Styles/images/onboarding/ponyo.jpg";
 import SailorMoon from "../Styles/images/onboarding/sailormoon.jpg";
 import SwordArtOnline from "../Styles/images/onboarding/swordartonline.jpg";
 import NoGameNoLife from "../Styles/images/onboarding/nogamenolife.jpg";
+import HtmlPageTitle from "./HtmlPageTitle";
 
 export default function Onboarding() {
   const [localUser, setLocalUser] = useContext(LocalUserContext);
@@ -43,6 +44,7 @@ export default function Onboarding() {
 
   return (
     <div className="App">
+      <HtmlPageTitle title={"Getting Set Up"} />
       <OnboardingHeader />
       <Container maxWidth="lg">
         <Typography

--- a/src/Components/ProfileListPage.js
+++ b/src/Components/ProfileListPage.js
@@ -31,6 +31,7 @@ import { GetListReactions } from "./Firestore";
 import Grid from "@mui/material/Grid";
 import useMediaQuery from "@mui/material/useMediaQuery";
 import useTheme from "@mui/material/styles/useTheme";
+import HtmlPageTitle from "./HtmlPageTitle";
 
 export default function ProfileListPage() {
   const navigate = useNavigate();
@@ -163,6 +164,7 @@ export default function ProfileListPage() {
 
   return (
     <Box>
+      <HtmlPageTitle title={name} />
       {/* Header */}
       <Grid
         container

--- a/src/Components/ProfileMainPage.js
+++ b/src/Components/ProfileMainPage.js
@@ -1,14 +1,16 @@
 import Grid from "@mui/material/Grid";
 import Typography from "@mui/material/Typography";
+import { useContext } from "react";
 import NoResultsImage from "./NoResultsImage";
 import WatchlistTile from "./WatchlistTile";
-import { useContext, useEffect, useMemo } from "react";
 import ProfilePageContext from "./ProfilePageContext";
 import ProfileMainPageGhost from "./ProfileMainPageGhost";
 import ProfileSidebar from "./ProfileSidebar";
+import HtmlPageTitle from "./HtmlPageTitle";
 
 export default function ProfileMainPage() {
-  const { profile, animeObjects, isLoading } = useContext(ProfilePageContext);
+  const { profile, animeObjects, isOwnProfile, isLoading } =
+    useContext(ProfilePageContext);
 
   const subheadStyle = {
     marginTop: "26px",
@@ -23,6 +25,7 @@ export default function ProfileMainPage() {
 
   return (
     <Grid container>
+      <HtmlPageTitle title={getHtmlTitle(profile, isOwnProfile)} />
       <Grid item xs={12} md={4}>
         <ProfileSidebar />
       </Grid>
@@ -99,4 +102,14 @@ export default function ProfileMainPage() {
       </Grid>
     </Grid>
   );
+}
+
+function getHtmlTitle(profile, isOwnProfile) {
+  if (isOwnProfile) {
+    return "Your Profile";
+  } else if (profile?.handle) {
+    return `@${profile.handle}'s Profile`;
+  } else {
+    return "Profile";
+  }
 }

--- a/src/Components/Register.js
+++ b/src/Components/Register.js
@@ -22,6 +22,7 @@ import { useForm } from "react-hook-form";
 import BreathingLogo from "./BreathingLogo";
 import EdwardMLLogo from "./EdwardMLLogo";
 import useAuthActions from "../Hooks/useAuthActions";
+import HtmlPageTitle from "./HtmlPageTitle";
 
 export default function Register() {
   const [email, setEmail] = useState("");
@@ -122,6 +123,7 @@ export default function Register() {
 
   return (
     <div className="register">
+      <HtmlPageTitle title={"Register"} />
       <Container maxWidth="lg">
         <div className="welcomeBanner">
           <Link to="/">

--- a/src/Components/Reset.js
+++ b/src/Components/Reset.js
@@ -18,6 +18,8 @@ import Button from "@mui/material/Button";
 import Divider from "@mui/material/Divider";
 import TextField from "@mui/material/TextField";
 import useTheme from "@mui/material/styles/useTheme";
+import HtmlPageTitle from "./HtmlPageTitle";
+import Typography from "@mui/material/Typography";
 
 export default function Reset() {
   const [email, setEmail] = useState("");
@@ -41,6 +43,8 @@ export default function Reset() {
 
   return (
     <div className="login">
+      <HtmlPageTitle title={"Password Reset"} />
+
       <Container maxWidth="lg">
         {/* //*************Pop-up that's displayed once reset email is sent********/}
         <Dialog
@@ -90,9 +94,9 @@ export default function Reset() {
             <EdwardMLLogo />
           </Link>
         </div>
-        <h4 className="H4" style={{ textAlign: "center" }}>
+        <Typography variant="h3" sx={{ textAlign: "center", mb: "18px" }}>
           Let's Reset Your Password!
-        </h4>
+        </Typography>
       </Container>
 
       <Container

--- a/src/Components/Search.js
+++ b/src/Components/Search.js
@@ -23,6 +23,7 @@ import SearchGhost from "./SearchGhost";
 import HandleDialog from "./HandleDialog";
 import SearchAvatars from "./SearchAvatars";
 import SearchResultsBanner from "./SearchResultsBanner";
+import HtmlPageTitle from "./HtmlPageTitle";
 
 export default function Search() {
   const location = useLocation();
@@ -72,6 +73,7 @@ export default function Search() {
 
   return (
     <div className="jsxWrapper">
+      <HtmlPageTitle title={"Search Results"} />
       {/* Below ensure the following: localUser has been loaded, user is not 
       on a guest account, and they do NOT have a handle.*/}
       {localUser.uid && !user.isAnonymous && !localUser.handle && (


### PR DESCRIPTION
I've installed a package called `react-helmet` that allows us to dynamically change the html doc head tags for each page. I've leveraged it to:
1. Update the `theme-color` which allows the iOS system bg color to match our bg color.  [before](https://drive.google.com/file/d/16LgmVQPVqj5qZ5ftYnqnanhOAP6U-nyl/view?usp=sharing), [after](https://drive.google.com/file/d/1abNQnRYEXTuMRo3bvDFCrNhrByTCLRPo/view?usp=sharing).
2. Set different page titles, depending on the page.  Now the titles will be things like "Naruto - EdwardML", "Your Profile - EdwardML", "Search Results - EdwardML".  This will make the back stack look nicer. [before](https://drive.google.com/file/d/1G5jJ1IC3CottD4qPvvC-ssSQB6z2WKC9/view?usp=sharing), [after](https://drive.google.com/file/d/1hCorAyZvxa64NbRPMUBRLRkTvoYL5Afv/view?usp=sharing).