### PR TITLE
Community Lists on Home

### DIFF
--- a/src/Components/AddToListDropMenu.js
+++ b/src/Components/AddToListDropMenu.js
@@ -19,7 +19,11 @@ import ListItemText from "@mui/material/ListItemText";
 import TextField from "@mui/material/TextField";
 import Tooltip from "@mui/material/Tooltip";
 import useTheme from "@mui/material/styles/useTheme";
-import { generateId, SaveToFirestore } from "./Firestore";
+import {
+  CreateWatchlistDataEntry,
+  generateId,
+  SaveToFirestore,
+} from "./Firestore";
 import AddButton from "./AddButton";
 import * as Yup from "yup";
 import { useForm } from "react-hook-form";
@@ -110,6 +114,7 @@ export default function AddToListDropMenu({ anime, variant, selected }) {
     ];
     setLocalUser(temp);
     SaveToFirestore(user, temp);
+    if (!privateList) CreateWatchlistDataEntry(user.uid, listId);
     setName("");
   };
 

--- a/src/Components/AnimeGrid.js
+++ b/src/Components/AnimeGrid.js
@@ -14,7 +14,7 @@ export default function AnimeGrid({ items, large }) {
   let [seeMore, setSeeMore] = useState(0);
 
   const ghosts = new Array(10).fill(0);
-  const showGhosts = !items?.length;
+  const showGhosts = !items.length;
 
   const shownItems = howManyItems(seeMore);
   const showSeeMoreButton = seeMore !== 2 && shownItems.length !== items.length;

--- a/src/Components/AnimeGrid.js
+++ b/src/Components/AnimeGrid.js
@@ -14,7 +14,7 @@ export default function AnimeGrid({ items, large }) {
   let [seeMore, setSeeMore] = useState(0);
 
   const ghosts = new Array(10).fill(0);
-  const showGhosts = !items.length;
+  const showGhosts = !items?.length;
 
   const shownItems = howManyItems(seeMore);
   const showSeeMoreButton = seeMore !== 2 && shownItems.length !== items.length;
@@ -75,7 +75,7 @@ export default function AnimeGrid({ items, large }) {
               />
             </Grid>
           ))}
