### PR TITLE
Fetch community list via TanStackQuery

### DIFF
--- a/src/Components/Home.js
+++ b/src/Components/Home.js
@@ -24,7 +24,7 @@ import { useAuthState } from "react-firebase-hooks/auth";
 import { auth } from "./Firebase";
 import { LocalUserContext } from "./LocalUserContext";
 import HandleDialog from "./HandleDialog";
-import { PopulateFromFirestore, getRandomCommunityList } from "./Firestore";
+import { PopulateFromFirestore, useCommunityList } from "./Firestore";
 import useGenreFilter from "../Hooks/useGenreFilter";
 import HtmlPageTitle from "./HtmlPageTitle";
 import useAnimeList from "../Hooks/useAnimeList";
@@ -33,7 +33,6 @@ import GreetingExplainer from "./GreetingExplainer";
 
 export default function Home() {
   let [animeRandom, setAnimeRandom] = useState(null); //randomized
-  let [communityListData, setCommunityListData] = useState(undefined); //randomized
 
   const [user, loading, error] = useAuthState(auth);
 
@@ -84,6 +83,12 @@ export default function Home() {
   const { data: animeMPTW } = useAnimeMPTW(genreQueryString);
   const { data: animeMH } = useAnimeMH(genreQueryString);
 
+  const {
+    data: communityListData,
+    refetch: refetchCLData,
+    remove: removeCLData,
+  } = useCommunityList();
+
   function getRandomNumbers() {
     for (let i = 0; i < 6; i++) {
       randomPage[i] = Math.floor(Math.random() * 250 + 1);
@@ -97,12 +102,6 @@ export default function Home() {
       .then((result) => setAnimeRandom(result))
       .catch((error) => console.log(error));
   }, [refresh]);
-
-  useEffect(() => {
-    getRandomCommunityList()
-      .then((result) => setCommunityListData(result))
-      .catch((error) => console.log(error));
-  }, [refreshCL]);
 
   useEffect(() => {
     PopulateFromFirestore(user, localUser, setLocalUser);
@@ -174,8 +173,8 @@ export default function Home() {
             size="small"
             startIcon={<RefreshIcon />}
             onClick={() => {
-              setCommunityListData(undefined);
-              setRefreshCL(!refreshCL);
+              removeCLData();
+              refetchCLData();
             }}
             sx={{ ml: 3 }}
           >


### PR DESCRIPTION
Envelopes call for a random community list in TanStackQuery, to minimize unnecessary firestore calls and mirror the updated behavior of 'random' shelf as implemented in PR #194 