### PR TITLE
Notifications - Refactored Infinite Scroll

### DIFF
--- a/src/Components/DropMenu.js
+++ b/src/Components/DropMenu.js
@@ -134,7 +134,7 @@ export default function DropMenu() {
       <Popper
         open={open}
         anchorEl={anchorRef.current}
-        role={undefined}
+        placement="bottom-end"
         transition
         style={{ zIndex: "4", maxWidth: "320px" }}
       >
@@ -145,7 +145,7 @@ export default function DropMenu() {
               transformOrigin: "right top",
             }}
           >
-            <Paper elevation={6}>
+            <Paper elevation={6} sx={{ mr: 1, ml: -1 }}>
               <ClickAwayListener onClickAway={handleClose}>
                 <MenuList
                   autoFocusItem={open}

--- a/src/Components/NotificationDropMenu.js
+++ b/src/Components/NotificationDropMenu.js
@@ -38,13 +38,12 @@ export default function NotificationDropMenu() {
 
   const [
     notifications,
-    setNotifications,
     showMore,
     hideBadge,
-    GetNotis,
-    setLastVisible,
+    getNotis,
     showNewNotiButton,
     displayLatestNotis,
+    resetPagination,
   ] = useContext(NotificationsContext);
 
   const isMobileWidth = useMediaQuery(
@@ -52,7 +51,7 @@ export default function NotificationDropMenu() {
   );
 
   const handleToggle = () => {
-    if (!open) GetNotis();
+    if (!open) getNotis();
     setOpen((prevOpen) => !prevOpen);
   };
 
@@ -158,10 +157,7 @@ export default function NotificationDropMenu() {
         {({ TransitionProps }) => (
           <Grow
             {...TransitionProps}
-            onExited={() => {
-              setNotifications([]);
-              setLastVisible();
-            }}
+            onExited={() => resetPagination()}
             style={{
               transformOrigin: "right top",
             }}
@@ -200,7 +196,7 @@ export default function NotificationDropMenu() {
                       <ListItemButton
                         sx={{ display: "flex", justifyContent: "center" }}
                         onClick={() => {
-                          GetNotis();
+                          getNotis();
                           setLoadingMoreNotis(true);
                         }}
                       >

--- a/src/Components/NotificationDropMenu.js
+++ b/src/Components/NotificationDropMenu.js
@@ -1,4 +1,11 @@
-import React, { useContext, useEffect, useMemo, useRef, useState } from "react";
+import React, {
+  Fragment,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import ClickAwayListener from "@mui/material/ClickAwayListener";
 import Grow from "@mui/material/Grow";
 import Paper from "@mui/material/Paper";
@@ -11,8 +18,10 @@ import ListItemButton from "@mui/material/ListItemButton";
 import CircularProgress from "@mui/material/CircularProgress";
 import Badge from "@mui/material/Badge";
 import useMediaQuery from "@mui/material/useMediaQuery";
+import Button from "@mui/material/Button";
+import Box from "@mui/material/Box";
 
-import { Bell, CaretDown } from "phosphor-react";
+import { Bell, CaretDown, CaretUp } from "phosphor-react";
 
 import NotificationsContext from "./NotificationsContext";
 import { NotificationListItem } from "./NotificationListItem";
@@ -34,6 +43,8 @@ export default function NotificationDropMenu() {
     hideBadge,
     GetNotis,
     setLastVisible,
+    showNewNotiButton,
+    displayLatestNotis,
   ] = useContext(NotificationsContext);
 
   const isMobileWidth = useMediaQuery(
@@ -165,41 +176,65 @@ export default function NotificationDropMenu() {
               }}
             >
               <ClickAwayListener onClickAway={handleClose}>
-                <MenuList
-                  autoFocusItem={open}
-                  variant="menu"
-                  id="composition-menu"
-                  aria-labelledby="composition-button"
-                  onKeyDown={handleListKeyDown}
-                >
-                  {notifications?.map((item, index) => {
-                    return (
-                      <NotificationListItem
-                        item={item}
-                        key={`${item.time?.seconds}+${item.interactorId}`}
-                        handleClose={handleClose}
-                        index={index}
-                      />
-                    );
-                  })}
-                  {/* Render SEE MORE button */}
-                  {showMore && (
-                    <ListItemButton
-                      sx={{ display: "flex", justifyContent: "center" }}
-                      onClick={() => {
-                        GetNotis();
-                        setLoadingMoreNotis(true);
-                      }}
-                    >
-                      {!loadingMoreNotis ? "See More" : ""}
-                      {!loadingMoreNotis ? (
-                        <CaretDown size={32} style={{ marginLeft: "10px" }} />
-                      ) : (
-                        <CircularProgress />
-                      )}
-                    </ListItemButton>
+                <Box>
+                  <MenuList
+                    autoFocusItem={open}
+                    variant="menu"
+                    id="composition-menu"
+                    aria-labelledby="composition-button"
+                    onKeyDown={handleListKeyDown}
+                  >
+                    {notifications?.map((item, index) => {
+                      return (
+                        <NotificationListItem
+                          item={item}
+                          key={`${item.time?.seconds}+${item.interactorId}`}
+                          handleClose={handleClose}
+                          index={index}
+                        />
+                      );
+                    })}
+
+                    {/* Render SEE MORE button */}
+                    {showMore && (
+                      <ListItemButton
+                        sx={{ display: "flex", justifyContent: "center" }}
+                        onClick={() => {
+                          GetNotis();
+                          setLoadingMoreNotis(true);
+                        }}
+                      >
+                        {!loadingMoreNotis ? "See More" : ""}
+                        {!loadingMoreNotis ? (
+                          <CaretDown size={32} style={{ marginLeft: "10px" }} />
+                        ) : (
+                          <CircularProgress />
+                        )}
+                      </ListItemButton>
+                    )}
+                  </MenuList>
+                  {/* Render SEE LATEST button */}
+                  {showNewNotiButton && (
+                    <Box sx={{ display: "flex", justifyContent: "center" }}>
+                      <Button
+                        onClick={() => {
+                          displayLatestNotis();
+                        }}
+                        sx={{
+                          position: "absolute",
+                          top: "10px",
+                          textAlign: "center",
+                          height: "25px",
+                        }}
+                        variant="contained"
+                        size="medium"
+                      >
+                        New Notifications
+                        <CaretUp size={28} style={{ marginLeft: "5px" }} />
+                      </Button>
+                    </Box>
                   )}
-                </MenuList>
+                </Box>
               </ClickAwayListener>
             </Paper>
           </Grow>

--- a/src/Components/NotificationDropMenu.js
+++ b/src/Components/NotificationDropMenu.js
@@ -32,8 +32,8 @@ export default function NotificationDropMenu() {
     setNotifications,
     showMore,
     hideBadge,
-    moreNotiRequests,
-    setMoreNotiRequests,
+    GetNotis,
+    setLastVisible,
   ] = useContext(NotificationsContext);
 
   const isMobileWidth = useMediaQuery(
@@ -41,6 +41,7 @@ export default function NotificationDropMenu() {
   );
 
   const handleToggle = () => {
+    if (!open) GetNotis();
     setOpen((prevOpen) => !prevOpen);
   };
 
@@ -99,11 +100,7 @@ export default function NotificationDropMenu() {
     }
   }, [open]);
 
-  // Makes popper show default # of notifications when re-opened.
-  useEffect(() => {
-    if (notifications && open === false) setMoreNotiRequests(0);
-  }, [open]);
-
+  // Hides spinner once additional notis have been added to notifications array
   useEffect(() => {
     setLoadingMoreNotis(false);
   }, [notifications]);
@@ -141,14 +138,6 @@ export default function NotificationDropMenu() {
         open={open}
         anchorEl={anchorRef.current}
         placement="bottom-end"
-        modifiers={[
-          {
-            name: "offset",
-            options: {
-              offset: [250, 0],
-            },
-          },
-        ]}
         transition
         style={{
           zIndex: "4",
@@ -158,15 +147,19 @@ export default function NotificationDropMenu() {
         {({ TransitionProps }) => (
           <Grow
             {...TransitionProps}
+            onExited={() => {
+              setNotifications([]);
+              setLastVisible();
+            }}
             style={{
-              transformOrigin: isMobileWidth ? "right top" : "center top",
+              transformOrigin: "right top",
             }}
           >
             <Paper
               elevation={6}
               sx={{
                 overflow: "auto",
-                mr: 1,
+                ml: 1,
                 maxHeight: "92vh",
                 overflowY: "auto",
               }}
@@ -183,7 +176,7 @@ export default function NotificationDropMenu() {
                     return (
                       <NotificationListItem
                         item={item}
-                        key={`${item.time?.seconds} + ${index}`}
+                        key={`${item.time?.seconds}+${item.interactorId}`}
                         handleClose={handleClose}
                         index={index}
                       />
@@ -194,7 +187,7 @@ export default function NotificationDropMenu() {
                     <ListItemButton
                       sx={{ display: "flex", justifyContent: "center" }}
                       onClick={() => {
-                        setMoreNotiRequests(moreNotiRequests + 1);
+                        GetNotis();
                         setLoadingMoreNotis(true);
                       }}
                     >

--- a/src/Components/NotificationsProvider.js
+++ b/src/Components/NotificationsProvider.js
@@ -36,10 +36,10 @@ export default function NotificationsProvider(props) {
     );
     const q = query(notisRef, orderBy("time", "desc"), limit(5));
     const unsub = onSnapshot(q, (documentSnapshots) => {
-      const latestNoti = [];
-      documentSnapshots.forEach((doc) => {
-        latestNoti.push({ ...doc.data(), firestoreDocId: doc.id });
-      });
+      const latestNoti = documentSnapshots.docs.map((doc) => ({
+        ...doc.data(),
+        firestoreDocId: doc.id,
+      }));
       setListeningDocs(latestNoti);
       if (latestNoti.length === 5)
         setLastVisibleListener(
@@ -50,7 +50,7 @@ export default function NotificationsProvider(props) {
     return unsub;
   }, [user]);
 
-  async function GetNotis() {
+  async function getNotis() {
     if (!user) return;
     const notisRef = collection(
       db,
@@ -124,13 +124,13 @@ export default function NotificationsProvider(props) {
   // The count() firestore fn can't be used with real-time listeners...so this is my work-around.
   useEffect(() => {
     if (!user || !notifications) return;
-    GetUnseenNotiCount().then((result) => {
+    getUnseenNotiCount().then((result) => {
       setHideBadge(result);
       setShowNewNotiButton(!result);
     });
   }, [listeningDocs]);
 
-  async function GetUnseenNotiCount() {
+  async function getUnseenNotiCount() {
     const notisRef = collection(
       db,
       "notifications",
@@ -150,17 +150,21 @@ export default function NotificationsProvider(props) {
     }
   }
 
+  function resetPagination() {
+    setNotifications([]);
+    setLastVisible();
+  }
+
   return (
     <NotificationsContext.Provider
       value={[
         notifications,
-        setNotifications,
         showMore,
         hideBadge,
-        GetNotis,
-        setLastVisible,
+        getNotis,
         showNewNotiButton,
         displayLatestNotis,
+        resetPagination,
       ]}
     >
       {props.children}

--- a/src/Components/NotificationsProvider.js
+++ b/src/Components/NotificationsProvider.js
@@ -2,13 +2,12 @@ import { useEffect, useState } from "react";
 import NotificationsContext from "./NotificationsContext";
 import {
   collection,
-  doc,
-  getCountFromServer,
   getDocs,
   limit,
   onSnapshot,
   orderBy,
   query,
+  startAfter,
   where,
 } from "firebase/firestore";
 import { auth, db } from "./Firebase";
@@ -16,45 +15,76 @@ import { useAuthState } from "react-firebase-hooks/auth";
 
 export default function NotificationsProvider(props) {
   const [user, loading, error] = useAuthState(auth);
-  const [notifications, setNotifications] = useState();
+  const [notifications, setNotifications] = useState([]);
   const [showMore, setShowMore] = useState(false);
   const [hideBadge, setHideBadge] = useState(true);
-  const [moreNotiRequests, setMoreNotiRequests] = useState(0);
+  const [listeningDoc, setListeningDoc] = useState([]);
+  const [lastVisible, setLastVisible] = useState();
 
-  // Read initial state from Firestore, or else use blank array.
-  // It calls Firestore one time, after user has been authed.
+  // Creates realtime listener on most recent notification
+  // Used as trigger for query of unseen data
   useEffect(() => {
     if (!user) return;
-    // Get notifications
+    // Set listener for changes
     const notisRef = collection(
       db,
       "notifications",
       user?.uid,
       "usersNotifications"
     );
-    const q = query(
-      notisRef,
-      orderBy("time", "desc"),
-      limit(5 + moreNotiRequests * 5)
+    const q = query(notisRef, orderBy("time", "desc"), limit(5));
+    const unsub = onSnapshot(q, (documentSnapshots) => {
+      const latestNoti = [];
+      documentSnapshots.forEach((doc) => {
+        latestNoti.push({ ...doc.data(), firestoreDocId: doc.id });
+      });
+      setListeningDoc(latestNoti);
+    });
+    return unsub;
+  }, [user]);
+
+  async function GetNotis() {
+    if (!user) return;
+    const notisRef = collection(
+      db,
+      "notifications",
+      user?.uid,
+      "usersNotifications"
     );
-    const unsub = onSnapshot(q, (querySnapshot) => {
-      const notis = [];
-      querySnapshot.forEach((doc) => {
+    let q;
+    if (!lastVisible) {
+      q = query(notisRef, orderBy("time", "desc"), limit(5));
+    } else {
+      q = query(
+        notisRef,
+        orderBy("time", "desc"),
+        startAfter(lastVisible),
+        limit(5)
+      );
+    }
+    try {
+      const documentSnapshots = await getDocs(q);
+      const notis = [...notifications];
+      let docCount = 0;
+      documentSnapshots.forEach((doc) => {
+        docCount++;
         notis.push({ ...doc.data(), firestoreDocId: doc.id });
       });
-      // Check if there are more notifications than being sent back.
-      if (notis.length === 5 + moreNotiRequests * 5) {
-        notis.splice(notis.length - 1);
-        setNotifications(notis);
+      if (docCount === 5) {
         setShowMore(true);
+        notis.splice(notis.length - 1);
+        setLastVisible(
+          documentSnapshots.docs[documentSnapshots.docs.length - 2]
+        );
       } else {
-        setNotifications(notis ?? []);
         setShowMore(false);
+        setLastVisible(null);
       }
-    });
-
-    return unsub;
-  }, [user, moreNotiRequests]);
+      setNotifications(notis);
+    } catch (error) {
+      console.error("Error getting more notifications from Firestore: ", error);
+    }
+  }
 
   // The count() firestore fn can't be used with real-time listeners...so this is my work-around.
   useEffect(() => {
@@ -62,7 +92,7 @@ export default function NotificationsProvider(props) {
     GetUnseenNotiCount().then((result) => {
       setHideBadge(result);
     });
-  }, [notifications]);
+  }, [listeningDoc]);
 
   async function GetUnseenNotiCount() {
     const notisRef = collection(
@@ -91,8 +121,8 @@ export default function NotificationsProvider(props) {
         setNotifications,
         showMore,
         hideBadge,
-        moreNotiRequests,
-        setMoreNotiRequests,
+        GetNotis,
+        setLastVisible,
       ]}
     >
       {props.children}


### PR DESCRIPTION
Updates notification popper to work as follows:
- Initial notifications read from real time listener.
- Real time listeners are used to trigger the "new notifications badge" and the initial (4) notifications only.
- All additional notifications are read using static `getDocs` - so once popper is opened all displayed notifications are "frozen in time". 
- Any new notifications will only be shown by clicking a "New Notifications" button that will appear the same time as the "new notifications badge".

This update significantly reduces the number of Firestore reads required by the notification popper....especially when a user goes way back in time.

Outstanding Item: After clicking on a notification, the user loses their spot among all of the loaded notifications.