### PR TITLE
Emoji Data Restructuring

### DIFF
--- a/src/Components/AddToListDropMenu.js
+++ b/src/Components/AddToListDropMenu.js
@@ -110,9 +110,6 @@ export default function AddToListDropMenu({ anime, variant, selected }) {
         privateList: privateList,
         desc: desc,
         id: listId,
-        applauseCount: 0,
-        heartCount: 0,
-        trashCount: 0,
       },
     ];
     setLocalUser(temp);

--- a/src/Components/AddToListDropMenu.js
+++ b/src/Components/AddToListDropMenu.js
@@ -110,6 +110,9 @@ export default function AddToListDropMenu({ anime, variant, selected }) {
         privateList: privateList,
         desc: desc,
         id: listId,
+        applauseCount: 0,
+        heartCount: 0,
+        trashCount: 0,
       },
     ];
     setLocalUser(temp);

--- a/src/Components/EmojiReactionChip.js
+++ b/src/Components/EmojiReactionChip.js
@@ -31,7 +31,7 @@ export default function EmojiReactionChip({
   const params = useParams();
   const ownerId = params.userId;
   const listId = params.listId;
-
+  console.log(rxnCount);
   tooltip = user?.isAnonymous ? "Register to react" : tooltip;
 
   useEffect(() => {

--- a/src/Components/EmojiReactionChip.js
+++ b/src/Components/EmojiReactionChip.js
@@ -32,7 +32,7 @@ export default function EmojiReactionChip({
   const [selected, setSelected] = useState();
   const [emojiCount, setEmojiCount] = useState(null);
   const theme = useTheme();
-  //TODO - HIDE EMOJI CHIPS FOR PRIVATE WATCHLISTS
+
   const params = useParams();
   const ownerId = params.userId;
   const listId = params.listId;

--- a/src/Components/EmojiReactionChip.js
+++ b/src/Components/EmojiReactionChip.js
@@ -15,8 +15,8 @@ import { useParams } from "react-router-dom";
 export default function EmojiReactionChip({
   docId, // "userId + listId" or "animeId"
   emoji, // Phosphor emoji component to display
-  item, // Object containing booleans whether user has reacted
-  setItem,
+  userRxns, // Object containing booleans whether user has reacted
+  setUserRxns,
   reaction, // "applause" "heart" or "trash"
   type, // content being reacted to: "list" "comments" or "reviews"
   tooltip,
@@ -35,9 +35,9 @@ export default function EmojiReactionChip({
 
   useEffect(() => {
     if (!user) return;
-    if (item?.[reaction]) setSelected(true);
+    if (userRxns?.[reaction]) setSelected(true);
     else setSelected(false);
-  }, [user, item?.[reaction]]);
+  }, [user, userRxns?.[reaction]]);
 
   useEffect(() => {
     setEmojiCount(rxnCount);
@@ -53,15 +53,15 @@ export default function EmojiReactionChip({
     read: false, // Remains false until popper is closed (so it can be specially styled)
     listId: listId ?? null,
     listOwnerId: ownerId ?? null,
-    commentOwnerId: item?.uid ?? null,
+    commentOwnerId: userRxns?.uid ?? null,
   };
 
   function reactToReview() {
     let docIdString = docId.toString();
     if (!selected) {
-      let temp = { ...item };
+      let temp = { ...userRxns };
       temp[reaction] = !temp[reaction];
-      setItem(temp);
+      setUserRxns(temp);
       setEmojiCount(emojiCount + 1);
       SaveReactionsToFirestore(
         user.uid,
@@ -72,11 +72,11 @@ export default function EmojiReactionChip({
         IdToNotify
       );
       if (reaction !== "trash")
-        SaveNotification(notification, IdToNotify ?? item.uid); // Good vibes only on EdwardML!
+        SaveNotification(notification, IdToNotify ?? userRxns.uid); // Good vibes only on EdwardML!
     } else if (selected) {
-      let temp = { ...item };
+      let temp = { ...userRxns };
       temp[reaction] = !temp[reaction];
-      setItem(temp);
+      setUserRxns(temp);
       setEmojiCount(emojiCount - 1);
       SaveReactionsToFirestore(
         user.uid,
@@ -87,29 +87,29 @@ export default function EmojiReactionChip({
         IdToNotify
       );
       if (reaction !== "trash")
-        DeleteNotification(notification, IdToNotify ?? item.uid);
+        DeleteNotification(notification, IdToNotify ?? userRxns.uid);
     }
   }
 
   function reactToList() {
     if (!selected) {
-      let temp = { ...item };
+      let temp = { ...userRxns };
       temp[reaction] = !temp[reaction];
-      setItem(temp);
+      setUserRxns(temp);
       setEmojiCount(emojiCount + 1);
       SaveReactionsToFirestore(user.uid, docId, temp, "list", reaction);
       if (reaction !== "trash") SaveNotification(notification, ownerId);
     } else if (selected) {
-      let temp = { ...item };
+      let temp = { ...userRxns };
       temp[reaction] = !temp[reaction];
-      setItem(temp);
+      setUserRxns(temp);
       setEmojiCount(emojiCount - 1);
       SaveReactionsToFirestore(user.uid, docId, temp, "list", reaction);
       if (reaction !== "trash") DeleteNotification(notification, ownerId);
     }
   }
 
-  if (!item)
+  if (!userRxns)
     return (
       <Skeleton
         variant="rounded"

--- a/src/Components/EmojiReactionChip.js
+++ b/src/Components/EmojiReactionChip.js
@@ -1,6 +1,5 @@
 import Chip from "@mui/material/Chip";
 import Tooltip from "@mui/material/Tooltip";
-import useTheme from "@mui/material/styles/useTheme";
 
 import { useEffect, useState } from "react";
 import { useAuthState } from "react-firebase-hooks/auth";

--- a/src/Components/EmojiReactionChip.js
+++ b/src/Components/EmojiReactionChip.js
@@ -7,31 +7,26 @@ import { useAuthState } from "react-firebase-hooks/auth";
 import { auth } from "./Firebase";
 import {
   DeleteNotification,
-  SaveListReactionsToFirestore,
   SaveNotification,
   SaveReactionsToFirestore,
-  SaveReviewToFirestore,
-  getReviewReactions,
 } from "./Firestore";
 import Skeleton from "@mui/material/Skeleton";
 import { useParams } from "react-router-dom";
 
 export default function EmojiReactionChip({
-  docId,
-  emoji,
-  item,
+  docId, // "userId + listId" or "animeId"
+  emoji, // Phosphor emoji component to display
+  item, // Object containing booleans whether user has reacted
   setItem,
-  reaction,
-  index,
-  type,
+  reaction, // "applause" "heart" or "trash"
+  type, // content being reacted to: "list" "comments" or "reviews"
   tooltip,
-  rxnCount,
+  rxnCount, // Number of reactions to display for this emoji
   IdToNotify,
 }) {
   const [user] = useAuthState(auth);
   const [selected, setSelected] = useState();
   const [emojiCount, setEmojiCount] = useState(null);
-  const theme = useTheme();
 
   const params = useParams();
   const ownerId = params.userId;
@@ -64,8 +59,6 @@ export default function EmojiReactionChip({
 
   function reactToReview() {
     let docIdString = docId.toString();
-    // if (type === "comments") docIdString = docId.toString() + IdToNotify;
-    // else docIdString = docId.toString();
     if (!selected) {
       let temp = { ...item };
       temp[reaction] = !temp[reaction];

--- a/src/Components/EmojiReactionChip.js
+++ b/src/Components/EmojiReactionChip.js
@@ -31,7 +31,7 @@ export default function EmojiReactionChip({
   const params = useParams();
   const ownerId = params.userId;
   const listId = params.listId;
-  console.log(rxnCount);
+
   tooltip = user?.isAnonymous ? "Register to react" : tooltip;
 
   useEffect(() => {

--- a/src/Components/Firestore.js
+++ b/src/Components/Firestore.js
@@ -345,6 +345,9 @@ export async function CreateWatchlistDataEntry(userId, listId) {
     userId: userId,
     listId: listId,
     random: generateRandomWatchlistInt(),
+    applauseCount: 0,
+    heartCount: 0,
+    trashCount: 0,
   };
   const docName = userId + listId;
   let docRef = doc(db, "watchlistData", docName);

--- a/src/Components/Firestore.js
+++ b/src/Components/Firestore.js
@@ -208,54 +208,44 @@ export function generateId() {
   return doc(collection(db, "test")).id;
 }
 
-export async function getReviewReactions(uid, uniqueEntityId, setReviewRxns) {
-  try {
-    let reactionsRef = doc(db, "users", uid, "reactions", uniqueEntityId);
-    let reactionSnap = await getDoc(reactionsRef);
-    // Use default value if the document doesn't exist yet.
-    if (!reactionSnap.data()) {
-      setReviewRxns({
-        uniqueEntityId: uniqueEntityId,
-        applause: false,
-        heart: false,
-        trash: false,
-      });
-    } else {
-      let temp = reactionSnap.data();
-      setReviewRxns(temp);
-    }
-  } catch (error) {
-    console.error("Error loading data from Firebase Database", error);
+export async function getReviewReactions(uid, uniqueEntityId) {
+  let reactionsRef = doc(db, "users", uid, "reactions", uniqueEntityId);
+  let reactionSnap = await getDoc(reactionsRef);
+  // Use default value if the document doesn't exist yet.
+  if (!reactionSnap.data()) {
+    return {
+      uniqueEntityId: uniqueEntityId,
+      applause: false,
+      heart: false,
+      trash: false,
+    };
+  } else {
+    return reactionSnap.data();
   }
 }
 
 // Handle "watchlistData / reactions" on firestore
 
-export async function getListReactions(uid, docId, setListRxns, setRxnCount) {
-  try {
-    let reactionsRef = doc(db, "users", uid, "reactions", docId);
-    let rxnCountRef = doc(db, "watchlistData", docId);
-    let [reactionSnap, rxnCountSnap] = await Promise.all([
-      getDoc(reactionsRef),
-      getDoc(rxnCountRef),
-    ]);
-    if (!reactionSnap.data()) {
-      // Use default value if the document doesn't exist yet.
-      setListRxns({
-        uniqueEntityId: docId,
-        applause: false,
-        heart: false,
-        trash: false,
-      });
-    } else {
-      let temp = reactionSnap.data();
-      setListRxns(temp);
-    }
-    let temp = rxnCountSnap.data();
-    setRxnCount([temp.applauseCount, temp.heartCount, temp.trashCount]);
-  } catch (error) {
-    console.error("Error loading data from Firebase Database", error);
+export async function getUserReactions(uid, docId) {
+  let reactionsRef = doc(db, "users", uid, "reactions", docId);
+  let reactionSnap = await getDoc(reactionsRef);
+  if (!reactionSnap.data()) {
+    // Use default value if the document doesn't exist yet.
+    return {
+      uniqueEntityId: docId,
+      applause: false,
+      heart: false,
+      trash: false,
+    };
+  } else {
+    return reactionSnap.data();
   }
+}
+
+export async function getReactionCount(uid, docId) {
+  let rxnCountRef = doc(db, "watchlistData", docId);
+  let rxnCountSnap = await getDoc(rxnCountRef);
+  return rxnCountSnap.data();
 }
 
 export async function SaveReactionsToFirestore(

--- a/src/Components/Firestore.js
+++ b/src/Components/Firestore.js
@@ -213,7 +213,6 @@ export function generateId() {
 }
 
 export async function getReviewReactions(uid, docId, setReviewRxns, type) {
-  console.log(uid);
   try {
     let reactionsRef = doc(db, "users", uid, "reactions", docId);
     let reactionSnap = await getDoc(reactionsRef);

--- a/src/Components/Firestore.js
+++ b/src/Components/Firestore.js
@@ -270,7 +270,6 @@ export async function SaveReactionsToFirestore(
   reaction,
   commentOwnerId
 ) {
-  console.log(updatedRxns, reaction);
   const value = updatedRxns[reaction] ? 1 : -1;
   let key;
   if (reaction === "trash") key = "trashCount";
@@ -287,7 +286,7 @@ export async function SaveReactionsToFirestore(
     rxnCountRef = doc(db, "animeData", docId, "reviews", uid);
   } else if (reactionTo === "comments") {
     rxnRef = doc(db, "users", uid, "reactions", docId + commentOwnerId);
-    rxnCountRef = doc(db, "watchlistData", docId, "reviews", uid);
+    rxnCountRef = doc(db, "watchlistData", docId, "reviews", commentOwnerId);
   }
   try {
     await Promise.all(

--- a/src/Components/Firestore.js
+++ b/src/Components/Firestore.js
@@ -193,7 +193,7 @@ export async function GetPaginatedReviewsFromFirestore(
   }
 }
 
-export async function GetReviewCount(docId, type, setReviewCount) {
+export async function getReviewCount(docId, type, setReviewCount) {
   if (!docId || !type) return;
   let collectionName = type === "reviews" ? "animeData" : "watchlistData";
   let docIdString = docId.toString();
@@ -212,7 +212,7 @@ export function generateId() {
   return doc(collection(db, "test")).id;
 }
 
-export async function getReviewReactions(uid, docId, setReviewRxns, type) {
+export async function getReviewReactions(uid, docId, setReviewRxns) {
   try {
     let reactionsRef = doc(db, "users", uid, "reactions", docId);
     let reactionSnap = await getDoc(reactionsRef);

--- a/src/Components/Firestore.js
+++ b/src/Components/Firestore.js
@@ -9,15 +9,10 @@ import {
   orderBy,
   limit,
   startAfter,
-  limitToLast,
-  endBefore,
   where,
   runTransaction,
   getCountFromServer,
-  arrayUnion,
-  onSnapshot,
   addDoc,
-  writeBatch,
   updateDoc,
   deleteField,
   increment,
@@ -213,14 +208,14 @@ export function generateId() {
   return doc(collection(db, "test")).id;
 }
 
-export async function getReviewReactions(uid, docId, setReviewRxns) {
+export async function getReviewReactions(uid, uniqueEntityId, setReviewRxns) {
   try {
-    let reactionsRef = doc(db, "users", uid, "reactions", docId);
+    let reactionsRef = doc(db, "users", uid, "reactions", uniqueEntityId);
     let reactionSnap = await getDoc(reactionsRef);
     // Use default value if the document doesn't exist yet.
     if (!reactionSnap.data()) {
       setReviewRxns({
-        uniqueEntityId: docId,
+        uniqueEntityId: uniqueEntityId,
         applause: false,
         heart: false,
         trash: false,
@@ -236,7 +231,7 @@ export async function getReviewReactions(uid, docId, setReviewRxns) {
 
 // Handle "watchlistData / reactions" on firestore
 
-export async function GetListReactions(uid, docId, setListRxns, setRxnCount) {
+export async function getListReactions(uid, docId, setListRxns, setRxnCount) {
   try {
     let reactionsRef = doc(db, "users", uid, "reactions", docId);
     let rxnCountRef = doc(db, "watchlistData", docId);
@@ -279,6 +274,7 @@ export async function SaveReactionsToFirestore(
 
   const uniqueEntityId =
     reactionTo === "comments" ? docId + commentOwnerId : docId;
+
   const rxnRef = doc(db, "users", uid, "reactions", uniqueEntityId);
   let rxnCountRef;
 

--- a/src/Components/ProfileListPage.js
+++ b/src/Components/ProfileListPage.js
@@ -13,7 +13,7 @@ import {
   X,
 } from "phosphor-react";
 import { useContext, useEffect, useState } from "react";
-import { Link, useNavigate, useParams } from "react-router-dom";
+import { Link, useLocation, useNavigate, useParams } from "react-router-dom";
 import { slugifyListName } from "../Util/ListUtil";
 import NoResultsImage from "./NoResultsImage";
 import ProfileListItem from "./ProfileListItem";
@@ -35,6 +35,7 @@ import HtmlPageTitle from "./HtmlPageTitle";
 
 export default function ProfileListPage() {
   const navigate = useNavigate();
+  const location = useLocation();
   const confirm = useConfirm();
   const theme = useTheme();
   const [user, loading, error] = useAuthState(auth);
@@ -71,13 +72,9 @@ export default function ProfileListPage() {
   let privateList = false;
   const [rxnCount, setRxnCount] = useState([]);
 
-  function updateEmojiCount(animeObjects) {
-    // applauseCount = ;
-  }
-
   useEffect(() => {
     GetListReactions(user.uid, `${userId}${listId}`, setListRxns, setRxnCount);
-  }, [listId]);
+  }, [listId, location.key]);
 
   const sevenHundredFifty = useMediaQuery(
     theme.breakpoints.up("sevenHundredFifty")
@@ -92,7 +89,6 @@ export default function ProfileListPage() {
     itemsIds = profile.likes;
     name = "Likes";
     typeName = "Watch History";
-    updateEmojiCount();
     updateFn = (newItems) => updateLikes(newItems);
   } else if (listId.toLowerCase() === "dislikes") {
     items = animeObjects?.dislikes;
@@ -203,6 +199,7 @@ export default function ProfileListPage() {
             {isOwnProfile && <PrivacySymbol privateList={privateList} />}
           </div>
         </Grid>
+
         <Grid
           item
           elevenHundred={3.25}
@@ -218,37 +215,42 @@ export default function ProfileListPage() {
             },
           }}
         >
-          <EmojiReactionChip
-            docId={`${userId}${listId}`}
-            item={listRxns}
-            setItem={setListRxns}
-            emoji={<HandsClapping size={24} />}
-            reaction="applause"
-            type="list"
-            ownerId={userId}
-            rxnCount={rxnCount[0]}
-          ></EmojiReactionChip>
-          <EmojiReactionChip
-            docId={`${userId}${listId}`}
-            item={listRxns}
-            setItem={setListRxns}
-            emoji={<Heart size={24} />}
-            reaction="heart"
-            type="list"
-            ownerId={userId}
-            rxnCount={rxnCount[1]}
-          ></EmojiReactionChip>
-          <EmojiReactionChip
-            docId={`${userId}${listId}`}
-            item={listRxns}
-            setItem={setListRxns}
-            emoji={<Trash size={24} />}
-            reaction="trash"
-            type="list"
-            ownerId={userId}
-            rxnCount={rxnCount[2]}
-          ></EmojiReactionChip>
+          {!privateList && (
+            <>
+              <EmojiReactionChip
+                docId={`${userId}${listId}`}
+                item={listRxns}
+                setItem={setListRxns}
+                emoji={<HandsClapping size={24} />}
+                reaction="applause"
+                type="list"
+                ownerId={userId}
+                rxnCount={rxnCount[0]}
+              ></EmojiReactionChip>
+              <EmojiReactionChip
+                docId={`${userId}${listId}`}
+                item={listRxns}
+                setItem={setListRxns}
+                emoji={<Heart size={24} />}
+                reaction="heart"
+                type="list"
+                ownerId={userId}
+                rxnCount={rxnCount[1]}
+              ></EmojiReactionChip>
+              <EmojiReactionChip
+                docId={`${userId}${listId}`}
+                item={listRxns}
+                setItem={setListRxns}
+                emoji={<Trash size={24} />}
+                reaction="trash"
+                type="list"
+                ownerId={userId}
+                rxnCount={rxnCount[2]}
+              ></EmojiReactionChip>
+            </>
+          )}
         </Grid>
+
         <Grid
           item
           xs={2}

--- a/src/Components/ProfileListPage.js
+++ b/src/Components/ProfileListPage.js
@@ -14,7 +14,6 @@ import {
 } from "phosphor-react";
 import { useContext, useEffect, useState } from "react";
 import { Link, useLocation, useNavigate, useParams } from "react-router-dom";
-import { slugifyListName } from "../Util/ListUtil";
 import NoResultsImage from "./NoResultsImage";
 import ProfileListItem from "./ProfileListItem";
 import ProfileListPageGhost from "./ProfileListPageGhost";
@@ -27,7 +26,7 @@ import ReviewContainer from "./ReviewContainer";
 import { auth } from "./Firebase";
 import { useAuthState } from "react-firebase-hooks/auth";
 import EmojiReactionChip from "./EmojiReactionChip";
-import { GetListReactions } from "./Firestore";
+import { getListReactions } from "./Firestore";
 import Grid from "@mui/material/Grid";
 import useMediaQuery from "@mui/material/useMediaQuery";
 import useTheme from "@mui/material/styles/useTheme";
@@ -73,7 +72,7 @@ export default function ProfileListPage() {
   const [rxnCount, setRxnCount] = useState([]);
 
   useEffect(() => {
-    GetListReactions(user.uid, `${userId}${listId}`, setListRxns, setRxnCount);
+    getListReactions(user.uid, `${userId}${listId}`, setListRxns, setRxnCount);
   }, [listId, location.key]);
 
   const sevenHundredFifty = useMediaQuery(
@@ -199,7 +198,6 @@ export default function ProfileListPage() {
             {isOwnProfile && <PrivacySymbol privateList={privateList} />}
           </div>
         </Grid>
-
         <Grid
           item
           elevenHundred={3.25}
@@ -250,7 +248,6 @@ export default function ProfileListPage() {
             </>
           )}
         </Grid>
-
         <Grid
           item
           xs={2}

--- a/src/Components/ProfileListPage.js
+++ b/src/Components/ProfileListPage.js
@@ -324,13 +324,15 @@ export default function ProfileListPage() {
       )}
 
       {/* Comments */}
-      <ReviewContainer
-        user={user}
-        docId={`${userId}${listId}`}
-        type={"comments"}
-        listOwnerId={userId}
-        listId={listId}
-      />
+      {!privateList && (
+        <ReviewContainer
+          user={user}
+          docId={`${userId}${listId}`}
+          type={"comments"}
+          listOwnerId={userId}
+          listId={listId}
+        />
+      )}
     </Box>
   );
 }

--- a/src/Components/ProfileListPage.js
+++ b/src/Components/ProfileListPage.js
@@ -69,9 +69,14 @@ export default function ProfileListPage() {
   let listHasDesc = false;
   let showSuggestions = false;
   let privateList = false;
+  const [rxnCount, setRxnCount] = useState([]);
+
+  function updateEmojiCount(animeObjects) {
+    // applauseCount = ;
+  }
 
   useEffect(() => {
-    GetListReactions(`${userId}${listId}`, setListRxns);
+    GetListReactions(user.uid, `${userId}${listId}`, setListRxns, setRxnCount);
   }, [listId]);
 
   const sevenHundredFifty = useMediaQuery(
@@ -87,6 +92,7 @@ export default function ProfileListPage() {
     itemsIds = profile.likes;
     name = "Likes";
     typeName = "Watch History";
+    updateEmojiCount();
     updateFn = (newItems) => updateLikes(newItems);
   } else if (listId.toLowerCase() === "dislikes") {
     items = animeObjects?.dislikes;
@@ -220,6 +226,7 @@ export default function ProfileListPage() {
             reaction="applause"
             type="list"
             ownerId={userId}
+            rxnCount={rxnCount[0]}
           ></EmojiReactionChip>
           <EmojiReactionChip
             docId={`${userId}${listId}`}
@@ -229,6 +236,7 @@ export default function ProfileListPage() {
             reaction="heart"
             type="list"
             ownerId={userId}
+            rxnCount={rxnCount[1]}
           ></EmojiReactionChip>
           <EmojiReactionChip
             docId={`${userId}${listId}`}
@@ -238,6 +246,7 @@ export default function ProfileListPage() {
             reaction="trash"
             type="list"
             ownerId={userId}
+            rxnCount={rxnCount[2]}
           ></EmojiReactionChip>
         </Grid>
         <Grid

--- a/src/Components/ProfileListPage.js
+++ b/src/Components/ProfileListPage.js
@@ -25,7 +25,7 @@ import ReviewContainer from "./ReviewContainer";
 import { auth } from "./Firebase";
 import { useAuthState } from "react-firebase-hooks/auth";
 import EmojiReactionChip from "./EmojiReactionChip";
-import { getReactionCount, getUserReactions } from "./Firestore";
+import { getWatchlistReactionCount, getUserReactions } from "./Firestore";
 import Grid from "@mui/material/Grid";
 import HtmlPageTitle from "./HtmlPageTitle";
 
@@ -74,7 +74,7 @@ export default function ProfileListPage() {
         .catch(() =>
           console.error("Error loading user reactions from Firestore")
         ),
-      getReactionCount(user.uid, `${userId}${listId}`)
+      getWatchlistReactionCount(`${userId}${listId}`)
         .then((value) =>
           setRxnCount([value.applauseCount, value.heartCount, value.trashCount])
         )

--- a/src/Components/Review.js
+++ b/src/Components/Review.js
@@ -10,13 +10,11 @@ import useTheme from "@mui/material/styles/useTheme";
 import { useConfirm } from "material-ui-confirm";
 import format from "date-fns/format";
 import fromUnixTime from "date-fns/fromUnixTime";
-import toDate from "date-fns/toDate";
 import { HandsClapping, Star, Trash, X, Heart } from "phosphor-react";
 import { useContext, useEffect, useMemo, useState } from "react";
 import { useAuthState } from "react-firebase-hooks/auth";
 import { Link, useLocation } from "react-router-dom";
 import { useProfile } from "./APICalls";
-import AvatarIcon from "./AvatarIcon";
 import EmojiReactionChip from "./EmojiReactionChip";
 import ExpandableText from "./ExpandableText";
 import { auth } from "./Firebase";
@@ -25,7 +23,6 @@ import {
   DeleteReviewFromFirestore,
   SaveToFirestore,
   deleteAllReactions,
-  deleteReactions,
   getReviewReactions,
 } from "./Firestore";
 import { LocalUserContext } from "./LocalUserContext";
@@ -72,9 +69,6 @@ export default function Review({
       cancellationButtonProps: { color: "inherit" },
       cancellationText: "Cancel",
     }).then(() => {
-      // TODO -
-      //
-      //        Delete ALL selections of emojis for that review/comment
       let temp = [...reviews];
       temp.splice(index, 1);
       setReviews(temp);

--- a/src/Components/Review.js
+++ b/src/Components/Review.js
@@ -70,6 +70,9 @@ export default function Review({
       cancellationButtonProps: { color: "inherit" },
       cancellationText: "Cancel",
     }).then(() => {
+      // TODO -
+      //
+      //        Delete ALL selections of emojis for that review/comment
       let temp = [...reviews];
       temp.splice(index, 1);
       setReviews(temp);
@@ -92,6 +95,9 @@ export default function Review({
         };
         DeleteNotification(notiInfo, listOwnerId);
       }
+
+      // TODO - Create collection group to delete all reaction information users who reacted to this comment/review has
+      //        This info lives under "users"/:uid/"reactions"/:animeId or :docId or :docId + commentOwnerId
     });
   }
 
@@ -222,7 +228,7 @@ export default function Review({
                       right: "-10px",
                     }}
                     onClick={(e) => {
-                      deleteReview(review, index);
+                      deleteReview(index);
                       e.stopPropagation();
                     }}
                   >

--- a/src/Components/Review.js
+++ b/src/Components/Review.js
@@ -24,6 +24,8 @@ import {
   DeleteNotification,
   DeleteReviewFromFirestore,
   SaveToFirestore,
+  deleteAllReactions,
+  deleteReactions,
   getReviewReactions,
 } from "./Firestore";
 import { LocalUserContext } from "./LocalUserContext";
@@ -96,8 +98,8 @@ export default function Review({
         DeleteNotification(notiInfo, listOwnerId);
       }
 
-      // TODO - Create collection group to delete all reaction information users who reacted to this comment/review has
-      //        This info lives under "users"/:uid/"reactions"/:animeId or :docId or :docId + commentOwnerId
+      // Delete stored reactions to the review/comment that's been deleted.
+      deleteAllReactions(uniqueEntityId);
     });
   }
 

--- a/src/Components/Review.js
+++ b/src/Components/Review.js
@@ -23,11 +23,7 @@ import { auth } from "./Firebase";
 import {
   DeleteNotification,
   DeleteReviewFromFirestore,
-  GetListReactions,
-  PopulateReviewsFromFirestore,
-  SaveReviewToFirestore,
   SaveToFirestore,
-  getReviewReactionCount,
   getReviewReactions,
 } from "./Firestore";
 import { LocalUserContext } from "./LocalUserContext";
@@ -275,7 +271,6 @@ export default function Review({
             reaction="applause"
             item={item}
             setItem={setItem}
-            index={index}
             type={type}
             tooltip={`Applaud this ${typeSingular}`}
             rxnCount={reviews[index].applauseCount}
@@ -288,7 +283,6 @@ export default function Review({
             reaction="heart"
             item={item}
             setItem={setItem}
-            index={index}
             type={type}
             tooltip={`Love this ${typeSingular}`}
             rxnCount={reviews[index].heartCount}
@@ -301,7 +295,6 @@ export default function Review({
             reaction="trash"
             item={item}
             setItem={setItem}
-            index={index}
             type={type}
             tooltip={`Disagree with this ${typeSingular}`}
             rxnCount={reviews[index].trashCount}

--- a/src/Components/Review.js
+++ b/src/Components/Review.js
@@ -22,8 +22,7 @@ import {
   DeleteNotification,
   DeleteReviewFromFirestore,
   SaveToFirestore,
-  deleteAllReactions,
-  getReviewReactions,
+  getUserReactions,
 } from "./Firestore";
 import { LocalUserContext } from "./LocalUserContext";
 import { getAvatarSrc } from "./Avatars";
@@ -57,7 +56,7 @@ export default function Review({
     type === "reviews" ? docId.toString() : docId.toString() + review?.uid;
 
   useEffect(() => {
-    getReviewReactions(user.uid, uniqueEntityId)
+    getUserReactions(user.uid, uniqueEntityId)
       .then((value) => setUserRxns(value))
       .catch(
         () => console.error("Error loading review reactions from Firestore")
@@ -96,9 +95,6 @@ export default function Review({
         };
         DeleteNotification(notiInfo, listOwnerId);
       }
-
-      // Delete stored reactions to the review/comment that's been deleted.
-      deleteAllReactions(uniqueEntityId);
     });
   }
 

--- a/src/Components/Review.js
+++ b/src/Components/Review.js
@@ -209,7 +209,7 @@ export default function Review({
                 <Typography component="span" sx={{ fontWeight: 900, mr: 2 }}>
                   {review.reviewTitle}
                 </Typography>{" "}
-                <ConvertDate item={review} />
+                <ConvertDate review={review} />
               </Grid>
             </Tooltip>
             {user.uid === review.uid ? (

--- a/src/Components/Review.js
+++ b/src/Components/Review.js
@@ -43,7 +43,7 @@ export default function Review({
   const theme = useTheme();
   const confirm = useConfirm();
 
-  const [item, setItem] = useState({});
+  const [userRxns, setUserRxns] = useState({});
   const { data: reviewerInfo } = useProfile(review.uid);
 
   const typeSingular = type === "comments" ? "comment" : "review";
@@ -57,8 +57,13 @@ export default function Review({
     type === "reviews" ? docId.toString() : docId.toString() + review?.uid;
 
   useEffect(() => {
-    getReviewReactions(user.uid, uniqueEntityId, setItem);
-  }, [docId]);
+    getReviewReactions(user.uid, uniqueEntityId)
+      .then((value) => setUserRxns(value))
+      .catch(
+        () => console.error("Error loading review reactions from Firestore")
+        // Todo: show error UI
+      );
+  }, [user.uid, uniqueEntityId]);
 
   function deleteReview(index) {
     confirm({
@@ -271,8 +276,8 @@ export default function Review({
             docId={docId}
             emoji={<HandsClapping size={24} />}
             reaction="applause"
-            item={item}
-            setItem={setItem}
+            userRxns={userRxns}
+            setUserRxns={setUserRxns}
             type={type}
             tooltip={`Applaud this ${typeSingular}`}
             rxnCount={reviews[index].applauseCount}
@@ -283,8 +288,8 @@ export default function Review({
             docId={docId}
             emoji={<Heart size={24} />}
             reaction="heart"
-            item={item}
-            setItem={setItem}
+            userRxns={userRxns}
+            setUserRxns={setUserRxns}
             type={type}
             tooltip={`Love this ${typeSingular}`}
             rxnCount={reviews[index].heartCount}
@@ -295,8 +300,8 @@ export default function Review({
             docId={docId}
             emoji={<Trash size={24} />}
             reaction="trash"
-            item={item}
-            setItem={setItem}
+            userRxns={userRxns}
+            setUserRxns={setUserRxns}
             type={type}
             tooltip={`Disagree with this ${typeSingular}`}
             rxnCount={reviews[index].trashCount}

--- a/src/Components/ReviewContainer.js
+++ b/src/Components/ReviewContainer.js
@@ -30,7 +30,11 @@ export default function ReviewContainer({
 
   const [lastVisible, setLastVisible] = useState(null);
   const [seeMore, setSeeMore] = useState(true);
-  const [sortOption, setSortOption] = useState(["time", "desc"]);
+  const [sortOption, setSortOption] = useState([
+    "applauseCount",
+    "desc",
+    "mostLoved",
+  ]);
   const [reviewCount, setReviewCount] = useState(undefined);
 
   const typeSingular = type === "comments" ? "comment" : "review";

--- a/src/Components/ReviewContainer.js
+++ b/src/Components/ReviewContainer.js
@@ -6,7 +6,11 @@ import Button from "@mui/material/Button";
 import IconButton from "@mui/material/IconButton";
 
 import { CaretDown, Minus, Plus } from "phosphor-react";
-import { GetPaginatedReviewsFromFirestore, GetReviewCount } from "./Firestore";
+import {
+  GetPaginatedReviewsFromFirestore,
+  GetReviewCount,
+  getReviewReactions,
+} from "./Firestore";
 import { useContext, useEffect, useState } from "react";
 import { useLocation } from "react-router-dom";
 import ReviewFilterDropMenu from "./ReviewFilterDropMenu";
@@ -155,7 +159,7 @@ export default function ReviewContainer({
         return (
           <Review
             key={`${item.uid}+${item.time.seconds}`}
-            item={item}
+            review={item}
             index={index}
             docId={docId}
             reviews={reviews}

--- a/src/Components/ReviewContainer.js
+++ b/src/Components/ReviewContainer.js
@@ -37,6 +37,8 @@ export default function ReviewContainer({
   ]);
   const [reviewCount, setReviewCount] = useState(undefined);
 
+  const [selected, setSelected] = useState("mostApplauded"); // <ReviewFilterDropMenu> selection
+
   const typeSingular = type === "comments" ? "comment" : "review";
 
   const subheadStyle = {
@@ -135,6 +137,8 @@ export default function ReviewContainer({
             <ReviewFilterDropMenu
               setLastVisible={setLastVisible}
               setSortOption={setSortOption}
+              selected={selected}
+              setSelected={setSelected}
             />
           </div>
         )}
@@ -152,6 +156,7 @@ export default function ReviewContainer({
           reviewCount={reviewCount}
           listOwnerId={listOwnerId}
           listId={listId}
+          setDropSelection={setSelected}
         />
       )}
 

--- a/src/Components/ReviewContainer.js
+++ b/src/Components/ReviewContainer.js
@@ -6,11 +6,7 @@ import Button from "@mui/material/Button";
 import IconButton from "@mui/material/IconButton";
 
 import { CaretDown, Minus, Plus } from "phosphor-react";
-import {
-  GetPaginatedReviewsFromFirestore,
-  GetReviewCount,
-  getReviewReactions,
-} from "./Firestore";
+import { GetPaginatedReviewsFromFirestore, getReviewCount } from "./Firestore";
 import { useContext, useEffect, useState } from "react";
 import { useLocation } from "react-router-dom";
 import ReviewFilterDropMenu from "./ReviewFilterDropMenu";
@@ -59,7 +55,7 @@ export default function ReviewContainer({
   }, [location.pathname, docId, sortOption]);
 
   useEffect(() => {
-    GetReviewCount(docId, type, setReviewCount);
+    getReviewCount(docId, type, setReviewCount);
   }, [localUser.reviews, localUser.comments]);
 
   return (

--- a/src/Components/ReviewFilterDropMenu.js
+++ b/src/Components/ReviewFilterDropMenu.js
@@ -19,7 +19,7 @@ export default function ReviewFilterDropMenu({
   const [open, setOpen] = useState(false);
   const anchorRef = useRef(null);
 
-  const [selected, setSelected] = useState("newestFirst");
+  const [selected, setSelected] = useState("mostApplauded");
 
   const smallDevice = useMediaQuery(theme.breakpoints.down("fiveHundred"));
 
@@ -103,6 +103,41 @@ export default function ReviewFilterDropMenu({
                   onKeyDown={handleListKeyDown}
                   sx={{ padding: 0 }}
                 >
+                  <MenuItem
+                    divider
+                    onClick={(e) => {
+                      handleSelection(e, [
+                        "applauseCount",
+                        "desc",
+                        "mostApplauded",
+                      ]);
+                    }}
+                    selected={selected === "mostApplauded" ? true : false}
+                  >
+                    Popularity: Most Applauded First
+                  </MenuItem>
+                  <MenuItem
+                    divider
+                    onClick={(e) => {
+                      handleSelection(e, ["heartCount", "desc", "mostloved"]);
+                    }}
+                    selected={selected === "mostloved" ? true : false}
+                  >
+                    Popularity: Most Loved First
+                  </MenuItem>
+                  <MenuItem
+                    divider
+                    onClick={(e) => {
+                      handleSelection(e, [
+                        "trashCount",
+                        "desc",
+                        "mostDisliked",
+                      ]);
+                    }}
+                    selected={selected === "mostDisliked" ? true : false}
+                  >
+                    Popularity: Most Disliked First
+                  </MenuItem>
                   <MenuItem
                     divider
                     onClick={(e) => {

--- a/src/Components/ReviewFilterDropMenu.js
+++ b/src/Components/ReviewFilterDropMenu.js
@@ -14,12 +14,12 @@ import useTheme from "@mui/material/styles/useTheme";
 export default function ReviewFilterDropMenu({
   setLastVisible,
   setSortOption,
+  selected,
+  setSelected,
 }) {
   const theme = useTheme();
   const [open, setOpen] = useState(false);
   const anchorRef = useRef(null);
-
-  const [selected, setSelected] = useState("mostApplauded");
 
   const smallDevice = useMediaQuery(theme.breakpoints.down("fiveHundred"));
 

--- a/src/Components/ReviewForm.js
+++ b/src/Components/ReviewForm.js
@@ -140,7 +140,8 @@ export default function ReviewForm({
       );
 
       // Only provide notification when a comment is created NOT when edited
-      if (!edited) SaveNotification(notification, listOwnerId);
+      if (!edited && type !== "reviews")
+        SaveNotification(notification, listOwnerId);
 
       await GetPaginatedReviewsFromFirestore(
         docId,

--- a/src/Components/ReviewForm.js
+++ b/src/Components/ReviewForm.js
@@ -19,6 +19,8 @@ import {
   SaveNotification,
   SaveReviewToFirestore,
   SaveToFirestore,
+  getReviewCount,
+  getReviewReactions,
   setLastVisible,
   setSeeMore,
 } from "./Firestore";
@@ -43,7 +45,7 @@ export default function ReviewForm({
   let [reviewTitle, setReviewTitle] = useState("");
   let [review, setReview] = useState("");
   let [rating, setRating] = useState(null);
-  let [emojis, setEmojis] = useState({});
+  let [emojis, setEmojis] = useState([0, 0, 0]);
 
   let [existingReview, setExistingReview] = useState(false);
 
@@ -75,8 +77,10 @@ export default function ReviewForm({
 
   function populateForm() {
     if (localUser[type].includes(docId)) {
+      console.log(localUser[type]);
       for (let i = 0; i < reviews.length; i++) {
         if (reviews[i].uid === user.uid) {
+          console.log(reviews[i]);
           setExistingReview(true);
           setReviewTitle(reviews[i].reviewTitle);
           setReview(reviews[i].review);
@@ -128,6 +132,7 @@ export default function ReviewForm({
         SaveToFirestore(user, localUser);
       }
       const userID = user.uid.toString();
+      console.log(emojis);
       await SaveReviewToFirestore(
         userID,
         userReview,

--- a/src/Components/ReviewForm.js
+++ b/src/Components/ReviewForm.js
@@ -77,10 +77,8 @@ export default function ReviewForm({
 
   function populateForm() {
     if (localUser[type].includes(docId)) {
-      console.log(localUser[type]);
       for (let i = 0; i < reviews.length; i++) {
         if (reviews[i].uid === user.uid) {
-          console.log(reviews[i]);
           setExistingReview(true);
           setReviewTitle(reviews[i].reviewTitle);
           setReview(reviews[i].review);
@@ -132,7 +130,6 @@ export default function ReviewForm({
         SaveToFirestore(user, localUser);
       }
       const userID = user.uid.toString();
-      console.log(emojis);
       await SaveReviewToFirestore(
         userID,
         userReview,

--- a/src/Components/ReviewForm.js
+++ b/src/Components/ReviewForm.js
@@ -37,6 +37,7 @@ export default function ReviewForm({
   reviewCount,
   listOwnerId,
   listId,
+  setDropSelection,
 }) {
   const [localUser, setLocalUser] = useContext(LocalUserContext);
   const [user] = useAuthState(auth);
@@ -152,6 +153,7 @@ export default function ReviewForm({
         setSeeMore,
         type
       );
+      setDropSelection("newestFirst");
       setShowReviewForm(false);
     }
   };

--- a/src/Components/ReviewForm.js
+++ b/src/Components/ReviewForm.js
@@ -15,14 +15,9 @@ import { useForm } from "react-hook-form";
 import { Star } from "phosphor-react";
 import {
   GetPaginatedReviewsFromFirestore,
-  PopulateReviewsFromFirestore,
   SaveNotification,
   SaveReviewToFirestore,
   SaveToFirestore,
-  getReviewCount,
-  getReviewReactions,
-  setLastVisible,
-  setSeeMore,
 } from "./Firestore";
 import { getAvatarSrc } from "./Avatars";
 

--- a/src/Components/ReviewForm.js
+++ b/src/Components/ReviewForm.js
@@ -81,7 +81,11 @@ export default function ReviewForm({
           setReviewTitle(reviews[i].reviewTitle);
           setReview(reviews[i].review);
           setRating(reviews[i].rating);
-          setEmojis(reviews[i].emojis);
+          setEmojis([
+            reviews[i].applauseCount,
+            reviews[i].heartCount,
+            reviews[i].trashCount,
+          ]);
         }
       }
     }
@@ -113,12 +117,10 @@ export default function ReviewForm({
         reviewTitle: reviewTitle,
         uid: user.uid,
         time: new Date(),
-        edited: { edited },
-        emojis: {
-          applause: [...emojis?.applause],
-          heart: [...emojis?.heart],
-          trash: [...emojis?.trash],
-        },
+        edited: edited,
+        applauseCount: emojis[0],
+        heartCount: emojis[1],
+        trashCount: emojis[2],
       };
       if (!localUser[type]) localUser[type] = [];
       if (!localUser[type].find((x) => x === docId)) {


### PR DESCRIPTION
Reworks where emoji data is stored to allow for sorting of comments/reviews by popularity.
- Whether a user has selected an emoji is stored within `users/:uid/reactions/:uniqueEntityId`
- The emoji tally for an item is stored within either `animeData` or `watchlistData` collection, in the same doc as the review/comment information.

Quirks to be aware of:
- On clicking an emoji, we only write to firestore. The visual update of the reaction count on the chip is faked, to eliminate a delay between clicking the chip and seeing the value increment.  Obviously this has serious flaws (ie. the firestore write fails). Will revisit.
- To update the emoji tally I'm using firestore's increment function which can only be called [once per second](https://firebase.blog/posts/2019/03/increment-server-side-cloud-firestore/). I will update to using a [distributed counter](https://firebase.google.com/docs/firestore/solutions/counters) on a future PR (this one's bursting at the seams already!)

Next steps for Ken after we merge:
- Write firestore rules.
- Move data for existing lists/comments/reviews to match new data structure.