### PR TITLE
Fixes MAL icon that was getting hidden for watchlists with only 1 item.

### DIFF
--- a/src/Components/WatchlistTile.js
+++ b/src/Components/WatchlistTile.js
@@ -116,6 +116,7 @@ export default function WatchlistTile({
                   backgroundSize: "cover",
                   borderRadius: " 0px 3px 0px 0px",
                   boxShadow: "2px 0 8px #000000cc",
+                  zIndex: 2,
                 }}
               />
             )}


### PR DESCRIPTION
To recreate - find any watchlist imported from MAL with only (1) item on a profile page - the MAL icon will be hidden behind the anime tiles.