### PR TITLE
Onboarding hover & header tweaks

### DIFF
--- a/src/Components/Header.js
+++ b/src/Components/Header.js
@@ -53,8 +53,8 @@ function Header() {
             </Grid>
           ) : (
             <>
-              <Grid item md={2.5} sm={4} xs={2.5}>
-                <Link to="/home">
+              <Grid item md={2.5} sm={4} xs={2.5} sx={{ display: "flex" }}>
+                <Link to="/home" style={{ flexShrink: 1 }}>
                   <EdwardMLLogo />
                 </Link>
               </Grid>

--- a/src/Components/Header.js
+++ b/src/Components/Header.js
@@ -1,12 +1,12 @@
 import "../Styles/Header.css";
 
-import { Link, useNavigate } from "react-router-dom";
+import { Link } from "react-router-dom";
 import Container from "@mui/material/Container";
 import Grid from "@mui/material/Grid";
 import useMediaQuery from "@mui/material/useMediaQuery";
 import useTheme from "@mui/material/styles/useTheme";
 
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import TitleAutocomplete from "./TitleAutocomplete";
 import { MagnifyingGlass, House, User, Bell } from "phosphor-react";
 import DropMenu from "./DropMenu";
@@ -15,13 +15,10 @@ import HeaderTab from "./HeaderTab";
 import { useAuthState } from "react-firebase-hooks/auth";
 import { auth } from "./Firebase";
 import NotificationDropMenu from "./NotificationDropMenu";
-import { useConfirm } from "material-ui-confirm";
 
 function Header() {
   const [user] = useAuthState(auth);
   const theme = useTheme();
-  const confirm = useConfirm();
-  const navigate = useNavigate();
 
   const [showSearch, setShowSearch] = useState(false);
 
@@ -32,26 +29,6 @@ function Header() {
   const toggleSearch = (e) => {
     setShowSearch(true);
     e?.preventDefault();
-  };
-
-  useEffect(() => {
-    setTimeout(() => {
-      pushRegistration();
-    }, 600000);
-  }, []);
-
-  const pushRegistration = () => {
-    confirm({
-      title: "Your account will be lost",
-      content: "Please register in order to save your profile.",
-      titleProps: { sx: { fontWeight: 800 } },
-      confirmationButtonProps: { variant: "contained" },
-      confirmationText: "Register Now",
-      cancellationButtonProps: { color: "inherit", variant: "contained" },
-      cancellationText: "Cancel",
-    }).then(() => {
-      navigate(`/register`);
-    });
   };
 
   return (

--- a/src/Components/LandingPageHeader.js
+++ b/src/Components/LandingPageHeader.js
@@ -28,8 +28,8 @@ export default function LandingPageHeader() {
           paddingBottom: 0,
         }}
       >
-        <Grid item md={9} sm={9} xs={9}>
-          <Link to="/" style={{ display: "flex" }}>
+        <Grid item md={9} sm={9} xs={9} sx={{ display: "flex" }}>
+          <Link to="/" style={{ flexShrink: 1 }}>
             <EdwardMLLogo />
           </Link>
         </Grid>

--- a/src/Components/Onboarding.js
+++ b/src/Components/Onboarding.js
@@ -68,7 +68,6 @@ export default function Onboarding() {
         ) : (
           <OnboardingButton />
         )}
-        <div style={{ marginTop: "20px" }} />
       </Container>
     </div>
   );

--- a/src/Components/OnboardingAnimeCard.js
+++ b/src/Components/OnboardingAnimeCard.js
@@ -46,6 +46,9 @@ export default function OnboardingAnimeCard({ anime }) {
           justifyContent: liked ? "space-around" : "flex-end",
           alignItems: liked ? "center" : "unset",
           background: liked ? "rgba(0,0,0,0.8)" : "unset",
+          "&:hover": {
+            background: liked ? "rgba(0,0,0,0.8)" : "rgba(0,0,0,0.3)",
+          },
         }}
       >
         {liked ? (

--- a/src/Components/OnboardingHeader.js
+++ b/src/Components/OnboardingHeader.js
@@ -39,7 +39,7 @@ export default function OnboardingHeader() {
           textAlign="right"
           sx={{ display: "flex", justifyContent: "flex-end" }}
         >
-          <Link to="/login">
+          <Link to="/login" tabIndex="-1">
             <Button
               variant="outlined"
               size="large"


### PR DESCRIPTION
- Deletes unnecessary gap at bottom of `onboarding`
- Deletes duplicated tabIndex on 'login' button
- Adds a slight color to `OnboardingAnimeCard` on :hover
- Resizes the <Link> that bounds the `EdwardMLLogo` so only the logo is clickable