### PR TITLE
Add greeting/explainer

### DIFF
--- a/src/Components/GreetingExplainer.js
+++ b/src/Components/GreetingExplainer.js
@@ -4,11 +4,11 @@ import useTheme from "@mui/material/styles/useTheme";
 import Grid from "@mui/material/Grid";
 import Typography from "@mui/material/Typography";
 import {
-  Atom,
   Binoculars,
   CaretRight,
   ChatsCircle,
-  Wrench,
+  FlyingSaucer,
+  PuzzlePiece,
   X,
 } from "phosphor-react";
 import { useState } from "react";
@@ -36,6 +36,12 @@ export default function GreetingExplainer() {
     display: "flex",
     justifyContent: "right",
     alignItems: "top",
+  };
+
+  const iconPhosphorStyling = {
+    size: 48,
+    weight: "duotone",
+    color: theme.palette.background.main,
   };
 
   const smallText = { fontSize: "0.875rem", marginTop: "6px" };
@@ -90,7 +96,7 @@ export default function GreetingExplainer() {
             sx={{ ...iconGridStyling }}
           >
             <Box sx={{ ...iconBoxStyling }}>
-              <Atom size={48} color={theme.palette.background.main} />
+              <FlyingSaucer {...iconPhosphorStyling} />
             </Box>
           </Grid>
           <Grid item xs={8} fiveHundred={9} sevenHundredFifty={4}>
@@ -110,7 +116,7 @@ export default function GreetingExplainer() {
             sx={{ ...iconGridStyling }}
           >
             <Box sx={{ ...iconBoxStyling }}>
-              <Wrench size={48} color={theme.palette.background.main} />
+              <PuzzlePiece {...iconPhosphorStyling} />
             </Box>
           </Grid>
           <Grid item xs={8} fiveHundred={9} sevenHundredFifty={4}>
@@ -131,7 +137,7 @@ export default function GreetingExplainer() {
             sx={{ ...iconGridStyling }}
           >
             <Box sx={{ ...iconBoxStyling }}>
-              <Binoculars size={48} color={theme.palette.background.main} />
+              <Binoculars {...iconPhosphorStyling} />
             </Box>
           </Grid>
           <Grid item xs={8} fiveHundred={9} sevenHundredFifty={4}>
@@ -151,7 +157,7 @@ export default function GreetingExplainer() {
             sx={{ ...iconGridStyling }}
           >
             <Box sx={{ ...iconBoxStyling }}>
-              <ChatsCircle size={48} color={theme.palette.background.main} />
+              <ChatsCircle {...iconPhosphorStyling} />
             </Box>
           </Grid>
           <Grid item xs={8} fiveHundred={9} sevenHundredFifty={4}>
@@ -189,7 +195,7 @@ export default function GreetingExplainer() {
             Register to save your profile!
             <Box
               sx={{
-                bgcolor: theme.palette.background.main,
+                bgcolor: "#fcfcfc",
                 width: 26,
                 height: 26,
                 borderRadius: "50%",

--- a/src/Components/GreetingExplainer.js
+++ b/src/Components/GreetingExplainer.js
@@ -1,0 +1,208 @@
+import Box from "@mui/material/Box";
+import IconButton from "@mui/material/IconButton";
+import useTheme from "@mui/material/styles/useTheme";
+import Grid from "@mui/material/Grid";
+import Typography from "@mui/material/Typography";
+import {
+  Atom,
+  Binoculars,
+  CaretRight,
+  ChatsCircle,
+  Wrench,
+  X,
+} from "phosphor-react";
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import Button from "@mui/material/Button";
+
+export default function GreetingExplainer() {
+  const theme = useTheme();
+  const navigate = useNavigate();
+
+  const [showExplainer, setShowExplainer] = useState(true);
+
+  const iconBoxStyling = {
+    bgcolor: "primary.main",
+    width: 60,
+    height: 60,
+    borderRadius: "50%",
+    mr: 2,
+    display: "flex",
+    justifyContent: "center",
+    alignItems: "center",
+  };
+
+  const iconGridStyling = {
+    display: "flex",
+    justifyContent: "right",
+    alignItems: "top",
+  };
+
+  const smallText = { fontSize: "0.875rem", marginTop: "6px" };
+
+  if (showExplainer)
+    return (
+      <Box
+        sx={{
+          px: { xs: 2, md: 6 },
+          py: { xs: 6, md: 6 },
+          mx: { xs: 0, lg: 16 },
+          mb: { xs: 8, md: 4 },
+          backgroundColor: theme.palette.custom.greetingBg,
+          borderRadius: "24px",
+          position: "relative",
+        }}
+      >
+        <IconButton
+          sx={{
+            position: "absolute",
+            top: { xs: 1, sm: 6 },
+            right: { xs: 1, sm: 6 },
+          }}
+          onClick={() => setShowExplainer(false)}
+        >
+          <X size={24} />
+        </IconButton>
+        <Grid container rowSpacing={4} sx={{ display: "inline-flex" }}>
+          {/* Title text */}
+          <Grid item xs={12}>
+            <Typography variant="h2" style={{ textAlign: "center" }}>
+              Your personal anime guide
+            </Typography>
+          </Grid>
+          <Grid
+            item
+            xs={12}
+            sx={{ mb: 1, mx: { xs: 1, sm: 6, sevenHundredFifty: 16 } }}
+          >
+            <Typography variant="h4" style={{ textAlign: "center" }}>
+              Use EdwardML's giant computer brain to help you decide which anime
+              to watch next.
+            </Typography>
+          </Grid>
+
+          {/* First row of icons/text */}
+          <Grid
+            item
+            xs={4}
+            fiveHundred={3}
+            sevenHundredFifty={2}
+            sx={{ ...iconGridStyling }}
+          >
+            <Box sx={{ ...iconBoxStyling }}>
+              <Atom size={48} color={theme.palette.background.main} />
+            </Box>
+          </Grid>
+          <Grid item xs={8} fiveHundred={9} sevenHundredFifty={4}>
+            <Typography variant="h5">Discover</Typography>
+            <Typography style={{ ...smallText }}>
+              {" "}
+              Edward understands anime relationships and will help you discover
+              new content similar to your favorites.
+            </Typography>
+          </Grid>
+
+          <Grid
+            item
+            xs={4}
+            fiveHundred={3}
+            sevenHundredFifty={2}
+            sx={{ ...iconGridStyling }}
+          >
+            <Box sx={{ ...iconBoxStyling }}>
+              <Wrench size={48} color={theme.palette.background.main} />
+            </Box>
+          </Grid>
+          <Grid item xs={8} fiveHundred={9} sevenHundredFifty={4}>
+            <Typography variant="h5">Customize</Typography>
+            <Typography style={{ ...smallText }}>
+              Search through EdwardML’s library to build your personal taste
+              profile. Save your progress and return later to discover even more
+              content picked for you.
+            </Typography>
+          </Grid>
+
+          {/* Second row of icons/text */}
+          <Grid
+            item
+            xs={4}
+            fiveHundred={3}
+            sevenHundredFifty={2}
+            sx={{ ...iconGridStyling }}
+          >
+            <Box sx={{ ...iconBoxStyling }}>
+              <Binoculars size={48} color={theme.palette.background.main} />
+            </Box>
+          </Grid>
+          <Grid item xs={8} fiveHundred={9} sevenHundredFifty={4}>
+            <Typography variant="h5">Explore</Typography>
+            <Typography style={{ ...smallText }}>
+              {" "}
+              Get insight into any anime. Edward will let you know how likely
+              you are to enjoy any title based on your taste profile.{" "}
+            </Typography>
+          </Grid>
+
+          <Grid
+            item
+            xs={4}
+            fiveHundred={3}
+            sevenHundredFifty={2}
+            sx={{ ...iconGridStyling }}
+          >
+            <Box sx={{ ...iconBoxStyling }}>
+              <ChatsCircle size={48} color={theme.palette.background.main} />
+            </Box>
+          </Grid>
+          <Grid item xs={8} fiveHundred={9} sevenHundredFifty={4}>
+            <Typography variant="h5">Socialize </Typography>
+            <Typography style={{ ...smallText }}>
+              {" "}
+              Create watchlists and share them with your friends and family.
+            </Typography>
+          </Grid>
+        </Grid>
+
+        {/* CTA to register account */}
+        <Box
+          sx={{
+            display: "flex",
+            justifyContent: "center",
+            width: "100%",
+            position: "relative",
+          }}
+        >
+          <Button
+            variant="contained"
+            size="large"
+            sx={{
+              width: "280px",
+              mt: { xs: 3, md: 3 },
+              fontSize: "0.875rem",
+              position: "absolute",
+              top: 0,
+            }}
+            onClick={(e) => {
+              navigate("/register");
+            }}
+          >
+            Register to save your profile!
+            <Box
+              sx={{
+                bgcolor: theme.palette.background.main,
+                width: 26,
+                height: 26,
+                borderRadius: "50%",
+                display: "flex",
+                ml: 2,
+                justifyContent: "center",
+                alignItems: "center",
+              }}
+            >
+              <CaretRight size={24} color={theme.palette.primary.main} />
+            </Box>
+          </Button>
+        </Box>
+      </Box>
+    );
+}

--- a/src/Components/Home.js
+++ b/src/Components/Home.js
@@ -124,7 +124,7 @@ export default function Home() {
       )}
       <Container maxWidth="lg">
         <div className="gap" />
-        {localUser.authProvider === "anonymous" && <GreetingExplainer />}
+        {user.isAnonymous && <GreetingExplainer />}
         {localUser.uid && localUser?.likes.length === 0 ? (
           <Typography
             variant="h2"

--- a/src/Components/Home.js
+++ b/src/Components/Home.js
@@ -29,6 +29,7 @@ import useGenreFilter from "../Hooks/useGenreFilter";
 import HtmlPageTitle from "./HtmlPageTitle";
 import useAnimeList from "../Hooks/useAnimeList";
 import CommunityListShelf from "./CommunityListShelf";
+import GreetingExplainer from "./GreetingExplainer";
 
 export default function Home() {
   let [animeRandom, setAnimeRandom] = useState(null); //randomized
@@ -123,6 +124,7 @@ export default function Home() {
       )}
       <Container maxWidth="lg">
         <div className="gap" />
+        {localUser.authProvider === "anonymous" && <GreetingExplainer />}
         {localUser.uid && localUser?.likes.length === 0 ? (
           <Typography
             variant="h2"

--- a/src/Components/OnboardingButton.js
+++ b/src/Components/OnboardingButton.js
@@ -38,7 +38,12 @@ export default function OnboardingButton({ disabled }) {
           },
         }}
       >
-        <Link to={linkLocation} onClick={registerNewUserAsGuest()}>
+        <Link
+          to={linkLocation}
+          onClick={() => {
+            registerNewUserAsGuest();
+          }}
+        >
           <Button
             color="primary"
             variant="contained"

--- a/src/Components/OnboardingButton.js
+++ b/src/Components/OnboardingButton.js
@@ -9,16 +9,22 @@ import { auth } from "./Firebase";
 import { useContext } from "react";
 import { LocalUserContext } from "./LocalUserContext";
 import { Link } from "react-router-dom";
+import useAuthActions from "../Hooks/useAuthActions";
 
 export default function OnboardingButton({ disabled }) {
   const [user] = useAuthState(auth);
   const [localUser, setLocalUser] = useContext(LocalUserContext);
+  const authActions = useAuthActions();
 
   const theme = useTheme();
 
   let linkLocation;
 
-  disabled ? (linkLocation = null) : (linkLocation = "/register");
+  disabled ? (linkLocation = null) : (linkLocation = "/home");
+
+  async function registerNewUserAsGuest() {
+    await authActions.registerAnonymously();
+  }
 
   return (
     <Container maxWidth="lg">
@@ -32,7 +38,7 @@ export default function OnboardingButton({ disabled }) {
           },
         }}
       >
-        <Link to={linkLocation}>
+        <Link to={linkLocation} onClick={registerNewUserAsGuest()}>
           <Button
             color="primary"
             variant="contained"

--- a/src/Components/theme.js
+++ b/src/Components/theme.js
@@ -32,6 +32,7 @@ export function createAppTheme(darkMode) {
           ? "linear-gradient(#171717, #4a3636)"
           : "linear-gradient(#f5f5f5, #f5eaea)",
         missingAnimeCover: darkMode ? "#2c2c2c" : "#cccccc",
+        greetingBg: darkMode ? "#4a3636" : "#f5eaea",
       },
     },
     breakpoints: {


### PR DESCRIPTION
1. Adds a greeting/explainer blurb to `/home` page for all guest accounts, that includes a registration 'upsell'
1. The greeting/explainer is shown to unregistered accounts every time they navigate to `/home`.  There is an option to close the blub...but it will re-open each time they re-visit `/home`. (This could get annoying, so I'd be happy to re-work this if desired)
1. Changes the user registration flow.  Now `/onboarding` sends everyone to `/home` as a guest: there is no longer a registration prompt.  This is done to reward to the user with content faster, avoid losing users that don't want to register, and make the logic for determining when to show the greeting/explainer simpler.
