### PR TITLE
Fix bug with profile cloning when Firebase User is lost

### DIFF
--- a/src/Components/DropMenu.js
+++ b/src/Components/DropMenu.js
@@ -15,7 +15,7 @@ import useTheme from "@mui/material/styles/useTheme";
 import { Moon, SignOut, Sun, User, UserCirclePlus } from "phosphor-react";
 import { useNavigate } from "react-router-dom";
 import { auth, logout } from "./Firebase";
-import { LocalUserContext } from "./LocalUserContext";
+import { LocalUserContext, getDefaultLocalUser } from "./LocalUserContext";
 import { useAuthState } from "react-firebase-hooks/auth";
 
 import AppSettingsContext from "./AppSettingsContext";
@@ -88,19 +88,7 @@ export default function DropMenu() {
   async function sendToLogout(e) {
     navigate("/logout");
     await logout();
-    setLocalUser({
-      name: [],
-      likes: [],
-      dislikes: [],
-      lists: [],
-      savedLists: [],
-      avatar: null,
-      bio: null,
-      top8: [],
-      reviews: [],
-      comments: [],
-      handle: null,
-    });
+    setLocalUser(getDefaultLocalUser());
     handleClose(e);
   }
 

--- a/src/Components/Firestore.js
+++ b/src/Components/Firestore.js
@@ -23,6 +23,7 @@ import {
 } from "firebase/firestore";
 import { db } from "./Firebase";
 import { useQuery } from "@tanstack/react-query";
+import { getDefaultLocalUser } from "./LocalUserContext";
 
 const fiveMinutesMs = 1000 * 60 * 5;
 
@@ -35,17 +36,8 @@ export async function PopulateFromFirestore(user, localUser, setLocalUser) {
     let data = querySnapshot.data();
     if (!data?.likes) {
       data = {
+        ...getDefaultLocalUser(),
         ...data,
-        likes: [],
-        dislikes: [],
-        lists: [],
-        savedLists: [],
-        avatar: "",
-        bio: "",
-        top8: [],
-        reviews: [],
-        comments: [],
-        handle: "",
       };
     }
     if (!data.savedLists) data.savedLists = [];

--- a/src/Components/Firestore.js
+++ b/src/Components/Firestore.js
@@ -40,6 +40,7 @@ export async function PopulateFromFirestore(user, localUser, setLocalUser) {
         ...data,
       };
     }
+    // Append fields to localUsers created BEFORE these features were added.
     if (!data.savedLists) data.savedLists = [];
     if (!data.top8) data.top8 = [];
     if (!data.reviews) data.reviews = [];

--- a/src/Components/Firestore.js
+++ b/src/Components/Firestore.js
@@ -34,17 +34,10 @@ export async function PopulateFromFirestore(user, localUser, setLocalUser) {
     let docRef = doc(db, "users", user.uid);
     let querySnapshot = await getDoc(docRef);
     let data = querySnapshot.data();
-    if (!data?.likes) {
-      data = {
-        ...getDefaultLocalUser(),
-        ...data,
-      };
-    }
-    // Append fields to localUsers created BEFORE these features were added.
-    if (!data.savedLists) data.savedLists = [];
-    if (!data.top8) data.top8 = [];
-    if (!data.reviews) data.reviews = [];
-    if (!data.comments) data.comments = [];
+    data = {
+      ...getDefaultLocalUser(),
+      ...data,
+    };
     setLocalUser(data);
   } catch (error) {
     console.error("Error loading data from Firebase Database", error);

--- a/src/Components/HandleDialog.js
+++ b/src/Components/HandleDialog.js
@@ -9,7 +9,7 @@ import DialogTitle from "@mui/material/DialogTitle";
 import { useContext, useEffect, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { logout } from "./Firebase";
-import { LocalUserContext } from "./LocalUserContext";
+import { LocalUserContext, getDefaultLocalUser } from "./LocalUserContext";
 import * as Yup from "yup";
 import { yupResolver } from "@hookform/resolvers/yup";
 import { useForm } from "react-hook-form";
@@ -40,19 +40,7 @@ export default function HandleDialog({ user }) {
 
   async function handleCancel() {
     await logout();
-    setLocalUser({
-      name: [],
-      likes: [],
-      dislikes: [],
-      lists: [],
-      savedLists: [],
-      avatar: null,
-      bio: null,
-      top8: [],
-      reviews: [],
-      comments: [],
-      null: null,
-    });
+    setLocalUser(getDefaultLocalUser());
     navigate("/");
   }
 

--- a/src/Components/LocalUserContext.js
+++ b/src/Components/LocalUserContext.js
@@ -3,7 +3,25 @@ import React, { useState, createContext } from "react";
 export const LocalUserContext = createContext();
 
 export const LocalUserProvider = (props) => {
-  const [localUser, setLocalUser] = useState({
+  const [localUser, setLocalUser] = useState(getDefaultLocalUser());
+  return (
+    <LocalUserContext.Provider value={[localUser, setLocalUser]}>
+      {props.children}
+    </LocalUserContext.Provider>
+  );
+};
+
+/**
+ * Gets a `LocalUser` object with default values for all fields.
+ *
+ * Note that this object does not contain fields that are set by auth, such as
+ * `authProvider`, `uid`, and `email`.
+ *
+ * @returns {Object} A `LocalUser` object with default values.
+ */
+export function getDefaultLocalUser() {
+  return {
+    name: "",
     likes: [],
     dislikes: [],
     lists: [],
@@ -13,11 +31,6 @@ export const LocalUserProvider = (props) => {
     top8: [],
     reviews: [],
     comments: [],
-    handle: "",
-  });
-  return (
-    <LocalUserContext.Provider value={[localUser, setLocalUser]}>
-      {props.children}
-    </LocalUserContext.Provider>
-  );
-};
+    handle: null,
+  };
+}

--- a/src/Components/RoutingHelper.js
+++ b/src/Components/RoutingHelper.js
@@ -1,16 +1,20 @@
-import { useEffect, useLayoutEffect } from "react";
+import { useContext, useEffect, useLayoutEffect } from "react";
 import { useAuthState } from "react-firebase-hooks/auth";
-import { matchPath, Outlet, useLocation } from "react-router-dom";
+import { matchPath, Outlet, useLocation, useNavigate } from "react-router-dom";
 import Header from "./Header";
 import { auth } from "./Firebase";
 import useAuthActions from "../Hooks/useAuthActions";
 import BreathingLogo from "./BreathingLogo";
+import { LocalUserContext, getDefaultLocalUser } from "./LocalUserContext";
 
 export const RoutingHelper = () => {
   const [user, loading, error] = useAuthState(auth);
   const authActions = useAuthActions();
 
   const location = useLocation();
+  const navigate = useNavigate();
+
+  const [localUser, setLocalUser] = useContext(LocalUserContext);
 
   // Scroll to top if path changes.
   useLayoutEffect(() => {
@@ -47,7 +51,14 @@ export const RoutingHelper = () => {
 
   useEffect(() => {
     if (!loading && !user && headerMatch) {
-      authActions.registerAnonymously();
+      // If we were logged in and lost auth, take us to login.
+      if (localUser.uid) {
+        setLocalUser(getDefaultLocalUser());
+        navigate("/login");
+      } else {
+        // Otherwise, start new users with an anonymous account.
+        authActions.registerAnonymously();
+      }
     }
   }, [loading, user, headerMatch]);
 


### PR DESCRIPTION
Problem description and demo in this video: https://drive.google.com/file/d/1_hbLZgrXuul9i9G0NdV7wfWAGLrxWm1j/view?usp=sharing

Basically, Safari can lose the Firebase User, which triggers code in `RoutingHelper` to register anonymously.  Unfortunately, the old user's LocalUser data is still present, and the registration code saves that, since usually, during registration, the user does have LocalUser data from onboarding that should be saved.

I've added a solution that takes the user to /login when this happens, since they were already logged in, and lost their authentication.

I've also tried to centralize the 'default LocalUser' definition to one spot, `LocalUserContext`.  Note that there are slight different variations of the default used in various places... `DropMenu` sets avatar and bio to `null` and name to `[]`, while `LocalUserContext` uses `""` for avatar and bio, and doesn't initialize a `name` field.  The logout code in `HandleDialog` seems to have a typo where the field handle is not reset, but instead there is `null: null`.  

I've chosen in my implementation to use empty strings, except for handle, and to initialize the name field to empty string everywhere.  Let's discuss this, though -- not sure if you foresee any issues with that.  There is one catch to setting the name field in the default, which is that it would stomp any name field loaded from firestore in `PopulateFromFirestore` in the `if(!data?.likes)` branch -- I've solved this by expanding the default, and _then_ expanding the data loaded from firestore.  So defaults will all be set, but any values in firestore will be preserved.