### PR TITLE
Add pre-home API pings on onboarding, login

### DIFF
--- a/src/Components/APICalls.js
+++ b/src/Components/APICalls.js
@@ -1,5 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 
+const fiveSecondsMs = 1000 * 5;
 const fiveMinutesMs = 1000 * 60 * 5;
 
 const apiUrl = `https://api-jet-lfoguxrv7q-uw.a.run.app`;
@@ -34,6 +35,12 @@ export function useAPISearch(inputValue, itemsReturned) {
     staleTime: fiveMinutesMs,
     placeholderData: [],
   });
+}
+
+export async function APIHeartbeat() {
+  let response = await fetch(`${apiUrl}/`, { mode: "cors" });
+  await handleErrors(response);
+  return await response.json();
 }
 
 export async function APIGetAnime(animeId) {
@@ -74,6 +81,12 @@ async function handleErrors(response) {
 }
 
 //***************TanStack Query Functions***************
+export function useHeartbeat() {
+  return useQuery(["heartbeat"], async () => APIHeartbeat(), {
+    staleTime: fiveSecondsMs,
+  });
+}
+
 export function useAnimeHR(selectedGenre) {
   return useGetTitles(
     `${apiUrl}/anime?sort=highest_rated&page_size=24${selectedGenre}`

--- a/src/Components/Home.js
+++ b/src/Components/Home.js
@@ -72,6 +72,18 @@ export default function Home() {
     return data;
   }
 
+  // API call for personalized recommendations.
+  const viewHistory = getViewHistory();
+  const { data: recommendation, isLoading: loadingRecs } =
+    useRecommendations(viewHistory);
+
+  //API calls for generic shelf content
+  const { data: animeTN } = useAnimeTN(genreQueryString);
+  const { data: animeHR } = useAnimeHR(genreQueryString);
+  const { data: animeMC } = useAnimeMC(genreQueryString);
+  const { data: animeMPTW } = useAnimeMPTW(genreQueryString);
+  const { data: animeMH } = useAnimeMH(genreQueryString);
+
   function getRandomNumbers() {
     for (let i = 0; i < 6; i++) {
       randomPage[i] = Math.floor(Math.random() * 250 + 1);
@@ -96,17 +108,6 @@ export default function Home() {
     PopulateFromFirestore(user, localUser, setLocalUser);
   }, [user]);
 
-  // API call for personalized recommendations.
-  const viewHistory = getViewHistory();
-  const { data: recommendation, isLoading: loadingRecs } =
-    useRecommendations(viewHistory);
-
-  //API calls for generic shelf content
-  const { data: animeTN } = useAnimeTN(genreQueryString);
-  const { data: animeHR } = useAnimeHR(genreQueryString);
-  const { data: animeMC } = useAnimeMC(genreQueryString);
-  const { data: animeMPTW } = useAnimeMPTW(genreQueryString);
-  const { data: animeMH } = useAnimeMH(genreQueryString);
   let { data: communityList } = useAnimeList(communityListData?.anime);
 
   const shelfTitleStyles = {

--- a/src/Components/Login.js
+++ b/src/Components/Login.js
@@ -16,6 +16,7 @@ import google from "../Styles/images/google.svg";
 import EdwardMLLogo from "./EdwardMLLogo";
 import useAuthActions from "../Hooks/useAuthActions";
 import HtmlPageTitle from "./HtmlPageTitle";
+import { useHeartbeat } from "./APICalls";
 
 export default function Login() {
   const authActions = useAuthActions();
@@ -27,6 +28,9 @@ export default function Login() {
   const theme = useTheme();
 
   let [loginError, setLoginError] = useState(undefined);
+
+  // Pre-warm API by sending a request now.
+  useHeartbeat();
 
   let regButtonStyling = {
     color: theme.palette.text.primary,

--- a/src/Components/Onboarding.js
+++ b/src/Components/Onboarding.js
@@ -27,6 +27,7 @@ import SailorMoon from "../Styles/images/onboarding/sailormoon.jpg";
 import SwordArtOnline from "../Styles/images/onboarding/swordartonline.jpg";
 import NoGameNoLife from "../Styles/images/onboarding/nogamenolife.jpg";
 import HtmlPageTitle from "./HtmlPageTitle";
+import { useHeartbeat } from "./APICalls";
 
 export default function Onboarding() {
   const [localUser, setLocalUser] = useContext(LocalUserContext);
@@ -43,6 +44,9 @@ export default function Onboarding() {
     // redirect existing authorized users
     if (!user.isAnonymous) navigate("/home");
   }, [user, localUser]);
+
+  // Pre-warm API by sending a request now.
+  useHeartbeat();
 
   return (
     <div className="App">


### PR DESCRIPTION
The first load of /home can take a while.  Probably too long.  This happens because the API service uses autoscaling and when no requests have come in for a while, it shuts down all the instances of it.  This saves us $, but has a downside.  When a new API request comes in, a new instance needs to start ("cold load") and this takes a few seconds.  My newly optimized API implementation should cold load faster (like 3s instead of 6s), but this is still slow, when you add actual processing time (~100ms) and network latency on top of that.

One way to get /home to load faster the first time is to wake the API up when the user is on /login or /onboarding, since they will probably get to /home next.  This gives the instances time to start up so /home loads don't cold-load so many instances.

There is still the problem of the fact that /home makes like 13 API requests (1 /recommend, 5 /anime for shelves, 6 more /anime for random items, plus a /get for the user shelf contents), so these really end up being split between multiple instances.  So even if I pre-warm an instance before /home, odds are some of these might need another new instance that will need to cold-load.  In this commit, I have lifted up the /recommend and shelf fetches so they run before other api requests and have better chance of being handled by the running instances.  The random shelf can take longer to load, since it is at the bottom of the page.

This problem should go away once we have enough traffic that the API never goes more than a few seconds without requests, but until then, this strategy might help smooth load times.  Really the /recommend load time is the most important one, since that is what the user sees first.  Sadly, that is a POST request so it has a pre-flight stage, meaning other requests usually end up beating it to the live instance, and it has a higher-than-usual chance to need a cold load.