### PR TITLE
Fixes /register redirects

### DIFF
--- a/src/Components/Onboarding.js
+++ b/src/Components/Onboarding.js
@@ -41,7 +41,7 @@ export default function Onboarding() {
     if (!user) return;
     // Let anonymous users register accounts and
     // redirect existing authorized users
-    if (!user?.isAnonymous) return navigate("/home");
+    if (!user.isAnonymous) navigate("/home");
   }, [user, localUser]);
 
   return (

--- a/src/Components/Onboarding.js
+++ b/src/Components/Onboarding.js
@@ -38,6 +38,7 @@ export default function Onboarding() {
   const navigate = useNavigate();
 
   useEffect(() => {
+    if (!user) return;
     // Let anonymous users register accounts and
     // redirect existing authorized users
     if (!user?.isAnonymous) return navigate("/home");

--- a/src/Components/Onboarding.js
+++ b/src/Components/Onboarding.js
@@ -38,8 +38,9 @@ export default function Onboarding() {
   const navigate = useNavigate();
 
   useEffect(() => {
-    //Check for existing user auth
-    if (user) return navigate("/home");
+    // Let anonymous users register accounts and
+    // redirect existing authorized users
+    if (!user?.isAnonymous) return navigate("/home");
   }, [user, localUser]);
 
   return (

--- a/src/Components/Register.js
+++ b/src/Components/Register.js
@@ -79,7 +79,7 @@ export default function Register() {
   useEffect(() => {
     if (loading) return;
     //Registering users without any likes causes /home rendering to error out --> this prevents that.
-    if (localUser["likes"]?.length === 0) navigate("/");
+    if (localUser["likes"]?.length === 0) navigate("/onboarding");
   }, [user, loading, forwardToken]);
 
   const handleRegister = async (provider) => {


### PR DESCRIPTION
- Allows anonymous users to stay on `/register` without being auto-forwarded to `/home`.

- Redirects users looking to register an account, but without any 'likes' to `/onboarding` instead of `/home`, for a shorter user journey.