-        {showSeeMoreButton && (
+        {showSeeMoreButton && !showGhosts && (
           <Grid
             item
             xs={columns}
@@ -90,6 +90,18 @@ export default function AnimeGrid({ items, large }) {
               See more
             </Button>
           </Grid>
+        )}
+        {showGhosts && (
+          <Box
+            sx={{ display: "flex", justifyContent: "center", width: "100%" }}
+          >
+            <Skeleton
+              variant="rounded"
+              width="120px"
+              height="40px"
+              sx={{ ml: "16px", mt: "16px", borderRadius: "20px" }}
+            />
+          </Box>
         )}
       </Grid>
     </Box>

--- a/src/Components/AnimeShelfClassic.js
+++ b/src/Components/AnimeShelfClassic.js
@@ -7,7 +7,7 @@ import useMediaQuery from "@mui/material/useMediaQuery";
 import useTheme from "@mui/material/styles/useTheme";
 
 import { CaretLeft, CaretRight } from "phosphor-react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useSwipeable } from "react-swipeable";
 import AnimeCard from "./AnimeCard";
 
@@ -67,6 +67,11 @@ export default function AnimeShelfClassic({ items }) {
     onSwipedRight: (eventData) =>
       setStartIndex(Math.max(startIndex - itemsPerPage, 0)),
   });
+
+  // Resets pagination back to beggining whenever new anime is received
+  useEffect(() => {
+    setStartIndex(0);
+  }, [items]);
 
   return (
     <Box

--- a/src/Components/CommunityListShelf.js
+++ b/src/Components/CommunityListShelf.js
@@ -33,7 +33,6 @@ export default function CommunityListShelf({ data, anime, titleStyle }) {
   return (
     <Fragment>
       {/* Render list name */}
-
       <Box sx={{ display: "flex", alignItems: "center" }}>
         <Typography
           variant="h4"
@@ -66,8 +65,7 @@ export default function CommunityListShelf({ data, anime, titleStyle }) {
       <Box
         tabIndex="0"
         onKeyDown={(e) => {
-          if (e.key === "Enter")
-            navigate(`/profile/${profile.uid}/list/${data.listId}`);
+          if (e.key === "Enter") navigate(`/profile/${profile.uid}`);
         }}
         sx={{
           display: "inline-flex",

--- a/src/Components/CommunityListShelf.js
+++ b/src/Components/CommunityListShelf.js
@@ -1,0 +1,99 @@
+import Typography from "@mui/material/Typography";
+import Box from "@mui/material/Box";
+import { getAvatarSrc } from "./Avatars";
+import { Fragment, useEffect, useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { useProfile } from "./APICalls";
+import Avatar from "@mui/material/Avatar";
+
+import AnimeShelf from "./AnimeShelf";
+import Skeleton from "@mui/material/Skeleton";
+
+export default function CommunityListShelf({ data, anime, titleStyle }) {
+  const navigate = useNavigate();
+  const { data: profile, isLoading: profileLoading } = useProfile(data?.userId);
+  const [listName, setListName] = useState();
+
+  const avatarSrc = useMemo(
+    () => getAvatarSrc(profile?.avatar),
+    [profile?.avatar]
+  );
+
+  useEffect(() => {
+    if (!profile?.lists) return;
+    for (let item of profile.lists) {
+      if (item.id === data.listId) setListName(item.name);
+    }
+  }, [profile]);
+
+  return (
+    <Fragment>
+      {/* Render list name */}
+      {profile?.uid ? (
+        <Box sx={{ display: "flex", alignItems: "center" }}>
+          <Typography
+            variant="h4"
+            tabIndex="0"
+            onClick={(e) => {
+              navigate(`/profile/${profile.uid}/list/${data.listId}`);
+              e.preventDefault();
+              e.stopPropagation();
+            }}
+            sx={{
+              ...titleStyle,
+              "&:hover": { color: "primary.main" },
+              cursor: "pointer",
+              flexShrink: 1,
+              mr: 2,
+            }}
+          >
+            {listName}
+          </Typography>
+        </Box>
+      ) : (
+        <Fragment>
+          <Skeleton
+            width="30%"
+            height={25}
+            variant="rounded"
+            sx={{ ...titleStyle }}
+          />
+        </Fragment>
+      )}
+
+      {/* Render anime shelf */}
+      <AnimeShelf items={anime} />
+
+      {/* Render list author avatar and author name */}
+      {profile?.uid ? (
+        <Box
+          tabIndex="0"
+          sx={{
+            display: "inline-flex",
+            alignItems: "center",
+            "&:hover": { color: "primary.main" },
+            cursor: "pointer",
+            flexShrink: 1,
+          }}
+          onClick={(e) => {
+            navigate(`/profile/${profile.uid}`);
+            e.preventDefault();
+            e.stopPropagation();
+          }}
+        >
+          <Avatar
+            sx={{ width: "35px", height: "35px", mr: 2 }}
+            alt={profile?.name}
+            src={avatarSrc}
+          />
+          <Typography> {profile?.name}</Typography>
+        </Box>
+      ) : (
+        <Box sx={{ display: "flex", alignItems: "center" }}>
+          <Skeleton variant="circular" width={35} height={35} sx={{ mr: 2 }} />
+          <Skeleton variant="text" width="20%" height={36} />
+        </Box>
+      )}
+    </Fragment>
+  );
+}

--- a/src/Components/CommunityListShelf.js
+++ b/src/Components/CommunityListShelf.js
@@ -8,92 +8,98 @@ import Avatar from "@mui/material/Avatar";
 
 import AnimeShelf from "./AnimeShelf";
 import Skeleton from "@mui/material/Skeleton";
+import { useMediaQuery } from "@mui/material";
 
 export default function CommunityListShelf({ data, anime, titleStyle }) {
   const navigate = useNavigate();
   const { data: profile, isLoading: profileLoading } = useProfile(data?.userId);
-  const [listName, setListName] = useState();
+  const cannotHover = useMediaQuery("(hover: none)");
+  const coarsePointer = useMediaQuery("(pointer: coarse)");
+
+  const isTouchscreen = cannotHover && coarsePointer;
 
   const avatarSrc = useMemo(
     () => getAvatarSrc(profile?.avatar),
     [profile?.avatar]
   );
 
-  useEffect(() => {
-    if (!profile?.lists) return;
+  const listName = useMemo(() => {
+    if (!profile?.lists || !data?.listId) return;
     for (let item of profile.lists) {
-      if (item.id === data.listId) setListName(item.name);
+      if (item.id === data.listId) return item.name;
     }
-  }, [profile]);
+  }, [profile?.lists, data?.listId]);
 
   return (
     <Fragment>
       {/* Render list name */}
-      {profile?.uid ? (
-        <Box sx={{ display: "flex", alignItems: "center" }}>
-          <Typography
-            variant="h4"
-            tabIndex="0"
-            onClick={(e) => {
+
+      <Box sx={{ display: "flex", alignItems: "center" }}>
+        <Typography
+          variant="h4"
+          tabIndex="0"
+          onKeyDown={(e) => {
+            if (e.key === "Enter")
               navigate(`/profile/${profile.uid}/list/${data.listId}`);
-              e.preventDefault();
-              e.stopPropagation();
-            }}
-            sx={{
-              ...titleStyle,
-              "&:hover": { color: "primary.main" },
-              cursor: "pointer",
-              flexShrink: 1,
-              mr: 2,
-            }}
-          >
-            {listName}
-          </Typography>
-        </Box>
-      ) : (
-        <Fragment>
-          <Skeleton
-            width="30%"
-            height={25}
-            variant="rounded"
-            sx={{ ...titleStyle }}
-          />
-        </Fragment>
-      )}
+          }}
+          onClick={(e) => {
+            navigate(`/profile/${profile.uid}/list/${data.listId}`);
+            e.preventDefault();
+            e.stopPropagation();
+          }}
+          sx={{
+            ...titleStyle,
+            "&:hover": { color: "primary.main" },
+            cursor: "pointer",
+            flexShrink: 1,
+            mr: 2,
+          }}
+        >
+          {!profile?.uid ? <Skeleton width="40vw" variant="text" /> : listName}
+        </Typography>
+      </Box>
 
       {/* Render anime shelf */}
       <AnimeShelf items={anime} />
 
       {/* Render list author avatar and author name */}
-      {profile?.uid ? (
-        <Box
-          tabIndex="0"
-          sx={{
-            display: "inline-flex",
-            alignItems: "center",
-            "&:hover": { color: "primary.main" },
-            cursor: "pointer",
-            flexShrink: 1,
-          }}
-          onClick={(e) => {
-            navigate(`/profile/${profile.uid}`);
-            e.preventDefault();
-            e.stopPropagation();
-          }}
-        >
+      <Box
+        tabIndex="0"
+        onKeyDown={(e) => {
+          if (e.key === "Enter")
+            navigate(`/profile/${profile.uid}/list/${data.listId}`);
+        }}
+        sx={{
+          display: "inline-flex",
+          alignItems: "center",
+          "&:hover": { color: "primary.main" },
+          cursor: "pointer",
+          flexShrink: 1,
+          mt: isTouchscreen ? 1 : 0,
+        }}
+        onClick={(e) => {
+          navigate(`/profile/${profile.uid}`);
+          e.preventDefault();
+          e.stopPropagation();
+        }}
+      >
+        {!profile?.uid ? (
+          <Skeleton variant="circular" width={35} height={35} sx={{ mr: 2 }} />
+        ) : (
           <Avatar
             sx={{ width: "35px", height: "35px", mr: 2 }}
             alt={profile?.name}
             src={avatarSrc}
           />
-          <Typography> {profile?.name}</Typography>
-        </Box>
-      ) : (
-        <Box sx={{ display: "flex", alignItems: "center" }}>
-          <Skeleton variant="circular" width={35} height={35} sx={{ mr: 2 }} />
-          <Skeleton variant="text" width="20%" height={36} />
-        </Box>
-      )}
+        )}
+        <Typography>
+          {!profile?.uid ? (
+            <Skeleton variant="text" width="20vw" />
+          ) : (
+            profile?.name
+          )}
+        </Typography>
+      </Box>
     </Fragment>
   );
 }

--- a/src/Components/Firestore.js
+++ b/src/Components/Firestore.js
@@ -260,11 +260,10 @@ export async function ClaimHandle(handle, userId) {
 }
 
 export async function CreateWatchlistDataEntry(userId, listId) {
-  const randomIndex = Math.floor(Math.random() * 9999999);
   const listData = {
     userId: userId,
     listId: listId,
-    random: randomIndex,
+    random: generateRandomWatchlistInt(),
   };
   const docName = userId + listId;
   let docRef = doc(db, "watchlistData", docName);
@@ -321,11 +320,15 @@ export async function MarkNotificationsSeenOrRead(notiArray, IdToNotify, verb) {
   }
 }
 
+function generateRandomWatchlistInt() {
+  return Math.floor(Math.random() * 9999999);
+}
+
 export async function getRandomCommunityList() {
   // Repeat call to try and ensure a list with at least (1) anime title is found.
   for (let i = 1; i < 6; i++) {
     try {
-      const randomNumber = Math.floor(Math.random() * 9999999);
+      const randomNumber = generateRandomWatchlistInt();
       const q = query(
         collection(db, "watchlistData"),
         where("random", ">=", randomNumber),

--- a/src/Components/Firestore.js
+++ b/src/Components/Firestore.js
@@ -19,6 +19,7 @@ import {
   addDoc,
   writeBatch,
   updateDoc,
+  deleteField,
 } from "firebase/firestore";
 import { db } from "./Firebase";
 
@@ -377,11 +378,15 @@ export async function deleteWatchlistDataEntry(userId, listId) {
     // This code may get re-run multiple times if there are conflicts.
     const listDoc = await transaction.get(listDocRef);
 
-    // The deletion will only succeed if the document read above has not changed since then.
+    // The update will only succeed if the document read above has not changed since then.
     // Otherwise, it will re-run this function.
-    transaction.delete(listDocRef);
+    transaction.update(listDocRef, {
+      random: deleteField(),
+      awaitingDeletion: true,
+    });
   });
-  // To-do: Write script to delete all sub-collections WITHOUT an ancestor.
+  // To-do: Write script to delete all sub-collections whose  ancestor doc
+  // has a true value for 'awaitingDeletion' field.
   // Run this script periodically from server as deleting collections
   // from a web client is not recommended by firestore.
 }

--- a/src/Components/Firestore.js
+++ b/src/Components/Firestore.js
@@ -321,7 +321,7 @@ export async function MarkNotificationsSeenOrRead(notiArray, IdToNotify, verb) {
 }
 
 export async function getRandomCommunityList() {
-  // Repeat call 5x or until a list with at least (1) anime title is found
+  // Repeat call to try and ensure a list with at least (1) anime title is found.
   for (let i = 1; i < 6; i++) {
     try {
       const randomNumber = Math.floor(Math.random() * 9999999);
@@ -355,7 +355,8 @@ export async function getRandomCommunityList() {
           const data = {
             userId: listInfo.userId,
             listId: listInfo.listId,
-            anime: item.anime,
+            // Only pull 24 shows from list, to prevent unnecessary firestore reads
+            anime: item.anime.slice(0, 24),
           };
           return data;
         }
@@ -380,4 +381,7 @@ export async function deleteWatchlistDataEntry(userId, listId) {
     // Otherwise, it will re-run this function.
     transaction.delete(listDocRef);
   });
+  // To-do: Write script to delete all sub-collections WITHOUT an ancestor.
+  // Run this script periodically from server as deleting collections
+  // from a web client is not recommended by firestore.
 }

--- a/src/Components/Home.js
+++ b/src/Components/Home.js
@@ -27,13 +27,11 @@ import { PopulateFromFirestore, getRandomCommunityList } from "./Firestore";
 import useGenreFilter from "../Hooks/useGenreFilter";
 import HtmlPageTitle from "./HtmlPageTitle";
 import useAnimeList from "../Hooks/useAnimeList";
-import { getAvatarSrc } from "./Avatars";
 import CommunityListShelf from "./CommunityListShelf";
 
 export default function Home() {
   let [animeRandom, setAnimeRandom] = useState(null); //randomized
   let [communityListData, setCommunityListData] = useState(undefined); //randomized
-  let [communityListData2, setCommunityListData2] = useState(undefined); //randomized
 
   const [user, loading, error] = useAuthState(auth);
 
@@ -90,9 +88,6 @@ export default function Home() {
     getRandomCommunityList()
       .then((result) => setCommunityListData(result))
       .catch((error) => console.log(error));
-    getRandomCommunityList()
-      .then((result) => setCommunityListData2(result))
-      .catch((error) => console.log(error));
   }, [refreshCL]);
 
   useEffect(() => {
@@ -110,7 +105,6 @@ export default function Home() {
   const { data: animeMPTW } = useAnimeMPTW(genreQueryString);
   const { data: animeMH } = useAnimeMH(genreQueryString);
   let { data: communityList } = useAnimeList(communityListData?.anime);
-  const { data: communityList2 } = useAnimeList(communityListData2?.anime);
 
   const shelfTitleStyles = {
     marginTop: "1.6em",
@@ -156,7 +150,7 @@ export default function Home() {
         )}
         <div className="gap" />
         <Box sx={{ display: "flex", alignItems: "center" }}>
-          <Typography variant="h3">Community Lists</Typography>{" "}
+          <Typography variant="h3">Fan Lists</Typography>{" "}
           <Button
             color="inherit"
             variant="outlined"
@@ -164,7 +158,6 @@ export default function Home() {
             startIcon={<RefreshIcon />}
             onClick={() => {
               setCommunityListData(undefined);
-              setCommunityListData2(undefined);
               setRefreshCL(!refreshCL);
             }}
             sx={{ ml: 3 }}
@@ -175,13 +168,6 @@ export default function Home() {
         <CommunityListShelf
           data={communityListData}
           anime={communityList}
-          refresh={refreshCL}
-          setRefresh={setRefreshCL}
-          titleStyle={shelfTitleStyles}
-        />
-        <CommunityListShelf
-          data={communityListData2}
-          anime={communityList2}
           refresh={refreshCL}
           setRefresh={setRefreshCL}
           titleStyle={shelfTitleStyles}
@@ -204,9 +190,6 @@ export default function Home() {
           Most Popular {selectedGenre}
         </Typography>
         <AnimeShelf items={animeMC} />
-        {/* 
-      <h4>All time Best</h4>
-      <AnimeShelf items={animeMR} /> */}
 
         <Typography variant="h4" sx={shelfTitleStyles}>
           Most Buzzed About {selectedGenre}

--- a/src/Components/ProfilePageContextProvider.js
+++ b/src/Components/ProfilePageContextProvider.js
@@ -2,7 +2,7 @@ import { useContext, useEffect } from "react";
 import { useAuthState } from "react-firebase-hooks/auth";
 import { useProfile } from "./APICalls";
 import { auth } from "./Firebase";
-import { SaveToFirestore } from "./Firestore";
+import { SaveToFirestore, deleteWatchlistDataEntry } from "./Firestore";
 import { LocalUserContext } from "./LocalUserContext";
 import ProfilePageContext from "./ProfilePageContext";
 import useProfileWithAnime from "../Hooks/useProfileWithAnime";
@@ -58,8 +58,9 @@ export default function ProfilePageContextProvider({ userId, children }) {
     deleteList: (index) => {
       throwIfNotOwner();
       const newLocalUser = { ...localUser };
-      newLocalUser.lists.splice(index, 1);
+      const deletedList = newLocalUser.lists.splice(index, 1);
       save(newLocalUser);
+      deleteWatchlistDataEntry(user.uid, deletedList[0].id);
     },
     updateTop8: (top8) => {
       throwIfNotOwner();


### PR DESCRIPTION
Displays a randomly chosen user list on the home page.  

The methodology used for the random firestore document selection came from this [stack overflow article](https://stackoverflow.com/questions/46798981/firestore-how-to-get-random-documents-in-a-collection) we discussed earlier.

Notes: 
1. I put a limit on the number of times the function that picks the random list `getRandomCommunityList()` will re-run if it picks an empty list. I did this to guard against an infinite loop of firestore reads that would cook our quota 😂, however, this means that it's possible for NO list to be chosen. (Thinking aloud here - alternatively, we could hard code in a fallback list?)
1. I also limited the # of anime pulled from the random list (to 24) in order to cap the # of reads this shelf could cost.
1. Currently, only the corresponding `watchlistData` document gets deleted when users delete a list.  Both sub-collections `reactions` and `reviews` are left in-place as deleting collections from a web client is [discouraged by Google](https://firebase.google.com/docs/firestore/manage-data/delete-data#collections).  I like the idea of running a script every so often to delete all sub-collections that no longer have their ancestor document, just to keep things tidy. ✨