### PR TITLE
Make the 'enter' key submit the email login form

### DIFF
--- a/src/Components/Login.js
+++ b/src/Components/Login.js
@@ -86,6 +86,11 @@ export default function Login() {
     }
   };
 
+  const handleEmailSubmit = (e) => {
+    e.preventDefault();
+    login("email");
+  };
+
   return (
     <div className="login">
       <HtmlPageTitle title={"Login"} />
@@ -213,91 +218,93 @@ export default function Login() {
             or
           </Divider>
           {/* *******************EdwardML - Email Field************************** */}
-          <TextField
-            type="text"
-            className="register__textBox"
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
-            label="Email"
-            required
-            inputProps={{
-              style: {
-                paddingTop: "12.5px",
-                paddingBottom: "12.5px",
-              },
-            }}
-            InputLabelProps={{
-              style: {
-                marginBottom: "88.5px",
-              },
-            }}
-            sx={{
-              width: {
-                xs: "250px",
-                fourHundred: "280px",
-                sm: "350px",
-              },
-              borderRadius: "9px",
-              marginBottom: "20px",
-            }}
-          />
-          {/* *******************EdwardML - Password Field************************** */}
-          <TextField
-            type="password"
-            className="register__textBox"
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-            label="Password"
-            helperText="Forgot Password?"
-            required
-            inputProps={{
-              style: {
-                paddingTop: "12.5px",
-                paddingBottom: "12.5px",
-              },
-            }}
-            FormHelperTextProps={{
-              style: {
-                color: theme.palette.text.primary,
-                textAlign: "right",
-                fontWeight: "600",
-                cursor: "pointer",
-              },
-              onClick: () => navigate("/reset"),
-            }}
-            sx={{
-              width: {
-                xs: "250px",
-                fourHundred: "280px",
-                sm: "350px",
-              },
-              borderRadius: "9px",
-              marginBottom: "20px",
-            }}
-          />
-          {loginError && (
-            <Typography
+          <form className="emailForm" onSubmit={handleEmailSubmit}>
+            <TextField
+              type="email"
+              className="register__textBox"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              label="Email"
+              required
+              inputProps={{
+                style: {
+                  paddingTop: "12.5px",
+                  paddingBottom: "12.5px",
+                },
+              }}
+              InputLabelProps={{
+                style: {
+                  marginBottom: "88.5px",
+                },
+              }}
               sx={{
-                color: "error.main",
-                fontWeight: 600,
-                marginY: "10px",
+                width: {
+                  xs: "250px",
+                  fourHundred: "280px",
+                  sm: "350px",
+                },
+                borderRadius: "9px",
+                marginBottom: "20px",
+              }}
+            />
+            {/* *******************EdwardML - Password Field************************** */}
+            <TextField
+              type="password"
+              className="register__textBox"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              label="Password"
+              helperText="Forgot Password?"
+              required
+              inputProps={{
+                style: {
+                  paddingTop: "12.5px",
+                  paddingBottom: "12.5px",
+                },
+              }}
+              FormHelperTextProps={{
+                style: {
+                  color: theme.palette.text.primary,
+                  textAlign: "right",
+                  fontWeight: "600",
+                  cursor: "pointer",
+                },
+                onClick: () => navigate("/reset"),
+              }}
+              sx={{
+                width: {
+                  xs: "250px",
+                  fourHundred: "280px",
+                  sm: "350px",
+                },
+                borderRadius: "9px",
+                marginBottom: "20px",
+              }}
+            />
+            {loginError && (
+              <Typography
+                sx={{
+                  color: "error.main",
+                  fontWeight: 600,
+                  marginY: "10px",
+                }}
+              >
+                {loginError}
+              </Typography>
+            )}
+            {/* *******************EdwardML - 'Login' Button************************** */}
+            <Button
+              variant="contained"
+              size="large"
+              type="submit"
+              sx={{
+                width: "211px",
+                padding: "0px",
               }}
             >
-              {loginError}
-            </Typography>
-          )}
-          {/* *******************EdwardML - 'Login' Button************************** */}
-          <Button
-            variant="contained"
-            size="large"
-            sx={{
-              width: "211px",
-              padding: "0px",
-            }}
-            onClick={() => login("email")}
-          >
-            {loadingEmail ? <BreathingLogo type={"smallButton"} /> : "Login"}
-          </Button>
+              {loadingEmail ? <BreathingLogo type={"smallButton"} /> : "Login"}
+            </Button>
+          </form>
 
           <Divider
             sx={{

--- a/src/Styles/Register.css
+++ b/src/Styles/Register.css
@@ -29,6 +29,13 @@
   }
 }
 
+.emailForm {
+  display: flex;
+  flex-direction: column;
+  text-align: center;
+  align-items: center;
+}
+
 .MuiButton-root {
   font-family: interExtraBold;
 }


### PR DESCRIPTION
This is just something that has been bugging me.  I like to type my password, then hit enter, instead of clicking a button.  To make this work, I've wrapped the email login form in a `<form>` tag with an `onSubmit` function, and switched the email login button to `type="submit"`.

I also changed the input type for the email input to `type="email"`, which I think will show a special keyboard with an @ sign on mobile, etc.