### PR TITLE
Fixes Notification Popper Bugs

### DIFF
--- a/src/Components/NotificationDropMenu.js
+++ b/src/Components/NotificationDropMenu.js
@@ -31,12 +31,13 @@ import { auth } from "./Firebase";
 
 export default function NotificationDropMenu() {
   const theme = useTheme();
-  const [open, setOpen] = useState(false);
   const anchorRef = useRef(null);
   const [user, loading, error] = useAuthState(auth);
   const [loadingMoreNotis, setLoadingMoreNotis] = useState(false);
 
   const [
+    open,
+    setOpen,
     notifications,
     showMore,
     hideBadge,

--- a/src/Components/NotificationListItem.js
+++ b/src/Components/NotificationListItem.js
@@ -52,7 +52,10 @@ export function NotificationListItem({ item, handleClose, index }) {
   const loading =
     !interactorData || !avatarSrc || animeLoading || loadingListOwner;
 
-  const time = getTimeElapsed(item.time, isMobileWidth);
+  const time = useMemo(
+    () => getTimeElapsed(item.time, isMobileWidth),
+    [item.time, isMobileWidth]
+  );
 
   if (loading)
     return (

--- a/src/Components/NotificationsProvider.js
+++ b/src/Components/NotificationsProvider.js
@@ -16,6 +16,7 @@ import { useAuthState } from "react-firebase-hooks/auth";
 export default function NotificationsProvider(props) {
   const [user, loading, error] = useAuthState(auth);
   const [notifications, setNotifications] = useState([]);
+  const [open, setOpen] = useState(false);
   const [showMore, setShowMore] = useState(false);
   const [hideBadge, setHideBadge] = useState(true);
   const [listeningDocs, setListeningDocs] = useState([]);
@@ -126,7 +127,7 @@ export default function NotificationsProvider(props) {
     if (!user || !notifications) return;
     getUnseenNotiCount().then((result) => {
       setHideBadge(result);
-      setShowNewNotiButton(!result);
+      if (open) setShowNewNotiButton(!result);
     });
   }, [listeningDocs]);
 
@@ -158,6 +159,8 @@ export default function NotificationsProvider(props) {
   return (
     <NotificationsContext.Provider
       value={[
+        open,
+        setOpen,
         notifications,
         showMore,
         hideBadge,


### PR DESCRIPTION
- Prevents the `New Notifications` button (within the notifications popper) from flashing on screen when the popper is opened.
- Prevents the notification times from re-rendering during popper's closing animation (bug only really visible while time is in [seconds]).