### PR TITLE
Don't refetch DataFromEdward on window focus && Stop DataFromEdward Flash

### DIFF
--- a/src/Components/DetailedView.js
+++ b/src/Components/DetailedView.js
@@ -46,13 +46,10 @@ export default function DetailedView() {
   const [anime, animeLoading, animeError] = useAnime(animeId, location.state);
 
   const [analysis, analysisLoading, analysisError, analysisFetching] =
-    useAnimeAnalysis(animeId);
+    useAnimeAnalysis(animeId, localUser);
 
   const analysisIsLoading =
-    analysisLoading ||
-    analysisFetching ||
-    analysis?.animeId !== anime.id ||
-    (!user.isAnonymous && localUser.handle === ""); //Prevents flashing the anonymous user's score for registered users
+    analysisLoading || analysisFetching || analysis?.animeId !== anime?.id;
 
   useEffect(() => {
     if (loading) return;

--- a/src/Hooks/useAnimeAnalysis.js
+++ b/src/Hooks/useAnimeAnalysis.js
@@ -10,9 +10,7 @@ const fiveMinutesMs = 1000 * 60 * 5;
  * @param {string} animeId The anime id to get analysis for.
  * @returns A list of `[anime, loading, error, fetching]`.
  */
-export default function useAnimeAnalysis(animeId) {
-  const [localUser] = useContext(LocalUserContext);
-
+export default function useAnimeAnalysis(animeId, localUser) {
   // Build view history once.
   const history = useMemo(
     () => [
@@ -29,11 +27,16 @@ export default function useAnimeAnalysis(animeId) {
   );
 
   const { data, isLoading, error, isFetching } = useQuery(
-    ["anime", animeId, "analysis", history],
+    ["anime", animeId, "analysis", history, localUser.uid],
     () => {
+      if (!localUser?.uid) return null; // Prevents call using blank watch history if registered/anonymous auth has not completed.
       return APIGetAnimeAnalysis(animeId, history);
     },
-    { keepPreviousData: true, staleTime: fiveMinutesMs }
+    {
+      keepPreviousData: true,
+      staleTime: fiveMinutesMs,
+      refetchOnWindowFocus: false,
+    }
   );
 
   return [data, isLoading, error, isFetching];


### PR DESCRIPTION
1. Stops refetch of 'DataFromEdward' on window focus.  (An extension of a previous PR: #203)
2. Prevents the display of 'DataFromEdward' if our Google Authorization call is not complete.  We were getting and displaying the 'DataFromEdward' analysis info for the default empty localUser object. This caused a nasty flash and a clunky animation effect.