### PR TITLE
UI Tweaks Part 1

### DIFF
--- a/src/Components/AddToListDropMenu.js
+++ b/src/Components/AddToListDropMenu.js
@@ -154,6 +154,7 @@ export default function AddToListDropMenu({ anime, variant, selected }) {
           onClick={(e) => {
             handleToggle();
             e.preventDefault();
+            e.stopPropagation();
           }}
           onKeyDown={(e) => {
             if (e.key === "Enter") handleToggle();
@@ -179,7 +180,11 @@ export default function AddToListDropMenu({ anime, variant, selected }) {
         {({ TransitionProps, placement }) => (
           <Grow {...TransitionProps} style={{ transformOrigin: "center-top" }}>
             <Paper elevation={6} onClick={(e) => e.stopPropagation()}>
-              <ClickAwayListener onClickAway={handleClose}>
+              <ClickAwayListener
+                onClickAway={handleClose}
+                mouseEvent="onMouseDown"
+                touchEvent="onTouchStart"
+              >
                 <MenuList
                   autoFocusItem={open}
                   id="composition-menu"

--- a/src/Components/AddToListDropMenu.js
+++ b/src/Components/AddToListDropMenu.js
@@ -154,7 +154,6 @@ export default function AddToListDropMenu({ anime, variant, selected }) {
           onClick={(e) => {
             handleToggle();
             e.preventDefault();
-            e.stopPropagation();
           }}
           onKeyDown={(e) => {
             if (e.key === "Enter") handleToggle();

--- a/src/Components/DropMenu.js
+++ b/src/Components/DropMenu.js
@@ -184,7 +184,9 @@ export default function DropMenu() {
                         overflow: "hidden",
                         textOverflow: "ellipsis",
                       }}
-                      secondary={`@${localUser?.handle}`}
+                      secondary={
+                        localUser?.handle ? `@${localUser?.handle}` : ""
+                      }
                       secondaryTypographyProps={{
                         variant: "body1",
                         color: theme.palette.text.main,

--- a/src/Components/LandingPage.js
+++ b/src/Components/LandingPage.js
@@ -220,14 +220,14 @@ export default function LandingPage() {
                 style={{
                   display: "flex",
                   alignItems: "center",
-                  margin: "24px 0px 27px",
+                  margin: "24px 0px 27px 27px",
                 }}
               >
                 <Icon
                   sx={{
                     width: "40px",
                     height: "40px",
-                    margin: "0px 20px 0px 10px",
+                    margin: "0px 20px 0px 0px",
                   }}
                 >
                   <MagnifyingGlass size={35} />
@@ -236,7 +236,7 @@ export default function LandingPage() {
                   variant="h6"
                   sx={{
                     fontSize: "1.5rem",
-                    marginRight: "15px",
+                    marginRight: "10px",
                     lineHeight: "1.25",
                   }}
                 >
@@ -245,7 +245,7 @@ export default function LandingPage() {
               </div>
               <Typography
                 sx={{
-                  margin: "0px 34px 20px 27px",
+                  margin: "0px 20px 20px 27px",
                 }}
               >
                 Search through EdwardML’s library to build your personal taste
@@ -289,14 +289,14 @@ export default function LandingPage() {
                 style={{
                   display: "flex",
                   alignItems: "center",
-                  margin: "24px 0px 27px",
+                  margin: "24px 0px 27px 27px",
                 }}
               >
                 <Icon
                   sx={{
                     width: "40px",
                     height: "40px",
-                    margin: "0px 20px 0px 10px",
+                    margin: "0px 20px 0px 0px",
                   }}
                 >
                   <ShareNetwork size={35} />
@@ -305,7 +305,7 @@ export default function LandingPage() {
                   variant="h6"
                   sx={{
                     fontSize: "1.5rem",
-                    marginRight: "20px",
+                    marginRight: "10px",
                     lineHeight: "1.25",
                   }}
                 >
@@ -314,7 +314,7 @@ export default function LandingPage() {
               </div>
               <Typography
                 sx={{
-                  margin: "0px 34px 0px 27px",
+                  margin: "0px 20px 0px 27px",
                 }}
               >
                 Edward understands anime relationships and can help you discover
@@ -362,14 +362,14 @@ export default function LandingPage() {
                 style={{
                   display: "flex",
                   alignItems: "center",
-                  margin: "24px 0px 27px",
+                  margin: "24px 0px 27px 27px",
                 }}
               >
                 <Icon
                   sx={{
                     width: "40px",
                     height: "40px",
-                    margin: "0px 20px 0px 10px",
+                    margin: "0px 20px 0px 0px",
                   }}
                 >
                   <User size={35} />
@@ -378,7 +378,7 @@ export default function LandingPage() {
                   variant="h6"
                   sx={{
                     fontSize: "1.5rem",
-                    marginRight: "15px",
+                    marginRight: "10px",
                     lineHeight: "1.25",
                   }}
                 >
@@ -387,7 +387,7 @@ export default function LandingPage() {
               </div>
               <Typography
                 sx={{
-                  margin: "0px 34px 20px 27px",
+                  margin: "0px 20px 20px 27px",
                 }}
               >
                 Edward learns your personal taste profile and can make new

--- a/src/Components/NoResultsImage.js
+++ b/src/Components/NoResultsImage.js
@@ -1,14 +1,16 @@
 import Typography from "@mui/material/Typography";
 import Box from "@mui/material/Box";
+import Grid from "@mui/material/Grid";
+
 import Spike from "../Styles/images/distraughtSpike2.webp";
 
-export default function NoResultsImage({ noImage }) {
+export default function NoResultsImage({ noImage, tile }) {
   return (
     <div
       style={{
         display: "flex",
         flexDirection: "column",
-        alignItems: "center",
+        alignItems: !tile ? "center" : "flex-start",
       }}
     >
       <Typography
@@ -19,9 +21,7 @@ export default function NoResultsImage({ noImage }) {
       >
         Nothing to see here...
       </Typography>
-      {noImage ? (
-        ""
-      ) : (
+      {!noImage && !tile && (
         <Box
           component="img"
           src={Spike}
@@ -32,6 +32,23 @@ export default function NoResultsImage({ noImage }) {
             maxWidth: "355px",
           }}
         ></Box>
+      )}
+      {!noImage && tile && (
+        <Grid container>
+          <Grid item xs={12} md={6}>
+            <Box
+              alt=""
+              sx={{
+                background: `url(${Spike})`,
+                backgroundPosition: "center",
+                backgroundSize: "cover",
+                borderRadius: "16px",
+                width: "100%",
+                height: "142.56px",
+              }}
+            ></Box>
+          </Grid>
+        </Grid>
       )}
     </div>
   );

--- a/src/Components/NoResultsImage.js
+++ b/src/Components/NoResultsImage.js
@@ -34,7 +34,7 @@ export default function NoResultsImage({ noImage, tile }) {
         ></Box>
       )}
       {!noImage && tile && (
-        <Grid container>
+        <Grid container columnSpacing={2}>
           <Grid item xs={12} md={6}>
             <Box
               alt=""

--- a/src/Components/ProfileListPage.js
+++ b/src/Components/ProfileListPage.js
@@ -301,7 +301,7 @@ export default function ProfileListPage() {
           </Droppable>
         </DragDropContext>
       )}
-      {items === [] && <NoResultsImage />}
+      {items?.length === 0 && <NoResultsImage />}
       {/*Suggestions*/}
       {showSuggestions && (
         <>

--- a/src/Components/ProfileMainPage.js
+++ b/src/Components/ProfileMainPage.js
@@ -73,7 +73,7 @@ export default function ProfileMainPage() {
           ))}
           {!profile?.lists?.length && (
             <Grid item xs={12}>
-              <NoResultsImage />
+              <NoResultsImage tile={true} />
             </Grid>
           )}
           <Grid item xs={12}>
@@ -95,7 +95,7 @@ export default function ProfileMainPage() {
           ))}
           {!profile?.savedLists?.length && (
             <Grid item xs={12}>
-              <NoResultsImage />
+              <NoResultsImage tile="true" />
             </Grid>
           )}
         </Grid>

--- a/src/Components/ProfileMainPage.js
+++ b/src/Components/ProfileMainPage.js
@@ -95,7 +95,7 @@ export default function ProfileMainPage() {
           ))}
           {!profile?.savedLists?.length && (
             <Grid item xs={12}>
-              <NoResultsImage tile="true" />
+              <NoResultsImage tile={true} />
             </Grid>
           )}
         </Grid>

--- a/src/Components/ScoreBars.js
+++ b/src/Components/ScoreBars.js
@@ -7,6 +7,17 @@ import { useEffect, useState } from "react";
 export default function ScoreBars({ scores }) {
   const [multiplier, setMultiplier] = useState(0);
 
+  const smallerTopMargin = {
+    modifiers: [
+      {
+        name: "offset",
+        options: {
+          offset: [0, -10],
+        },
+      },
+    ],
+  };
+
   // LinearProgress components animate changes in value.  To get them to
   // animate the bars to their initial positions, a multiplier is applied to
   // each score, starting at 0 and set to 1 after a very short delay.
@@ -22,7 +33,11 @@ export default function ScoreBars({ scores }) {
     <>
       {scores.map((score) => (
         <Box key={score.name} sx={{ display: "flex", alignItems: "center" }}>
-          <Tooltip title={score.description}>
+          <Tooltip
+            title={score.description}
+            arrow={true}
+            PopperProps={{ ...smallerTopMargin }}
+          >
             <Typography
               sx={{
                 mb: "4px",
@@ -35,7 +50,9 @@ export default function ScoreBars({ scores }) {
             </Typography>
           </Tooltip>
           <Tooltip
+            arrow={true}
             title={Math.floor((score.value * 0.8 + 0.2) * 100 * multiplier)}
+            PopperProps={{ ...smallerTopMargin }}
           >
             <LinearProgress
               variant="determinate"

--- a/src/Components/WatchlistTile.js
+++ b/src/Components/WatchlistTile.js
@@ -61,7 +61,7 @@ export default function WatchlistTile({
                 flexShrink: 0,
               }}
             >
-              {items?.length ?? "0"} {items?.length === 1 ? "item" : "items"}
+              {items.length ?? "0"} {items.length === 1 ? "item" : "items"}
             </Typography>
           )}
         </Box>

--- a/src/Components/WatchlistTile.js
+++ b/src/Components/WatchlistTile.js
@@ -53,15 +53,17 @@ export default function WatchlistTile({
           >
             {name}
           </Typography>
-          <Typography
-            variant="body2"
-            sx={{
-              marginLeft: "8px",
-              flexShrink: 0,
-            }}
-          >
-            {items?.length ?? "0"} {items?.length === 1 ? "item" : "items"}
-          </Typography>
+          {items && (
+            <Typography
+              variant="body2"
+              sx={{
+                marginLeft: "8px",
+                flexShrink: 0,
+              }}
+            >
+              {items?.length ?? "0"} {items?.length === 1 ? "item" : "items"}
+            </Typography>
+          )}
         </Box>
         <Grid container columnSpacing={1}>
           {items?.slice(0, 5).map((item, index) => (


### PR DESCRIPTION
1. Prevents watchlist tiles from showing list have "0 items" during the loading state.
2. Display `NoResultsImage` on DetailedView page for empty watchlists.
3. Hides text showing the users handle on `DropMenu` for guests (who don't have a handle)
4. Prevents multiple `AddToListDropMenu` components from being opened at the same time.
5. On the landing page, left aligns the icons on the bottom (3) cards (to match the smaller text).
6. Styles tooltips on `ScoreBars` to have an arrow and appear closer to the component they're meant for.