### PR TITLE
Fix: Duplicate guest registrations

### DIFF
--- a/src/Components/OnboardingButton.js
+++ b/src/Components/OnboardingButton.js
@@ -1,30 +1,12 @@
 import Button from "@mui/material/Button";
 import Container from "@mui/material/Container";
 import Grid from "@mui/material/Grid";
-import useTheme from "@mui/material/styles/useTheme";
-import { SaveToFirestore } from "./Firestore";
-
-import { useAuthState } from "react-firebase-hooks/auth";
-import { auth } from "./Firebase";
-import { useContext } from "react";
-import { LocalUserContext } from "./LocalUserContext";
 import { Link } from "react-router-dom";
-import useAuthActions from "../Hooks/useAuthActions";
 
 export default function OnboardingButton({ disabled }) {
-  const [user] = useAuthState(auth);
-  const [localUser, setLocalUser] = useContext(LocalUserContext);
-  const authActions = useAuthActions();
-
-  const theme = useTheme();
-
   let linkLocation;
 
   disabled ? (linkLocation = null) : (linkLocation = "/home");
-
-  async function registerNewUserAsGuest() {
-    await authActions.registerAnonymously();
-  }
 
   return (
     <Container maxWidth="lg">
@@ -38,12 +20,7 @@ export default function OnboardingButton({ disabled }) {
           },
         }}
       >
-        <Link
-          to={linkLocation}
-          onClick={() => {
-            registerNewUserAsGuest();
-          }}
-        >
+        <Link to={linkLocation}>
           <Button
             color="primary"
             variant="contained"


### PR DESCRIPTION
Deletes a redundant call to 'authActions.registerAnonymously' when clicking 'let's go' button on `/onboarding`.  This was creating a 2nd firestore user auth whenever a new visitor went through the onboarding process.