### PR TITLE
Move watch links to left column on desktop

### DIFF
--- a/src/Components/DetailedView.js
+++ b/src/Components/DetailedView.js
@@ -196,6 +196,16 @@ export default function DetailedView() {
               />
             ))}
           </Box>
+
+          {/* Desktop-only Watch Links */}
+          <Box sx={{ display: { xs: "none", md: "block" } }}>
+            <Typography variant="h5" style={subheadStyle}>
+              Watch
+            </Typography>
+            <Box sx={{ display: "block" }}>
+              <UrlButtons anime={anime} />
+            </Box>
+          </Box>
         </Grid>
         <Grid item xs={12} md={9}>
           <Grid container sx={{ paddingLeft: { xs: 0, md: "46px" } }}>
@@ -314,8 +324,8 @@ export default function DetailedView() {
               />
             </Grid>
 
-            {/* Watch Links */}
-            <Grid item xs={12}>
+            {/* Mobile-only Watch Links */}
+            <Grid item xs={12} sx={{ display: { xs: "block", md: "none" } }}>
               <Typography variant="h3" style={subheadStyle}>
                 Watch
               </Typography>

--- a/src/Components/UrlButtons.js
+++ b/src/Components/UrlButtons.js
@@ -76,7 +76,7 @@ function UrlButton({ title, link, image }) {
         display: "flex",
         flexDirection: "column",
         alignItems: "center",
-        margin: "0 8px 8px 8px",
+        margin: "0 12px 8px 0",
       }}
     >
       <IconButton
@@ -86,7 +86,7 @@ function UrlButton({ title, link, image }) {
         target="_blank"
         rel="noopener"
       >
-        <Box component="img" src={image} alt={title} sx={{ height: 48 }} />
+        <Box component="img" src={image} alt={title} sx={{ height: 40 }} />
       </IconButton>
       <Typography>{title}</Typography>
     </Box>


### PR DESCRIPTION
This gets rid of the big waste of space that usually happens in the "Watch" section on DetailedView on desktop.  I left it where it is on mobile, though, since I quite like our DetailedView header as-is on mobile now.

Also tweaked the watch link icons to make them slightly smaller, and shifted the padding so the left-most watch link aligns properly with the left edge of its content space.

Check it out and lmk what you think.