### PR TITLE
Fetch random anime via single API call

### DIFF
--- a/src/Components/APICalls.js
+++ b/src/Components/APICalls.js
@@ -117,6 +117,24 @@ export function useAnimeTN(selectedGenre) {
   );
 }
 
+export function useAnimeRND() {
+  const url = `${apiUrl}/anime?sort=random&page_size=6`;
+  return useQuery(
+    [url],
+    async () => {
+      let response = await fetch(url, { mode: "cors" });
+      await handleErrors(response);
+      let responseJson = await response.json();
+      return responseJson.items;
+    },
+    {
+      staleTime: fiveMinutesMs,
+      refetchOnWindowFocus: false,
+      refetchOnReconnect: false,
+    }
+  );
+}
+
 export function useGetTitles(fullUrl) {
   return useQuery(
     [fullUrl],
@@ -188,20 +206,6 @@ export function useRecommendations(viewHistory) {
     },
     { staleTime: fiveMinutesMs, keepPreviousData: true }
   );
-}
-
-export async function getRandomAnimeListing(randomPage, randomItem) {
-  let tempItem = [];
-  for (let k = 0; k < 6; k++) {
-    let response = await fetch(`${apiUrl}/anime?page=${randomPage[k]}`, {
-      mode: "cors",
-    });
-    await handleErrors(response);
-    let responseJson = await response.json();
-    console.assert(responseJson.items.length === 10, "LIST IS LESS THAN 10");
-    tempItem = [...tempItem, responseJson.items[randomItem[k]]];
-  }
-  return tempItem;
 }
 
 export async function APIGetAnimeList(ids) {

--- a/src/Components/Home.js
+++ b/src/Components/Home.js
@@ -11,13 +11,12 @@ import ShelfTitle from "./ShelfTitle";
 import Stack from "@mui/material/Stack";
 import AnimeShelf from "./AnimeShelf";
 import {
-  getRandomAnimeListing,
   useAnimeHR,
   useAnimeMC,
   useAnimeMH,
   useAnimeMPTW,
+  useAnimeRND,
   useAnimeTN,
-  useProfile,
   useRecommendations,
 } from "./APICalls";
 import { useAuthState } from "react-firebase-hooks/auth";
@@ -32,7 +31,6 @@ import CommunityListShelf from "./CommunityListShelf";
 import GreetingExplainer from "./GreetingExplainer";
 
 export default function Home() {
-  let [animeRandom, setAnimeRandom] = useState(null); //randomized
   let [communityListData, setCommunityListData] = useState(undefined); //randomized
 
   const [user, loading, error] = useAuthState(auth);
@@ -44,9 +42,6 @@ export default function Home() {
 
   let [refresh, setRefresh] = useState(false);
   let [refreshCL, setRefreshCL] = useState(false);
-
-  let randomPage = [];
-  let randomItem = [];
 
   function getViewHistory() {
     let data = {
@@ -83,20 +78,11 @@ export default function Home() {
   const { data: animeMC } = useAnimeMC(genreQueryString);
   const { data: animeMPTW } = useAnimeMPTW(genreQueryString);
   const { data: animeMH } = useAnimeMH(genreQueryString);
-
-  function getRandomNumbers() {
-    for (let i = 0; i < 6; i++) {
-      randomPage[i] = Math.floor(Math.random() * 250 + 1);
-      randomItem[i] = Math.floor(Math.random() * 10);
-    }
-  }
-
-  useEffect(() => {
-    getRandomNumbers();
-    getRandomAnimeListing(randomPage, randomItem)
-      .then((result) => setAnimeRandom(result))
-      .catch((error) => console.log(error));
-  }, [refresh]);
+  const {
+    data: animeRND,
+    refetch: refetchRND,
+    remove: removeRND,
+  } = useAnimeRND();
 
   useEffect(() => {
     getRandomCommunityList()
@@ -221,15 +207,15 @@ export default function Home() {
             size="small"
             startIcon={<RefreshIcon />}
             onClick={() => {
-              setAnimeRandom(null);
-              refresh ? setRefresh(false) : setRefresh(true);
+              removeRND();
+              refetchRND();
             }}
           >
             Surprise Me!
           </Button>
         </Stack>
 
-        <AnimeShelf items={animeRandom} />
+        <AnimeShelf items={animeRND} />
 
         <div className="gap" />
       </Container>


### PR DESCRIPTION
Since fetching the random items was 6 of the 12 api calls that are made on a /home load, I added support for a 'random' sort via the api's /anime endpoint.  This lets us get a random set of n items with a single api call.  It does return a different set on every call, so I tweaked the react-query settings to get rid of some 'stale' refetches that could happen and make the shelf spontaneously reload without a new page load.  Lmk what you think!