### PR TITLE
Add info text when reaction buttons are disabled

### DIFF
--- a/src/Components/EmojiReactionChip.js
+++ b/src/Components/EmojiReactionChip.js
@@ -1,4 +1,5 @@
 import Chip from "@mui/material/Chip";
+import Tooltip from "@mui/material/Tooltip";
 import useTheme from "@mui/material/styles/useTheme";
 
 import { useEffect, useState } from "react";
@@ -23,6 +24,7 @@ export default function EmojiReactionChip({
   index,
   setReviews,
   type,
+  tooltip,
 }) {
   const [user] = useAuthState(auth);
   let [selected, setSelected] = useState();
@@ -31,6 +33,8 @@ export default function EmojiReactionChip({
   const params = useParams();
   const ownerId = params.userId;
   const listId = params.listId;
+
+  tooltip = user?.isAnonymous ? "Register to react" : tooltip;
 
   useEffect(() => {
     if (item?.emojis[reaction]?.includes(user.uid)) setSelected(true);
@@ -102,25 +106,29 @@ export default function EmojiReactionChip({
       />
     );
   return (
-    <Chip
-      variant={selected ? "filled" : "outlined"}
-      icon={emoji}
-      label={item.emojis[reaction].length}
-      disabled={user?.isAnonymous}
-      sx={{
-        paddingLeft: 0.5,
-        borderRadius: "20px",
-        mr: 2,
-        "& .MuiChip-label": { fontSize: "1rem" },
-        "& .MuiChip-icon": {
-          ...(selected && { color: "inherit" }),
-        },
-      }}
-      onClick={(e) => {
-        if (type === "list") reactToList();
-        else reactToReview();
-        e?.stopPropagation();
-      }}
-    />
+    <Tooltip title={tooltip} followCursor>
+      <div>
+        <Chip
+          variant={selected ? "filled" : "outlined"}
+          icon={emoji}
+          label={item.emojis[reaction].length}
+          disabled={user?.isAnonymous}
+          sx={{
+            paddingLeft: 0.5,
+            borderRadius: "20px",
+            mr: 2,
+            "& .MuiChip-label": { fontSize: "1rem" },
+            "& .MuiChip-icon": {
+              ...(selected && { color: "inherit" }),
+            },
+          }}
+          onClick={(e) => {
+            if (type === "list") reactToList();
+            else reactToReview();
+            e?.stopPropagation();
+          }}
+        />
+      </div>
+    </Tooltip>
   );
 }

--- a/src/Components/Review.js
+++ b/src/Components/Review.js
@@ -258,50 +258,41 @@ export default function Review({
             marginTop: "10px",
           }}
         >
-          <Tooltip title={`Applaude this ${typeSingular}`} followCursor>
-            <div>
-              <EmojiReactionChip
-                docId={docId}
-                emoji={<HandsClapping size={24} />}
-                reaction="applause"
-                item={item}
-                index={index}
-                reviews={reviews}
-                setReviews={setReviews}
-                type={type}
-              />
-            </div>
-          </Tooltip>
+          <EmojiReactionChip
+            docId={docId}
+            emoji={<HandsClapping size={24} />}
+            reaction="applause"
+            item={item}
+            index={index}
+            reviews={reviews}
+            setReviews={setReviews}
+            type={type}
+            tooltip={`Applaud this ${typeSingular}`}
+          />
 
-          <Tooltip title={`Love this ${typeSingular}`} followCursor>
-            <div>
-              <EmojiReactionChip
-                docId={docId}
-                emoji={<Heart size={24} />}
-                reaction="heart"
-                item={item}
-                index={index}
-                reviews={reviews}
-                setReviews={setReviews}
-                type={type}
-              />
-            </div>
-          </Tooltip>
+          <EmojiReactionChip
+            docId={docId}
+            emoji={<Heart size={24} />}
+            reaction="heart"
+            item={item}
+            index={index}
+            reviews={reviews}
+            setReviews={setReviews}
+            type={type}
+            tooltip={`Love this ${typeSingular}`}
+          />
 
-          <Tooltip title={`Disagree with this ${typeSingular}`} followCursor>
-            <div>
-              <EmojiReactionChip
-                docId={docId}
-                emoji={<Trash size={24} />}
-                reaction="trash"
-                item={item}
-                index={index}
-                reviews={reviews}
-                setReviews={setReviews}
-                type={type}
-              />
-            </div>
-          </Tooltip>
+          <EmojiReactionChip
+            docId={docId}
+            emoji={<Trash size={24} />}
+            reaction="trash"
+            item={item}
+            index={index}
+            reviews={reviews}
+            setReviews={setReviews}
+            type={type}
+            tooltip={`Disagree with this ${typeSingular}`}
+          />
         </div>
       </Grid>
     </Paper>


### PR DESCRIPTION
In this case, I changed the tooltip to let the user know why these buttons are disabled and how to enable them.  Lmk if you have thoughts about copy.

I also sunk the Tooltip into the EmojiReactionChip component since the logic for whether the button is enabled lives in there, so the tooltip text determination should probably be made in the same place.