### PR TITLE
Loading Indicator on "For You" Refetch

### DIFF
--- a/src/Components/DelayedLinearProgress.js
+++ b/src/Components/DelayedLinearProgress.js
@@ -1,4 +1,4 @@
-import { LinearProgress } from "@mui/material";
+import LinearProgress from "@mui/material/LinearProgress";
 import React, { useEffect, useState } from "react";
 
 const DelayedLinearProgress = ({ isRefetching }) => {

--- a/src/Components/DelayedLinearProgress.js
+++ b/src/Components/DelayedLinearProgress.js
@@ -1,0 +1,18 @@
+import { LinearProgress } from "@mui/material";
+import React, { useEffect, useState } from "react";
+
+const DelayedLinearProgress = ({ isRefetching }) => {
+  const [showSpinner, setShowSpinner] = useState(false);
+
+  useEffect(() => {
+    const timer = setTimeout(() => setShowSpinner(true), 800);
+
+    return () => clearTimeout(timer);
+  });
+
+  if (!isRefetching || !showSpinner) return;
+
+  return <LinearProgress sx={{ mt: -1.5, mb: 1 }} />;
+};
+
+export default DelayedLinearProgress;

--- a/src/Components/Home.js
+++ b/src/Components/Home.js
@@ -29,6 +29,8 @@ import HtmlPageTitle from "./HtmlPageTitle";
 import useAnimeList from "../Hooks/useAnimeList";
 import CommunityListShelf from "./CommunityListShelf";
 import GreetingExplainer from "./GreetingExplainer";
+import { LinearProgress } from "@mui/material";
+import DelayedLinearProgress from "./DelayedLinearProgress";
 
 export default function Home() {
   const [user, loading, error] = useAuthState(auth);
@@ -67,7 +69,7 @@ export default function Home() {
 
   // API call for personalized recommendations.
   const viewHistory = getViewHistory();
-  const { data: recommendation, isLoading: loadingRecs } =
+  const { data: recommendation, isRefetching: isRefetchingRecs } =
     useRecommendations(viewHistory);
 
   //API calls for generic shelf content
@@ -120,6 +122,7 @@ export default function Home() {
         >
           For You
         </Typography>
+        <DelayedLinearProgress isRefetching={isRefetchingRecs} />
         {localUser.uid && localUser?.likes.length === 0 ? (
           <div style={{ position: "relative", textAlign: "center" }}>
             <AnimeShelf />

--- a/src/Components/Home.js
+++ b/src/Components/Home.js
@@ -29,7 +29,6 @@ import HtmlPageTitle from "./HtmlPageTitle";
 import useAnimeList from "../Hooks/useAnimeList";
 import CommunityListShelf from "./CommunityListShelf";
 import GreetingExplainer from "./GreetingExplainer";
-import { LinearProgress } from "@mui/material";
 import DelayedLinearProgress from "./DelayedLinearProgress";
 
 export default function Home() {


### PR DESCRIPTION
When 'For You' recommendations are being refetched, an indeterminate linear progress bar is displayed.

I don't really like how choppy the progress bar looks during fast queries. I've added a slight delay to prevent the worst of the UI flashes - but on my machine a load time of around 1 second still looks unpolished.  It looks great on slow 3G though!!