### PR TITLE
Bug fix: Prevents tooltip from obstructing emojis on <ProfileListPage>

### DIFF
--- a/src/Components/NotificationDropMenu.js
+++ b/src/Components/NotificationDropMenu.js
@@ -153,12 +153,12 @@ export default function NotificationDropMenu() {
         style={{
           zIndex: "4",
           maxWidth: isMobileWidth ? "95vw" : "530px",
-          maxHeight: open ? "92vh" : "0",
         }}
       >
         {({ TransitionProps }) => (
           <Grow
             {...TransitionProps}
+            unmountOnExit
             onExited={() => resetPagination()}
             style={{
               transformOrigin: "right top",

--- a/src/Components/NotificationDropMenu.js
+++ b/src/Components/NotificationDropMenu.js
@@ -153,6 +153,7 @@ export default function NotificationDropMenu() {
         style={{
           zIndex: "4",
           maxWidth: isMobileWidth ? "95vw" : "530px",
+          maxHeight: open ? "92vh" : "0",
         }}
       >
         {({ TransitionProps }) => (


### PR DESCRIPTION
Using the `onExited()` parameter within `<Grow>` causes the popper to not unmount from the DOM when closed.  As a result, the popper's tooltip obstructs the watchlist emojis when closed. 

To replicate bug:
1. On a user profile with > 4 notifications, go to a `<ProfileListPage>`. 
2. Open the `<NotificationDropMenu>`
3. Expand the menu by clicking `see more`.
4. Close `<NotificationDropMenu>`
5. Emojis for the watchlist will be obstructed by the Tooltip from the closed `<NotificationDropMenu>`. 