### PR TITLE
Don't refetch recs on window focus.

### DIFF
--- a/src/Components/APICalls.js
+++ b/src/Components/APICalls.js
@@ -204,7 +204,11 @@ export function useRecommendations(viewHistory) {
       responseJson.items.map((item, index) => temp.push(item.anime));
       return temp;
     },
-    { staleTime: fiveMinutesMs, keepPreviousData: true }
+    {
+      staleTime: fiveMinutesMs,
+      keepPreviousData: true,
+      refetchOnWindowFocus: false,
+    }
   );
 }
 


### PR DESCRIPTION
When the EdwardML browser window/tab is selected, if five minutes have passed since Home page load, react-query will re-fetch the recommendations.  This was pretty much hidden before when the recommendations were deterministic, but now that I am extending that system to involve some randomness, it means sometimes you come back to the browser window and your recs shift around after a second.  It would be better to make the user explicitly request the refetch, by navigation events, reloading the browser, updating their likes, etc.