### PR TITLE
Disables Emojis for Guests

### DIFF
--- a/src/Components/EmojiReactionChip.js
+++ b/src/Components/EmojiReactionChip.js
@@ -107,6 +107,7 @@ export default function EmojiReactionChip({
       variant={selected ? "filled" : "outlined"}
       icon={emoji}
       label={item.emojis[reaction].length}
+      disabled={!user?.handle}
       sx={{
         paddingLeft: 0.5,
         borderRadius: "20px",


### PR DESCRIPTION
- When guests react to content, the notification it creates won't display properly due to guests not having a handle.  
- I think this is also a good step to prevent feature abuse (folks creating oodles of guest accounts to pad stats).