### PR TITLE
Home Page Changes

### DIFF
--- a/src/Components/Firestore.js
+++ b/src/Components/Firestore.js
@@ -30,7 +30,7 @@ export async function PopulateFromFirestore(user, localUser, setLocalUser) {
     let docRef = doc(db, "users", user.uid);
     let querySnapshot = await getDoc(docRef);
     let data = querySnapshot.data();
-    if (!data.likes) {
+    if (!data?.likes) {
       data = {
         ...data,
         likes: [],

--- a/src/Components/Home.js
+++ b/src/Components/Home.js
@@ -126,32 +126,44 @@ export default function Home() {
       <Container maxWidth="lg">
         <div className="gap" />
         {user.isAnonymous && <GreetingExplainer />}
+        <Typography
+          variant="h2"
+          style={{
+            marginBlockStart: 0,
+            marginBlockEnd: "0.5rem",
+          }}
+        >
+          For You
+        </Typography>
         {localUser.uid && localUser?.likes.length === 0 ? (
-          <Typography
-            variant="h2"
-            style={{
-              fontSize: "2.0rem",
-              marginBlockStart: 0,
-              marginBlockEnd: "0.5rem",
-            }}
-          >
-            Like a show to receive{" "}
-            <span className="rainbow_text_animated">personalized</span>{" "}
-            recommendations!
-          </Typography>
-        ) : (
-          <>
-            <Typography
-              variant="h2"
+          <div style={{ position: "relative", textAlign: "center" }}>
+            <AnimeShelf />
+            <div
               style={{
-                marginBlockStart: 0,
-                marginBlockEnd: "0.5rem",
+                position: "absolute",
+                top: "50%",
+                left: "50%",
+                transform: "translate(-50%, -50%)",
               }}
             >
-              For You
-            </Typography>
-            <AnimeGrid items={recommendation} large />
-          </>
+              <Typography
+                variant="h2"
+                sx={{
+                  position: "relative",
+                  top: "40%",
+                  fontSize: { xs: "1.6rem", fourHundred: "2.0rem" },
+                  marginBlockStart: 0,
+                  marginBlockEnd: "0.5rem",
+                }}
+              >
+                Like a show to receive{" "}
+                <span className="rainbow_text_animated">personalized</span>{" "}
+                recommendations!
+              </Typography>
+            </div>
+          </div>
+        ) : (
+          <AnimeGrid items={recommendation} large />
         )}
         <div className="gap" />
         <Box sx={{ display: "flex", alignItems: "center" }}>

--- a/src/Components/Register.js
+++ b/src/Components/Register.js
@@ -78,8 +78,6 @@ export default function Register() {
 
   useEffect(() => {
     if (loading) return;
-    //Registering users without any likes causes /home rendering to error out --> this prevents that.
-    if (localUser["likes"]?.length === 0) navigate("/onboarding");
   }, [user, loading, forwardToken]);
 
   const handleRegister = async (provider) => {
@@ -226,51 +224,6 @@ export default function Register() {
             }
           >
             Register with Twitter
-          </Button>
-          {/* *******************Guest Button************************** */}
-          <Button
-            variant="outlined"
-            className="register__btn"
-            sx={{
-              ...regButtonStyling,
-              marginBottom: "0px",
-              fontSize: {
-                xs: "0.9rem",
-                fourHundred: "1rem",
-              },
-              width: {
-                sm: "350px",
-                fourHundred: "280px",
-                xs: "250px",
-              },
-              "&:hover": {
-                border: "3px #EF2727 solid",
-              },
-            }}
-            onClick={() => handleRegister("anonymous")}
-            startIcon={
-              regLoadingGuest ? (
-                ""
-              ) : (
-                <User
-                  size={44}
-                  style={{
-                    paddingRight: "20px",
-                    width: {
-                      fourHundred: "42px",
-                      xs: "31px",
-                    },
-                    height: { fourHundred: "42px", xs: "31px" },
-                  }}
-                />
-              )
-            }
-          >
-            {regLoadingGuest ? (
-              <BreathingLogo type={"largeButton"} />
-            ) : (
-              "Visit as a Guest"
-            )}
           </Button>
           <Divider
             sx={{


### PR DESCRIPTION
- Allows users without any likes to go directly to /register (forcing them to like a show first doesn't make sense any more - as on /onboarding there's no way to differentiate between folks we want to send to /register next as opposed to the typical flow of hitting /home next)
- Deletes 'register as guest' button from /register. Due to our new flow, users will only land on /register by navigating there in the hope of saving their account. So, having the 'register as guest' button felt unnecessary and possibly even misleading as nothing would get saved.
- Styles the homepage for anonymous users with 0 likes.  I didn't really like how this looked...it wasn't clear the page had any real structure.  Check out the before and after.  Also, feel free to play around with it - I'm tinkering with a few ideas: 
1.  Removing the rainbow or possibly adding a horizontal scrolling effect. 
2. Instead of ghost cards, show some hardcoded cards overlaid with a gradient that makes our Typography legible.

LMKWYT!

**BEFORE**
![BeforeSnapshot](https://github.com/KennethMetz/anime_finder/assets/106927391/689938eb-174b-440d-b3d3-de8793964d29)
 
**AFTER**
![AfterSnapshot](https://github.com/KennethMetz/anime_finder/assets/106927391/b76c0342-e5ac-403f-9054-34c0a516c6cc)