### PR TITLE
Fix - Prevent temporary render of incorrect 'For You' score

### DIFF
--- a/src/Components/DetailedView.js
+++ b/src/Components/DetailedView.js
@@ -48,6 +48,12 @@ export default function DetailedView() {
   const [analysis, analysisLoading, analysisError, analysisFetching] =
     useAnimeAnalysis(animeId);
 
+  const analysisIsLoading =
+    analysisLoading ||
+    analysisFetching ||
+    analysis?.animeId !== anime.id ||
+    (!user.isAnonymous && localUser.handle === ""); //Prevents flashing the anonymous user's score for registered users
+
   useEffect(() => {
     if (loading) return;
     if (!user) return navigate("/login");
@@ -250,7 +256,7 @@ export default function DetailedView() {
                   minHeight: "200px",
                 }}
               >
-                {analysisFetching && analysis?.animeId !== anime.id && (
+                {analysisIsLoading ? (
                   <Box
                     sx={{
                       position: "absolute",
@@ -273,11 +279,14 @@ export default function DetailedView() {
                       <BreathingLogo />
                     </Box>
                   </Box>
+                ) : (
+                  <>
+                    <ScorePercentText
+                      scores={analysis?.scores ?? []}
+                    ></ScorePercentText>
+                    <ScoreBars scores={analysis?.scores ?? []} />
+                  </>
                 )}
-                <ScorePercentText
-                  scores={analysis?.scores ?? []}
-                ></ScorePercentText>
-                <ScoreBars scores={analysis?.scores ?? []} />
               </Box>
             </Grid>
 


### PR DESCRIPTION
Prevents displaying the 'For You' score based on an empty localUser object for registered users when on a slow network.

- To recreate bug, as a registered user refresh a <detailedView> page with a throttled network.  A preliminary 'For You' score will be displayed (based on an empty localUser) until localUser gets populated from Firestore.