### PR TITLE
Add 'Reviewers Often Say' tags on DetailedView

### DIFF
--- a/src/Components/DetailedView.js
+++ b/src/Components/DetailedView.js
@@ -28,6 +28,7 @@ import ReviewContainer from "./ReviewContainer";
 import HandleDialog from "./HandleDialog";
 import HtmlPageTitle from "./HtmlPageTitle";
 import ScorePercentText from "./ScorePercentText";
+import ExpandableTags from "./ExpandableTags";
 
 export default function DetailedView() {
   const navigate = useNavigate();
@@ -289,6 +290,18 @@ export default function DetailedView() {
                 </Typography>
               </Box>
             </Grid>
+
+            {/* Reviewers Often Say */}
+            {anime.review_qualities?.length > 0 && (
+              <Grid item xs={12}>
+                <Typography variant="h3" style={subheadStyle}>
+                  Reviewers Often Say
+                </Typography>
+                <ExpandableTags
+                  items={anime.review_qualities.map((q) => q.text)}
+                />
+              </Grid>
+            )}
 
             {/* Summary */}
             <Grid item xs={12}>

--- a/src/Components/ExpandableTags.js
+++ b/src/Components/ExpandableTags.js
@@ -1,19 +1,18 @@
-import { Button } from "@mui/material/";
 import Box from "@mui/material/Box";
 import Link from "@mui/material/Link";
 import useTheme from "@mui/material/styles/useTheme";
 import { useState } from "react";
 
-export default function ExpandableTags({ items, compactItems }) {
-  compactItems = compactItems ?? 4;
+const compactSize = 4;
 
+export default function ExpandableTags({ items }) {
   const theme = useTheme();
 
   const [expanded, setExpanded] = useState(false);
 
-  const canShorten = items?.length > compactItems;
+  const canShorten = items?.length > compactSize;
 
-  const shownItems = expanded ? items : items?.slice(0, compactItems);
+  const shownItems = expanded ? items : items?.slice(0, compactSize);
 
   return (
     <Box sx={{ display: "flex", flexWrap: "wrap" }}>
@@ -44,6 +43,7 @@ export default function ExpandableTags({ items, compactItems }) {
           component="button"
           sx={{
             fontWeight: 600,
+            mb: 1.5,
             "&:hover": {
               color: theme.palette.primary.main,
             },

--- a/src/Components/ExpandableTags.js
+++ b/src/Components/ExpandableTags.js
@@ -1,0 +1,57 @@
+import { Button } from "@mui/material/";
+import Box from "@mui/material/Box";
+import Link from "@mui/material/Link";
+import useTheme from "@mui/material/styles/useTheme";
+import { useState } from "react";
+
+export default function ExpandableTags({ items, compactItems }) {
+  compactItems = compactItems ?? 4;
+
+  const theme = useTheme();
+
+  const [expanded, setExpanded] = useState(false);
+
+  const canShorten = items?.length > compactItems;
+
+  const shownItems = expanded ? items : items?.slice(0, compactItems);
+
+  return (
+    <Box sx={{ display: "flex", flexWrap: "wrap" }}>
+      {shownItems?.map((item, index) => (
+        <Box
+          key={index}
+          sx={{
+            background: theme.palette.custom.subtleCardBg,
+            borderRadius: "8px",
+            mr: 2,
+            mb: 1.5,
+            px: 2,
+            py: 1,
+          }}
+        >
+          "{item}"
+        </Box>
+      ))}
+      {canShorten && (
+        <Link
+          color="inherit"
+          variant="body1"
+          underline="none"
+          onClick={(e) => {
+            setExpanded(!expanded);
+            e.stopPropagation();
+          }}
+          component="button"
+          sx={{
+            fontWeight: 600,
+            "&:hover": {
+              color: theme.palette.primary.main,
+            },
+          }}
+        >
+          {expanded ? "See less" : "See more"}
+        </Link>
+      )}
+    </Box>
+  );
+}


### PR DESCRIPTION
In the spirit of not letting perfect be the enemy of good, this is an initial version of the derived quality tags on anime pages.  I think it is actually pretty cool.  I show up to 4 of the most-commonly described qualities, with a 'see more' button to show the rest.  Future improvements might involve either grouping quality tags by sentiment (positive/negative), including more mixed and negative reviews in the review clustering and labeling to derive more negative tags, and ranking qualities by their uniqueness to make sure interesting ones are surfaced before the 'See more', and generic things like "Strong character development" get moved toward the end of the list.